### PR TITLE
Fix statically linked build

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -6,8 +6,6 @@ builds:
     - packages.x86_64-linux.selector4nix
     - packages.aarch64-darwin.selector4nix
     - packages.x86_64-linux.selector4nix-static
-    - packages.aarch64-darwin.selector4nix-static
+    # - packages.aarch64-darwin.selector4nix-static # Broken
     - packages.x86_64-linux.rust-toolchain
     - packages.aarch64-darwin.rust-toolchain
-    - packages.x86_64-linux.rust-toolchain-static
-    - packages.aarch64-darwin.rust-toolchain-static

--- a/nix/flake/package.nix
+++ b/nix/flake/package.nix
@@ -28,16 +28,10 @@
           };
         };
 
-        selector4nix-static = pkgs.pkgsStatic.callPackage ../package.nix {
-          rustPlatform = pkgs.pkgsStatic.makeRustPlatform {
-            cargo = config.packages.rust-toolchain-static;
-            rustc = config.packages.rust-toolchain-static;
-          };
-        };
+        # Build statically linked artifact with `rust-overlay` is broken.
+        selector4nix-static = pkgs.pkgsStatic.callPackage ../package.nix { };
 
         rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./../../rust-toolchain.toml;
-
-        rust-toolchain-static = pkgs.pkgsStatic.rust-bin.fromRustupToolchainFile ./../../rust-toolchain.toml;
       };
 
       legacyPackages = config.packages;


### PR DESCRIPTION
Previously added `garnix.yaml` triggers build of the `selector4nix` package and `rust-toolchain` package by both dynamically and statically linking on `x86_64-linux` and `aarch64-darwin` platform. But the following builds are broken:

- All statically linked rust-overlay `rust-toolchain` on all platform
- All statically linked `selector4nix` with rust-overlay `rustPlatform`
- Statically linked `selector4nix` with `nixpkgs`-provided `rustPlatform` on `aarch64-darwin`

This PR fixes those build failure by either switching to rust toolchain from `nixpkgs` or disabling builds that can't be trivially fixed.