### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build And Release
+        uses: lxl66566/rust-simple-release@main
+        with:
+          targets: |
+            x86_64-unknown-linux-gnu
+            aarch64-unknown-linux-gnu
+            x86_64-unknown-linux-musl
+            aarch64-unknown-linux-musl
+            x86_64-apple-darwin
+            aarch64-apple-darwin
+          release_options: --draft
+          files_to_pack: README.md, LICENSE, docs


### PR DESCRIPTION
Add GitHub Actions release workflow using [rust-simple-release](https://github.com/lxl66566/rust-simple-release), which builds Linux (GNU/Musl) and macOS (Darwin) binaries on tag push automatically.

Special thanks to @lxl66566 for rust-simple-release.