### PR TITLE
Add per-substituter NAR info querying and NAR streaming timeout configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,3 +165,15 @@ Override the base URL used for NAR file downloads.
 - Default: `40`
 
 Priority of this substituter. Higher values mean lower priority.
+
+### `substituters[].nar_info_timeout_secs`
+
+- Type: Natural
+
+Per-substituter override for NAR info lookup timeout in seconds. When unset, falls back to `network.nar_info_timeout_secs`.
+
+### `substituters[].nar_timeout_secs`
+
+- Type: Natural
+
+Per-substituter override for NAR file download timeout in seconds. When unset, falls back to `network.nar_timeout_secs`.

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -61,6 +61,9 @@ priority = 40
 url = "https://mirrors.tuna.tsinghua.edu.cn/nix-channels/store/"
 # Higher priority value than the official cache, so it is tried after cache.nixos.org.
 priority = 45
+# Per-substituter timeout overrides (when unset, falls back to network.nar_info_timeout_secs / network.nar_timeout_secs).
+# nar_info_timeout_secs = 30
+# nar_timeout_secs = 30
 
 [[substituters]]
 url = "https://mirrors.ustc.edu.cn/nix-channels/store/"

--- a/src/application/nar/actor/runner.rs
+++ b/src/application/nar/actor/runner.rs
@@ -79,14 +79,12 @@ impl NarActor {
 
     async fn publish_nar_file_registration(&self, resolution: &NarInfoResolution) {
         if let NarInfoResolution::Resolved {
-            nar_info,
-            source_url,
-            ..
+            nar_info, location, ..
         } = resolution
         {
             let event = NarFileEvent::Registered {
                 nar_file: nar_info.nar_file().clone(),
-                source_url: source_url.clone(),
+                location: location.clone(),
             };
             let _ = self.nar_file_index_pub.tell(event).await;
         }

--- a/src/application/nar/usecase/streaming.rs
+++ b/src/application/nar/usecase/streaming.rs
@@ -3,11 +3,10 @@ use std::sync::Arc;
 use selector4nix_actor::actor::AnyAddress;
 
 use crate::application::{AppErrorKind, AppOptionExt, AppResult, AppResultExt};
-use crate::domain::nar::index::{NarFileEvent, NarFileIndex};
+use crate::domain::nar::index::{NarFileEvent, NarFileIndex, NarFileLocation};
 use crate::domain::nar::model::NarFileName;
 use crate::domain::nar::port::{NarStreamData, NarStreamProvider};
 use crate::domain::substituter::index::SubstituterAvailabilityIndex;
-use crate::domain::substituter::model::Url;
 
 pub struct NarStreamingUseCase {
     substituter_availability_index: Arc<dyn SubstituterAvailabilityIndex>,
@@ -34,11 +33,11 @@ impl NarStreamingUseCase {
     pub async fn stream_nar(&self, nar_file: &NarFileName) -> AppResult<NarStreamData> {
         tracing::info!(nar_file = %nar_file.value(), "acquiring nar stream from substituter");
 
-        if let Some(source_url) = &self.nar_file_index.get_source_url(nar_file).await {
-            tracing::info!(nar_file = %nar_file.value(), source_url = %source_url, "use cached nar file location");
+        if let Some(location) = self.nar_file_index.get_location(nar_file).await {
+            tracing::info!(nar_file = %nar_file.value(), source_url = %location.source_url(), "use cached nar file location");
 
-            let urls = [source_url.clone()];
-            let outcome = self.nar_stream_provider.stream_nar(&urls).await;
+            let locations = [location];
+            let outcome = self.nar_stream_provider.stream_nar(&locations).await;
 
             if let Ok(Some(data)) = outcome {
                 return Ok(data);
@@ -53,15 +52,19 @@ impl NarStreamingUseCase {
     }
 
     async fn stream_nar_from_all(&self, nar_file: &NarFileName) -> AppResult<NarStreamData> {
-        let urls = self.build_fallback_urls(nar_file);
-        let outcome = self.nar_stream_provider.stream_nar(&urls).await;
+        let locations = self.build_fallback_locations(nar_file);
+        let outcome = self.nar_stream_provider.stream_nar(&locations).await;
 
         match &outcome {
             Ok(Some(NarStreamData { source_url, .. })) => {
                 tracing::info!(nar_file = %nar_file.value(), %source_url, "streamed nar from substituter");
                 let request = NarFileEvent::Registered {
                     nar_file: nar_file.clone(),
-                    source_url: source_url.clone(),
+                    location: locations
+                        .iter()
+                        .find(|loc| loc.source_url() == source_url)
+                        .cloned()
+                        .expect("there should exists a `location` corresponded to the returned `source_url`"),
                 };
                 let _ = self.nar_file_index_pub.tell(request).await;
             }
@@ -76,13 +79,15 @@ impl NarStreamingUseCase {
         outcome.wrap(AppErrorKind::Infrastructure).flat()
     }
 
-    fn build_fallback_urls(&self, nar_file: &NarFileName) -> Vec<Url> {
+    fn build_fallback_locations(&self, nar_file: &NarFileName) -> Vec<NarFileLocation> {
         self.substituter_availability_index
             .query_all()
             .iter()
             .map(|substituter| {
                 let prefix = substituter.target().storage_url();
-                nar_file.with_storage_prefix(prefix)
+                let source_url = nar_file.with_storage_prefix(prefix);
+                let timeout = substituter.target().nar_timeout();
+                NarFileLocation::new(source_url, timeout)
             })
             .collect()
     }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -59,7 +59,9 @@ pub fn init_context(config: &AppConfiguration) -> AnyhowResult<Arc<AppContext>> 
         .substituters
         .iter()
         .map(|c| {
-            let meta = SubstituterMeta::new(c.url.clone(), c.priority);
+            let meta = SubstituterMeta::new(c.url.clone(), c.priority)
+                .with_nar_info_timeout(c.nar_info_timeout)
+                .with_nar_timeout(c.nar_timeout);
             let meta = match c.storage_url.clone() {
                 Some(storage_url) => meta.with_storage_url(storage_url),
                 None => meta,

--- a/src/domain/nar/index/mod.rs
+++ b/src/domain/nar/index/mod.rs
@@ -1,3 +1,3 @@
 mod nar_file;
 
-pub use nar_file::{NarFileEvent, NarFileIndex};
+pub use nar_file::{NarFileEvent, NarFileIndex, NarFileLocation};

--- a/src/domain/nar/index/nar_file.rs
+++ b/src/domain/nar/index/nar_file.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
+use getset::{CopyGetters, Getters};
 
 use crate::domain::nar::model::NarFileName;
 use crate::domain::substituter::model::Url;
@@ -7,7 +10,7 @@ use crate::domain::substituter::model::Url;
 pub enum NarFileEvent {
     Registered {
         nar_file: NarFileName,
-        source_url: Url,
+        location: NarFileLocation,
     },
     Evicted {
         nar_file: NarFileName,
@@ -16,5 +19,22 @@ pub enum NarFileEvent {
 
 #[async_trait]
 pub trait NarFileIndex: Send + Sync {
-    async fn get_source_url(&self, nar_file: &NarFileName) -> Option<Url>;
+    async fn get_location(&self, nar_file: &NarFileName) -> Option<NarFileLocation>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters, CopyGetters)]
+pub struct NarFileLocation {
+    #[getset(get = "pub")]
+    source_url: Url,
+    #[getset(get_copy = "pub")]
+    timeout: Option<Duration>,
+}
+
+impl NarFileLocation {
+    pub fn new(source_url: Url, timeout: Option<Duration>) -> Self {
+        Self {
+            source_url,
+            timeout,
+        }
+    }
 }

--- a/src/domain/nar/model/nar.rs
+++ b/src/domain/nar/model/nar.rs
@@ -1,5 +1,6 @@
 use getset::Getters;
 
+use crate::domain::nar::index::NarFileLocation;
 use crate::domain::nar::model::{NarInfoData, StorePathHash};
 use crate::domain::substituter::model::{SubstituterMeta, Url};
 
@@ -7,7 +8,7 @@ use crate::domain::substituter::model::{SubstituterMeta, Url};
 pub enum NarInfoResolution {
     Resolved {
         nar_info: NarInfoData,
-        source_url: Url,
+        location: NarFileLocation,
     },
     NotFound,
 }
@@ -24,6 +25,7 @@ impl NarInfoResolution {
                         .nar_file()
                         .with_storage_prefix(substituter.storage_url())
                 });
+                let location = NarFileLocation::new(source_url, substituter.nar_timeout());
                 let nar_info = match rewrite_nar_url {
                     NarUrlRewriteOption::Keep => nar_info,
                     NarUrlRewriteOption::ToSelf => nar_info.rewrite_url_to_self(),
@@ -31,10 +33,7 @@ impl NarInfoResolution {
                         nar_info.set_source_and_rewrite_url(substituter.storage_url())
                     }
                 };
-                Self::Resolved {
-                    nar_info,
-                    source_url,
-                }
+                Self::Resolved { nar_info, location }
             }
             None => Self::NotFound,
         }
@@ -49,7 +48,7 @@ impl NarInfoResolution {
 
     pub fn source_url(&self) -> Option<&Url> {
         match self {
-            Self::Resolved { source_url, .. } => Some(source_url),
+            Self::Resolved { location, .. } => Some(location.source_url()),
             _ => None,
         }
     }
@@ -97,6 +96,8 @@ impl Nar {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::domain::substituter::model::Priority;
 
     use super::*;
@@ -152,15 +153,12 @@ mod tests {
         );
 
         match resolution {
-            NarInfoResolution::Resolved {
-                nar_info,
-                source_url,
-            } => {
+            NarInfoResolution::Resolved { nar_info, location } => {
                 assert!(nar_info.content().contains(
                     "URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
                 ));
                 assert_eq!(
-                    source_url.value(),
+                    location.source_url().value(),
                     "https://cache.nixos.org/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
                 );
             }
@@ -179,16 +177,13 @@ mod tests {
         );
 
         match resolution {
-            NarInfoResolution::Resolved {
-                nar_info,
-                source_url,
-            } => {
+            NarInfoResolution::Resolved { nar_info, location } => {
                 assert!(nar_info.content().contains(
                     "URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
                 ));
                 assert!(!nar_info.content().contains("https://storage.example.com"));
                 assert_eq!(
-                    source_url.value(),
+                    location.source_url().value(),
                     "https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
                 );
             }
@@ -207,16 +202,29 @@ mod tests {
         );
 
         match resolution {
-            NarInfoResolution::Resolved {
-                nar_info,
-                source_url,
-            } => {
+            NarInfoResolution::Resolved { nar_info, location } => {
                 assert!(nar_info.content().contains("https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"));
                 assert!(!nar_info.content().contains("URL: nar/"));
                 assert_eq!(
-                    source_url.value(),
+                    location.source_url().value(),
                     "https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
                 );
+            }
+            _ => panic!("expected Resolved"),
+        }
+    }
+
+    #[test]
+    fn from_completed_query_set_nar_timeout() {
+        let meta = make_substituter_meta().with_nar_timeout(Duration::from_secs(60));
+        let resolution = NarInfoResolution::from_completed_query(
+            Some((make_nar_info_data(), meta)),
+            NarUrlRewriteOption::ToSelf,
+        );
+
+        match resolution {
+            NarInfoResolution::Resolved { location, .. } => {
+                assert_eq!(location.timeout(), Some(Duration::from_secs(60)));
             }
             _ => panic!("expected Resolved"),
         }

--- a/src/domain/nar/port/nar_info_provider.rs
+++ b/src/domain/nar/port/nar_info_provider.rs
@@ -8,7 +8,11 @@ use crate::domain::substituter::model::Url;
 
 #[async_trait]
 pub trait NarInfoProvider: Send + Sync {
-    async fn provide_nar_info(&self, url: &Url) -> AnyhowResult<Option<NarInfoQueryData>>;
+    async fn provide_nar_info(
+        &self,
+        url: &Url,
+        timeout: Option<Duration>,
+    ) -> AnyhowResult<Option<NarInfoQueryData>>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/domain/nar/port/nar_stream_provider.rs
+++ b/src/domain/nar/port/nar_stream_provider.rs
@@ -5,11 +5,15 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 
+use crate::domain::nar::index::NarFileLocation;
 use crate::domain::substituter::model::Url;
 
 #[async_trait]
 pub trait NarStreamProvider: Send + Sync {
-    async fn stream_nar(&self, urls: &[Url]) -> AnyhowResult<Option<NarStreamData>>;
+    async fn stream_nar(
+        &self,
+        locations: &[NarFileLocation],
+    ) -> AnyhowResult<Option<NarStreamData>>;
 }
 
 pub struct NarStreamData {

--- a/src/domain/nar/service/nar_resolution.rs
+++ b/src/domain/nar/service/nar_resolution.rs
@@ -100,9 +100,10 @@ impl NarResolutionService {
         for substituter in substituters.iter() {
             let handle = query_tracker.spawn({
                 let provider = Arc::clone(&self.nar_info_provider);
-                let url = hash.on_substituter(substituter.target());
                 let sub = substituter.clone();
-                async move { (sub, provider.provide_nar_info(&url).await) }
+                let url = hash.on_substituter(substituter.target());
+                let timeout = sub.target().nar_info_timeout();
+                async move { (sub, provider.provide_nar_info(&url, timeout).await) }
             });
             query_cancellers.insert(substituter, handle);
         }

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -4,10 +4,9 @@ use tokio::time::Instant;
 use crate::domain::substituter::model::{Availability, Priority, SubstituterMeta, Url};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Getters)]
+#[getset(get = "pub")]
 pub struct Substituter {
-    #[getset(get = "pub")]
     target: SubstituterMeta,
-    #[getset(get = "pub")]
     availability: Availability,
 }
 

--- a/src/domain/substituter/model/substituter_meta.rs
+++ b/src/domain/substituter/model/substituter_meta.rs
@@ -1,15 +1,18 @@
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde::{Serialize, Serializer};
 
 use crate::domain::substituter::model::{Priority, Url};
 
-#[derive(Debug, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 struct SubstituterMetaInner {
     url: Url,
     storage_url: Url,
     priority: Priority,
+    nar_info_timeout: Option<Duration>,
+    nar_timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]
@@ -22,6 +25,8 @@ impl SubstituterMeta {
             url,
             storage_url,
             priority,
+            nar_info_timeout: None,
+            nar_timeout: None,
         }))
     }
 
@@ -37,11 +42,38 @@ impl SubstituterMeta {
         self.0.priority
     }
 
+    pub fn nar_info_timeout(&self) -> Option<Duration> {
+        self.0.nar_info_timeout
+    }
+
+    pub fn nar_timeout(&self) -> Option<Duration> {
+        self.0.nar_timeout
+    }
+
     pub fn with_storage_url(&self, storage_url: Url) -> Self {
         Self(Arc::new(SubstituterMetaInner {
-            url: self.0.url.clone(),
             storage_url,
-            priority: self.0.priority,
+            ..(*self.0).clone()
+        }))
+    }
+
+    pub fn with_nar_info_timeout<T>(&self, timeout: T) -> Self
+    where
+        T: Into<Option<Duration>>,
+    {
+        Self(Arc::new(SubstituterMetaInner {
+            nar_info_timeout: timeout.into(),
+            ..(*self.0).clone()
+        }))
+    }
+
+    pub fn with_nar_timeout<T>(&self, timeout: T) -> Self
+    where
+        T: Into<Option<Duration>>,
+    {
+        Self(Arc::new(SubstituterMetaInner {
+            nar_timeout: timeout.into(),
+            ..(*self.0).clone()
         }))
     }
 }

--- a/src/infrastructure/config/parsed.rs
+++ b/src/infrastructure/config/parsed.rs
@@ -205,6 +205,8 @@ pub struct SubstituterConfiguration {
     pub url: Url,
     pub storage_url: Option<Url>,
     pub priority: Priority,
+    pub nar_info_timeout: Option<Duration>,
+    pub nar_timeout: Option<Duration>,
 }
 
 impl TryFrom<SubstituterRawConfiguration> for SubstituterConfiguration {
@@ -215,6 +217,10 @@ impl TryFrom<SubstituterRawConfiguration> for SubstituterConfiguration {
             url: Url::new(&raw.url)?,
             storage_url: raw.storage_url.map(|s| Url::new(&s)).transpose()?,
             priority: raw.priority.map_or(Priority::new(40), Priority::new)?,
+            nar_info_timeout: raw
+                .nar_info_timeout_secs
+                .map(|t| Duration::from_secs(t.max(1))),
+            nar_timeout: raw.nar_timeout_secs.map(|t| Duration::from_secs(t.max(1))),
         })
     }
 }

--- a/src/infrastructure/config/parsed.rs
+++ b/src/infrastructure/config/parsed.rs
@@ -111,10 +111,10 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
         Ok(Self {
             nar_info_timeout: raw
                 .nar_info_timeout_secs
-                .map_or(Duration::from_secs(30), |t| Duration::from_secs(t.max(1))),
+                .map_or(Duration::from_secs(30), to_clamped_duration),
             nar_timeout: raw
                 .nar_timeout_secs
-                .map_or(Duration::from_secs(30), |t| Duration::from_secs(t.max(1))),
+                .map_or(Duration::from_secs(30), to_clamped_duration),
             max_concurrent_requests: raw.max_concurrent_requests.unwrap_or(24),
             tolerance: raw.tolerance_msecs.unwrap_or(50).max(1),
         })
@@ -191,11 +191,11 @@ impl TryFrom<CacheRawConfiguration> for CacheConfiguration {
             nar_info_lookup_capacity: raw.nar_info_lookup_capacity.unwrap_or(4096),
             nar_info_lookup_ttl: raw
                 .nar_info_lookup_ttl_secs
-                .map_or(Duration::from_hours(4), |t| Duration::from_secs(t.max(1))),
+                .map_or(Duration::from_hours(4), to_clamped_duration),
             nar_location_capacity: raw.nar_location_capacity.unwrap_or(4096),
             nar_location_ttl: raw
                 .nar_location_ttl_secs
-                .map_or(Duration::from_hours(4), |t| Duration::from_secs(t.max(1))),
+                .map_or(Duration::from_hours(4), to_clamped_duration),
         })
     }
 }
@@ -217,10 +217,12 @@ impl TryFrom<SubstituterRawConfiguration> for SubstituterConfiguration {
             url: Url::new(&raw.url)?,
             storage_url: raw.storage_url.map(|s| Url::new(&s)).transpose()?,
             priority: raw.priority.map_or(Priority::new(40), Priority::new)?,
-            nar_info_timeout: raw
-                .nar_info_timeout_secs
-                .map(|t| Duration::from_secs(t.max(1))),
-            nar_timeout: raw.nar_timeout_secs.map(|t| Duration::from_secs(t.max(1))),
+            nar_info_timeout: raw.nar_info_timeout_secs.map(to_clamped_duration),
+            nar_timeout: raw.nar_timeout_secs.map(to_clamped_duration),
         })
     }
+}
+
+fn to_clamped_duration(secs: u64) -> Duration {
+    Duration::from_secs(secs.max(1))
 }

--- a/src/infrastructure/config/raw.rs
+++ b/src/infrastructure/config/raw.rs
@@ -59,4 +59,6 @@ pub struct SubstituterRawConfiguration {
     pub url: String,
     pub storage_url: Option<String>,
     pub priority: Option<u32>,
+    pub nar_info_timeout_secs: Option<u64>,
+    pub nar_timeout_secs: Option<u64>,
 }

--- a/src/infrastructure/index/nar_file.rs
+++ b/src/infrastructure/index/nar_file.rs
@@ -4,31 +4,30 @@ use async_trait::async_trait;
 use moka::future::Cache;
 use selector4nix_actor::actor::{Actor, ActorPre, ActorPreBuilder, Context, EmptyInternal};
 
-use crate::domain::nar::index::{NarFileEvent, NarFileIndex};
+use crate::domain::nar::index::{NarFileEvent, NarFileIndex, NarFileLocation};
 use crate::domain::nar::model::NarFileName;
-use crate::domain::substituter::model::Url;
 
 #[derive(Clone)]
 pub struct NarFileIndexView {
-    cache: Arc<Cache<NarFileName, Url>>,
+    cache: Arc<Cache<NarFileName, NarFileLocation>>,
 }
 
 impl NarFileIndexView {
-    pub fn new(cache: Arc<Cache<NarFileName, Url>>) -> Self {
+    pub fn new(cache: Arc<Cache<NarFileName, NarFileLocation>>) -> Self {
         Self { cache }
     }
 }
 
 #[async_trait]
 impl NarFileIndex for NarFileIndexView {
-    async fn get_source_url(&self, nar_file: &NarFileName) -> Option<Url> {
+    async fn get_location(&self, nar_file: &NarFileName) -> Option<NarFileLocation> {
         self.cache.get(nar_file).await
     }
 }
 
 pub struct NarFileIndexActor {
     context: Context<NarFileEvent, EmptyInternal>,
-    cache: Option<Arc<Cache<NarFileName, Url>>>,
+    cache: Option<Arc<Cache<NarFileName, NarFileLocation>>>,
 }
 
 impl NarFileIndexActor {
@@ -42,13 +41,10 @@ impl NarFileIndexActor {
         (pre, view)
     }
 
-    async fn apply_event(cache: &Cache<NarFileName, Url>, event: NarFileEvent) {
+    async fn apply_event(cache: &Cache<NarFileName, NarFileLocation>, event: NarFileEvent) {
         match event {
-            NarFileEvent::Registered {
-                nar_file,
-                source_url,
-            } => {
-                cache.insert(nar_file, source_url).await;
+            NarFileEvent::Registered { nar_file, location } => {
+                cache.insert(nar_file, location).await;
             }
             NarFileEvent::Evicted { nar_file } => {
                 cache.remove(&nar_file).await;
@@ -60,7 +56,7 @@ impl NarFileIndexActor {
 impl Actor for NarFileIndexActor {
     type Request = NarFileEvent;
     type Internal = EmptyInternal;
-    type State = Arc<Cache<NarFileName, Url>>;
+    type State = Arc<Cache<NarFileName, NarFileLocation>>;
 
     fn context(&mut self) -> &mut Context<Self::Request, Self::Internal> {
         &mut self.context
@@ -90,6 +86,10 @@ mod tests {
         NarFileName::new(name.to_string()).unwrap()
     }
 
+    fn make_nar_file_location(source_url: &str) -> NarFileLocation {
+        NarFileLocation::new(Url::new(source_url).unwrap(), None)
+    }
+
     #[tokio::test]
     async fn apply_event_inserts_entry_given_registered() {
         let cache = Cache::new(100);
@@ -98,13 +98,15 @@ mod tests {
             &cache,
             NarFileEvent::Registered {
                 nar_file: nar_file.clone(),
-                source_url: Url::new("https://cache.nixos.org/nar/abc.nar.xz").unwrap(),
+                location: make_nar_file_location("https://cache.nixos.org/nar/abc.nar.xz"),
             },
         )
         .await;
         assert_eq!(
             cache.get(&nar_file).await,
-            Some(Url::new("https://cache.nixos.org/nar/abc.nar.xz").unwrap())
+            Some(make_nar_file_location(
+                "https://cache.nixos.org/nar/abc.nar.xz"
+            ))
         );
     }
 
@@ -116,7 +118,7 @@ mod tests {
             &cache,
             NarFileEvent::Registered {
                 nar_file: nar_file.clone(),
-                source_url: Url::new("https://cache-a.example.com/nar/abc.nar.xz").unwrap(),
+                location: make_nar_file_location("https://cache-a.example.com/nar/abc.nar.xz"),
             },
         )
         .await;
@@ -124,13 +126,15 @@ mod tests {
             &cache,
             NarFileEvent::Registered {
                 nar_file: nar_file.clone(),
-                source_url: Url::new("https://cache-b.example.com/nar/abc.nar.xz").unwrap(),
+                location: make_nar_file_location("https://cache-b.example.com/nar/abc.nar.xz"),
             },
         )
         .await;
         assert_eq!(
             cache.get(&nar_file).await,
-            Some(Url::new("https://cache-b.example.com/nar/abc.nar.xz").unwrap())
+            Some(make_nar_file_location(
+                "https://cache-b.example.com/nar/abc.nar.xz"
+            ))
         );
     }
 
@@ -142,7 +146,7 @@ mod tests {
             &cache,
             NarFileEvent::Registered {
                 nar_file: nar_file.clone(),
-                source_url: Url::new("https://cache.nixos.org/nar/abc.nar.xz").unwrap(),
+                location: make_nar_file_location("https://cache.nixos.org/nar/abc.nar.xz"),
             },
         )
         .await;
@@ -165,7 +169,7 @@ mod tests {
             &cache,
             NarFileEvent::Registered {
                 nar_file: nar_file.clone(),
-                source_url: Url::new("https://cache.nixos.org/nar/abc.nar.xz").unwrap(),
+                location: make_nar_file_location("https://cache.nixos.org/nar/abc.nar.xz"),
             },
         )
         .await;

--- a/src/infrastructure/provider/nar_info_provider.rs
+++ b/src/infrastructure/provider/nar_info_provider.rs
@@ -12,15 +12,15 @@ use crate::domain::substituter::model::Url;
 
 pub struct ReqwestNarInfoProvider {
     client: Client,
-    timeout: Duration,
+    default_timeout: Duration,
     concurrency: Arc<Semaphore>,
 }
 
 impl ReqwestNarInfoProvider {
-    pub fn new(client: Client, timeout: Duration, concurrency: Arc<Semaphore>) -> Self {
+    pub fn new(client: Client, default_timeout: Duration, concurrency: Arc<Semaphore>) -> Self {
         Self {
             client,
-            timeout,
+            default_timeout,
             concurrency,
         }
     }
@@ -28,12 +28,17 @@ impl ReqwestNarInfoProvider {
 
 #[async_trait]
 impl NarInfoProvider for ReqwestNarInfoProvider {
-    async fn provide_nar_info(&self, url: &Url) -> AnyhowResult<Option<NarInfoQueryData>> {
+    async fn provide_nar_info(
+        &self,
+        url: &Url,
+        timeout: Option<Duration>,
+    ) -> AnyhowResult<Option<NarInfoQueryData>> {
         tracing::debug!(%url, "fetching nar info from substituter");
 
         let _permit = self.concurrency.acquire().await.unwrap();
 
-        let request = self.client.get(url.value()).timeout(self.timeout);
+        let timeout = timeout.unwrap_or(self.default_timeout);
+        let request = self.client.get(url.value()).timeout(timeout);
 
         let start = Instant::now();
         let response = (request.send().await)

--- a/src/infrastructure/provider/nar_stream_provider.rs
+++ b/src/infrastructure/provider/nar_stream_provider.rs
@@ -7,6 +7,7 @@ use reqwest::{Client, Response, StatusCode};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
+use crate::domain::nar::index::NarFileLocation;
 use crate::domain::nar::port::{NarStreamData, NarStreamHeaders, NarStreamProvider};
 use crate::domain::substituter::model::Url;
 
@@ -47,34 +48,43 @@ impl ReqwestNarStreamProvider {
 
 #[async_trait]
 impl NarStreamProvider for ReqwestNarStreamProvider {
-    async fn stream_nar(&self, urls: &[Url]) -> AnyhowResult<Option<NarStreamData>> {
-        if urls.is_empty() {
+    async fn stream_nar(
+        &self,
+        locations: &[NarFileLocation],
+    ) -> AnyhowResult<Option<NarStreamData>> {
+        if locations.is_empty() {
             return Ok(None);
         }
 
         let mut set = JoinSet::new();
-        for url in urls {
+        for location in locations {
             let client = self.client.clone();
-            let url = url.clone();
+            let location = location.clone();
             let concurrency = self.concurrency.clone();
             set.spawn(async move {
                 let _permit = concurrency.acquire().await.unwrap();
-                let response = client.get(url.value()).send().await;
-                (url, response)
+                let request = client.get(location.source_url().value());
+                let response = if let Some(timeout) = location.timeout() {
+                    tokio::time::timeout(timeout, request.send()).await
+                } else {
+                    Ok(request.send().await)
+                };
+                (location.clone(), response)
             });
         }
 
         let mut not_found_count = 0;
 
         while let Some(result) = set.join_next().await {
-            let Ok((url, response)) = result else {
+            let Ok((location, response)) = result else {
                 continue;
             };
+            let url = location.source_url();
 
             match response {
-                Ok(resp) => match resp.status() {
+                Ok(Ok(response)) => match response.status() {
                     StatusCode::OK => {
-                        return Self::wrap_ok_response(url, resp);
+                        return Self::wrap_ok_response(url.clone(), response);
                     }
                     StatusCode::NOT_FOUND | StatusCode::FORBIDDEN => {
                         not_found_count += 1;
@@ -83,13 +93,18 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
                         tracing::debug!(%url, %status, "received unexpected status from substituter");
                     }
                 },
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::debug!(%url, error = %e, "failed to request nar from substituter");
+                }
+                Err(_) => {
+                    if let Some(timeout) = location.timeout() {
+                        tracing::debug!(%url, timeout_secs = %timeout.as_secs(), "timeout for requesting nar from substituter elapsed");
+                    }
                 }
             }
         }
 
-        if not_found_count == urls.len() {
+        if not_found_count == locations.len() {
             Ok(None)
         } else {
             Err(anyhow::anyhow!("could not fetch nar from any substituter"))


### PR DESCRIPTION
Add `substituters[].nar_info_timeout_secs` and `substituters[].nar_timeout_secs` as optional per-substituter overrides for the global `network.nar_info_timeout_secs` and `network.nar_timeout_secs` settings.