### PR TITLE
Fix unexpected actor eviction and remove panic in NAR resolution

### DIFF
--- a/components/selector4nix-actor/src/actor/address.rs
+++ b/components/selector4nix-actor/src/actor/address.rs
@@ -1,5 +1,6 @@
 use tokio::sync::mpsc::error::{SendError, TrySendError};
-use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::mpsc::{self, Receiver as MpscReceiver, Sender as MpscSender};
+use tokio::sync::oneshot::{self, Sender as OneshotSender};
 
 use crate::actor::{Actor, Message};
 
@@ -9,7 +10,7 @@ pub struct Address<A: Actor> {
 }
 
 impl<A: Actor> Address<A> {
-    pub fn mock() -> (Self, Receiver<Message<A::Request>>) {
+    pub fn mock() -> (Self, MpscReceiver<Message<A::Request>>) {
         let (inner, receiver) = AnyAddress::mock();
         (Self { inner }, receiver)
     }
@@ -24,6 +25,20 @@ impl<A: Actor> Address<A> {
 
     pub fn try_tell(&self, request: A::Request) -> Result<(), TryTellError<A::Request>> {
         self.inner.try_tell(request)
+    }
+
+    pub async fn ask<F, T>(&self, preparation: F) -> Result<T, AskError<A::Request>>
+    where
+        F: FnOnce(OneshotSender<T>) -> A::Request,
+    {
+        self.inner.ask(preparation).await
+    }
+
+    pub async fn try_ask<F, T>(&self, preparation: F) -> Result<T, TryAskError<A::Request>>
+    where
+        F: FnOnce(OneshotSender<T>) -> A::Request,
+    {
+        self.inner.try_ask(preparation).await
     }
 
     pub async fn shutdown(self) {
@@ -55,8 +70,8 @@ impl<A: Actor> PartialEq for Address<A> {
 
 impl<A: Actor> Eq for Address<A> {}
 
-impl<A: Actor> From<Sender<Message<A::Request>>> for Address<A> {
-    fn from(sender: Sender<Message<A::Request>>) -> Self {
+impl<A: Actor> From<MpscSender<Message<A::Request>>> for Address<A> {
+    fn from(sender: MpscSender<Message<A::Request>>) -> Self {
         Self {
             inner: AnyAddress::from(sender),
         }
@@ -65,11 +80,11 @@ impl<A: Actor> From<Sender<Message<A::Request>>> for Address<A> {
 
 #[derive(Debug)]
 pub struct AnyAddress<R> {
-    sender: Sender<Message<R>>,
+    sender: MpscSender<Message<R>>,
 }
 
 impl<R> AnyAddress<R> {
-    pub fn mock() -> (Self, Receiver<Message<R>>) {
+    pub fn mock() -> (Self, MpscReceiver<Message<R>>) {
         let (sender, receiver) = mpsc::channel(64);
         (sender.into(), receiver)
     }
@@ -93,6 +108,29 @@ impl<R> AnyAddress<R> {
                 "`try_tell(..)` should not send messages other than `Message::Main(..)`"
             ),
         }
+    }
+
+    pub async fn ask<F, T>(&self, preparation: F) -> Result<T, AskError<R>>
+    where
+        F: FnOnce(OneshotSender<T>) -> R,
+    {
+        let (reply_to, reply) = oneshot::channel::<T>();
+        let request = preparation(reply_to);
+        self.tell(request)
+            .await
+            .map_err(|err| AskError::Tell(err))?;
+        reply.await.map_err(|_| AskError::Receive)
+    }
+
+    pub async fn try_ask<F, T>(&self, preparation: F) -> Result<T, TryAskError<R>>
+    where
+        F: FnOnce(OneshotSender<T>) -> R,
+    {
+        let (reply_to, reply) = oneshot::channel::<T>();
+        let request = preparation(reply_to);
+        self.try_tell(request)
+            .map_err(|err| TryAskError::Tell(err))?;
+        reply.await.map_err(|_| TryAskError::Receive)
     }
 
     pub async fn shutdown(self) {
@@ -124,8 +162,8 @@ impl<R> PartialEq for AnyAddress<R> {
 
 impl<R> Eq for AnyAddress<R> {}
 
-impl<R> From<Sender<Message<R>>> for AnyAddress<R> {
-    fn from(sender: Sender<Message<R>>) -> Self {
+impl<R> From<MpscSender<Message<R>>> for AnyAddress<R> {
+    fn from(sender: MpscSender<Message<R>>) -> Self {
         Self { sender }
     }
 }
@@ -137,4 +175,16 @@ pub struct TellError<T>(pub T);
 pub enum TryTellError<T> {
     Full(T),
     Closed(T),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AskError<T> {
+    Tell(TellError<T>),
+    Receive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TryAskError<T> {
+    Tell(TryTellError<T>),
+    Receive,
 }

--- a/components/selector4nix-actor/src/actor/mod.rs
+++ b/components/selector4nix-actor/src/actor/mod.rs
@@ -2,6 +2,6 @@ mod address;
 mod pre;
 mod runner;
 
-pub use address::{Address, AnyAddress, TellError, TryTellError};
+pub use address::{Address, AnyAddress, AskError, TellError, TryAskError, TryTellError};
 pub use pre::{ActorPre, ActorPreBuilder};
 pub use runner::{Actor, Context, EmptyInternal, Message};

--- a/components/selector4nix-actor/src/registry/builder.rs
+++ b/components/selector4nix-actor/src/registry/builder.rs
@@ -2,9 +2,9 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::time::Duration;
 
-use moka::future::{Cache, FutureExt};
+use moka::future::Cache;
 
-use crate::actor::{Actor, Address};
+use crate::actor::Actor;
 use crate::registry::{NoFactory, Registry};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -64,12 +64,7 @@ impl<K, A, F> RegistryBuilder<K, A, F> {
             ExpirationOption::Ttl(duration) => builder.time_to_live(duration),
             ExpirationOption::Tti(duration) => builder.time_to_idle(duration),
         };
-        let actors = builder
-            .async_eviction_listener(|_hash, address: Address<A>, _cause| {
-                address.shutdown().boxed()
-            })
-            .build();
-        Registry::new(actors, self.factory)
+        Registry::new(builder.build(), self.factory)
     }
 }
 

--- a/components/selector4nix-actor/src/registry/container.rs
+++ b/components/selector4nix-actor/src/registry/container.rs
@@ -143,8 +143,8 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use crate::actor::{ActorPreBuilder, Context, EmptyInternal, Message};
-    use crate::registry::{CapacityOption, RegistryBuilder};
+    use crate::actor::{ActorPreBuilder, Context, EmptyInternal};
+    use crate::registry::RegistryBuilder;
 
     use super::*;
 
@@ -324,20 +324,5 @@ mod tests {
         let recreated = registry.get(&"a".to_string()).await;
         assert!(!original.is_same(&recreated));
         assert_eq!(counter.load(Ordering::Relaxed), 2);
-    }
-
-    #[tokio::test]
-    async fn eviction_sends_shutdown() {
-        let registry = RegistryBuilder::new()
-            .capacity(CapacityOption::Lru(1))
-            .build();
-
-        let (addr, mut rx) = Address::<TestActor>::mock();
-        registry.insert("a".to_string(), addr).await;
-
-        registry.clear().await;
-
-        let msg = rx.recv().await.unwrap();
-        assert!(matches!(msg, Message::Shutdown));
     }
 }

--- a/src/application/nar/usecase/resolution.rs
+++ b/src/application/nar/usecase/resolution.rs
@@ -1,10 +1,8 @@
 use std::sync::Arc;
 
-use tokio::sync::oneshot;
-
 use crate::application::nar::actor::{NarActorRegistry, NarRequest};
 use crate::application::substituter::actor::{SubstituterActorRegistry, SubstituterRequest};
-use crate::application::{AppOptionExt, AppResult};
+use crate::application::{AppErrorKind, AppOptionExt, AppResult, AppResultExt};
 use crate::domain::nar::model::{NarInfoData, StorePathHash};
 use crate::domain::nar::service::{NarResolutionEvent, ResolveNarInfoError};
 
@@ -29,9 +27,11 @@ impl NarResolutionUseCase {
 
         let address = self.nar_registry.get(&hash).await;
 
-        let (reply_to, reply) = oneshot::channel();
-        let _ = address.tell(NarRequest::ResolveNarInfo(reply_to)).await;
-        let response = reply.await.expect("nar actor shouldn't be dropped");
+        let response = address
+            .ask(|reply_to| NarRequest::ResolveNarInfo(reply_to))
+            .await
+            .map_err(|_| anyhow::anyhow!("nar actor terminated unexpectedly"))
+            .wrap(AppErrorKind::Unknown)?;
 
         match &response.result {
             Ok(Some(data)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::new_without_default)]
+#![allow(clippy::redundant_closure)]
 
 pub mod api;
 pub mod application;


### PR DESCRIPTION
`moka` cache's eviction listener called `address.shutdown()` on actors that were still handling requests. The `oneshot::Receiver::await.expect()` in `resolution.rs` then panicked because the sender was dropped during shutdown.

- Remove eviction listener from `RegistryBuilder` that sent `Shutdown` to actors on LRU/TTL eviction, causing in-flight nar resolution requests to panic
- Add `ask`/`try_ask` convenience methods on `Address`/`AnyAddress` for request-reply interaction with proper error propagation
- Replace `expect` panic in `resolution.rs` with error return, mapping actor termination to `AppError`