### PR TITLE
Distinguish offline from service error in NAR info queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ selector4nix # A configuration file must be discoverable (see Configuration abov
 On the same machine, point Nix to the proxy, then everything is done. All NAR info queries and subsequent NAR fetching will transparently go through the `selector4nix` proxy.
 
 ```sh
-nix build --option substituters "http://127.0.0.1:5496" ...
+nix build --option substituters "http://127.0.0.1:5496/" ...
 ```
 
 If you care about definite robustness, you can place it before other substituters so it takes priority while keeping fallbacks:
 
 ```sh
-nix build --option substituters "http://127.0.0.1:5496 https://cache.nixos.org/" ...
+nix build --option substituters "http://127.0.0.1:5496/ https://cache.nixos.org/" ...
 ```
 
 ### Import the NixOS/Nix-darwin/Home Manager Module (flake)
@@ -112,6 +112,8 @@ For nix-darwin:
   };
 }
 ```
+
+For Home Manager:
 
 ```nix
 # Home Manager flake.nix

--- a/src/domain/nar/port/mod.rs
+++ b/src/domain/nar/port/mod.rs
@@ -1,5 +1,5 @@
 mod nar_info_provider;
 mod nar_stream_provider;
 
-pub use nar_info_provider::{NarInfoProvider, NarInfoQueryData};
+pub use nar_info_provider::{NarInfoProvider, NarInfoQueryData, QueryNarInfoError, error_ctx};
 pub use nar_stream_provider::{NarStreamData, NarStreamHeaders, NarStreamProvider};

--- a/src/domain/nar/port/nar_info_provider.rs
+++ b/src/domain/nar/port/nar_info_provider.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
-use anyhow::Result as AnyhowResult;
+use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
+use snafu::Snafu;
 
 use crate::domain::nar::model::NarInfoData;
 use crate::domain::substituter::model::Url;
@@ -12,7 +13,7 @@ pub trait NarInfoProvider: Send + Sync {
         &self,
         url: &Url,
         timeout: Option<Duration>,
-    ) -> AnyhowResult<Option<NarInfoQueryData>>;
+    ) -> Result<Option<NarInfoQueryData>, QueryNarInfoError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,4 +29,18 @@ impl NarInfoQueryData {
             latency,
         }
     }
+}
+
+#[derive(Snafu, Debug)]
+#[non_exhaustive]
+#[snafu(visibility(pub))]
+pub enum QueryNarInfoError {
+    #[snafu(display("could not query nar info from offline substituter"))]
+    Offline { source: AnyhowError },
+    #[snafu(display("query nar info got service error from substituter"))]
+    Service { source: AnyhowError },
+}
+
+pub mod error_ctx {
+    pub use super::{OfflineSnafu, ServiceSnafu};
 }

--- a/src/domain/nar/port/nar_info_provider.rs
+++ b/src/domain/nar/port/nar_info_provider.rs
@@ -8,7 +8,7 @@ use crate::domain::substituter::model::Url;
 
 #[async_trait]
 pub trait NarInfoProvider: Send + Sync {
-    async fn provide_nar_info(
+    async fn query_nar_info(
         &self,
         url: &Url,
         timeout: Option<Duration>,

--- a/src/domain/nar/service/resolution.rs
+++ b/src/domain/nar/service/resolution.rs
@@ -9,7 +9,7 @@ use tokio::time::Instant;
 use crate::domain::nar::model::{
     NarInfoData, NarInfoResolution, NarUrlRewriteOption, StorePathHash,
 };
-use crate::domain::nar::port::NarInfoProvider;
+use crate::domain::nar::port::{NarInfoProvider, QueryNarInfoError};
 use crate::domain::nar::service::DeadlineGroup;
 use crate::domain::substituter::index::SubstituterAvailabilityIndex;
 use crate::domain::substituter::model::{Substituter, SubstituterMeta, Url};
@@ -132,7 +132,7 @@ impl NarResolutionService {
                 Some(Ok((substituter, Ok(outcome)))) => {
                     query_cancellers.remove(&substituter);
                     query_deadlines.remove(&substituter);
-                    let cur_grace = substituter_graces.remove(&substituter).unwrap();
+                    let current_grace = substituter_graces.remove(&substituter).unwrap();
                     if !substituter.is_normal() {
                         let url = substituter.url().clone();
                         events.push(NarResolutionEvent::SubstituterSucceeded(url));
@@ -142,7 +142,7 @@ impl NarResolutionService {
                         let current = NarInfoQueryCandidate {
                             substituter,
                             nar_info: data.original_data,
-                            grace: cur_grace,
+                            grace: current_grace,
                             latency: data.latency,
                         };
                         update_optimal_and_deadlines(
@@ -155,8 +155,8 @@ impl NarResolutionService {
                         );
                     }
                 }
-                Some(Ok((substituter, Err(_)))) => {
-                    if !self.ignore_query_error {
+                Some(Ok((substituter, Err(e)))) => {
+                    if !self.ignore_query_error && matches!(e, QueryNarInfoError::Service { .. }) {
                         has_error = true;
                     }
                     query_cancellers.remove(&substituter);

--- a/src/domain/nar/service/resolution.rs
+++ b/src/domain/nar/service/resolution.rs
@@ -106,7 +106,7 @@ impl NarResolutionService {
                 let sub = substituter.clone();
                 let url = hash.on_substituter(substituter.target());
                 let timeout = sub.target().nar_info_timeout();
-                async move { (sub, provider.provide_nar_info(&url, timeout).await) }
+                async move { (sub, provider.query_nar_info(&url, timeout).await) }
             });
             query_cancellers.insert(substituter, handle);
         }

--- a/src/infrastructure/provider/nar_info_provider.rs
+++ b/src/infrastructure/provider/nar_info_provider.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result as AnyhowResult};
+use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
 use reqwest::{Client, StatusCode};
+use snafu::ResultExt;
 use tokio::sync::Semaphore;
 
 use crate::domain::nar::model::NarInfoData;
-use crate::domain::nar::port::{NarInfoProvider, NarInfoQueryData};
+use crate::domain::nar::port::error_ctx::{OfflineSnafu, ServiceSnafu};
+use crate::domain::nar::port::{NarInfoProvider, NarInfoQueryData, QueryNarInfoError};
 use crate::domain::substituter::model::Url;
 
 pub struct ReqwestNarInfoProvider {
@@ -32,7 +34,7 @@ impl NarInfoProvider for ReqwestNarInfoProvider {
         &self,
         url: &Url,
         timeout: Option<Duration>,
-    ) -> AnyhowResult<Option<NarInfoQueryData>> {
+    ) -> Result<Option<NarInfoQueryData>, QueryNarInfoError> {
         tracing::debug!(%url, "fetching nar info from substituter");
 
         let _permit = self.concurrency.acquire().await.unwrap();
@@ -41,21 +43,38 @@ impl NarInfoProvider for ReqwestNarInfoProvider {
         let request = self.client.get(url.value()).timeout(timeout);
 
         let start = Instant::now();
-        let response = (request.send().await)
-            .with_context(|| format!("failed to fetch narinfo from {}", url))?;
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(err) => {
+                tracing::trace!(%url, "failed to send nar info query request");
+                if err.is_timeout() || err.is_connect() || err.is_request() {
+                    return Err(AnyhowError::new(err)).context(OfflineSnafu);
+                } else {
+                    return Err(AnyhowError::new(err)).context(ServiceSnafu);
+                }
+            }
+        };
 
         match response.status() {
             StatusCode::OK => {
-                tracing::debug!(%url, "fetched nar info from substituter");
                 let text = (response.text().await)
-                    .with_context(|| format!("failed to read narinfo body from {}", url))?;
+                    .map_err(|err| AnyhowError::new(err))
+                    .map_err(|err| err.context(format!("failed to read nar info body from {url}")))
+                    .context(ServiceSnafu)
+                    .inspect_err(|_| tracing::debug!(%url, "failed to read nar info body"))?;
                 let latency = start.elapsed();
                 let original_data = NarInfoData::original(text)
-                    .with_context(|| format!("invalid narinfo from {}", url))?;
+                    .map_err(|err| AnyhowError::new(err))
+                    .map_err(|err| err.context(format!("invalid nar info from {url}")))
+                    .context(ServiceSnafu)
+                    .inspect_err(|_| tracing::debug!(%url, "failed to parse nar info body"))?;
+                tracing::debug!(%url, "fetched nar info from substituter");
                 Ok(Some(NarInfoQueryData::new(original_data, latency)))
             }
             StatusCode::NOT_FOUND | StatusCode::FORBIDDEN => Ok(None),
-            status => Err(anyhow::anyhow!("unexpected status {} from {}", status, url)),
+            status => Err(anyhow::anyhow!("unexpected status {} from {}", status, url))
+                .context(ServiceSnafu)
+                .inspect_err(|_| tracing::debug!(%url, "encountered bad nar info response status")),
         }
     }
 }

--- a/src/infrastructure/provider/nar_info_provider.rs
+++ b/src/infrastructure/provider/nar_info_provider.rs
@@ -28,7 +28,7 @@ impl ReqwestNarInfoProvider {
 
 #[async_trait]
 impl NarInfoProvider for ReqwestNarInfoProvider {
-    async fn provide_nar_info(
+    async fn query_nar_info(
         &self,
         url: &Url,
         timeout: Option<Duration>,

--- a/tests/integration/fixture/substituter.rs
+++ b/tests/integration/fixture/substituter.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use selector4nix::domain::substituter::model::{
     Availability, Priority, Substituter, SubstituterMeta, Url,
 };
@@ -8,6 +10,17 @@ pub fn make_substituter_meta(url: &Url, priority: u32) -> SubstituterMeta {
 
 pub fn make_substituter_normal(url: &Url, priority: u32) -> Substituter {
     Substituter::new(make_substituter_meta(url, priority), Availability::Normal)
+}
+
+pub fn make_substituter_normal_with_nar_info_timeout(
+    url: &Url,
+    priority: u32,
+    timeout: Duration,
+) -> Substituter {
+    Substituter::new(
+        make_substituter_meta(url, priority).with_nar_info_timeout(timeout),
+        Availability::Normal,
+    )
 }
 
 pub fn make_substituter_maybe_ready(url: &Url, priority: u32) -> Substituter {

--- a/tests/integration/mock/nar_info_provider.rs
+++ b/tests/integration/mock/nar_info_provider.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
-use selector4nix::domain::nar::port::{NarInfoProvider, NarInfoQueryData};
+use selector4nix::domain::nar::port::error_ctx::{OfflineSnafu, ServiceSnafu};
+use selector4nix::domain::nar::port::{NarInfoProvider, NarInfoQueryData, QueryNarInfoError};
 use selector4nix::domain::substituter::model::Url;
+use snafu::ResultExt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MockNarInfoProvider {
@@ -28,7 +29,7 @@ impl NarInfoProvider for MockNarInfoProvider {
         &self,
         url: &Url,
         timeout: Option<Duration>,
-    ) -> AnyhowResult<Option<NarInfoQueryData>> {
+    ) -> Result<Option<NarInfoQueryData>, QueryNarInfoError> {
         let Some(data) = self.queries.get(url) else {
             return Ok(None);
         };
@@ -36,13 +37,13 @@ impl NarInfoProvider for MockNarInfoProvider {
         match (data, timeout) {
             (Ok(data), Some(timeout)) if data.latency > timeout => {
                 tokio::time::sleep(timeout).await;
-                Err(anyhow::anyhow!("timeout"))
+                Err(anyhow::anyhow!("timeout")).context(OfflineSnafu)
             }
             (Ok(data), _) => {
                 tokio::time::sleep(data.latency).await;
                 Ok(Some(data.clone()))
             }
-            (Err(err), _) => Err(anyhow::anyhow!("{err}")),
+            (Err(err), _) => Err(anyhow::anyhow!("{err}")).context(ServiceSnafu),
         }
     }
 }

--- a/tests/integration/mock/nar_info_provider.rs
+++ b/tests/integration/mock/nar_info_provider.rs
@@ -24,7 +24,7 @@ impl MockNarInfoProvider {
 
 #[async_trait]
 impl NarInfoProvider for MockNarInfoProvider {
-    async fn provide_nar_info(
+    async fn query_nar_info(
         &self,
         url: &Url,
         timeout: Option<Duration>,

--- a/tests/integration/nar_resolution_service_test.rs
+++ b/tests/integration/nar_resolution_service_test.rs
@@ -257,7 +257,7 @@ async fn partial_error_with_success() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn all_subs_fail_with_ignore_error() {
+async fn all_subs_service_fail_with_ignore_error() {
     let sub_a_url = Url::new("https://cache-a.example.com").unwrap();
     let sub_b_url = Url::new("https://cache-b.example.com").unwrap();
     let sub_a = substituter::make_substituter_normal(&sub_a_url, 40);
@@ -279,6 +279,50 @@ async fn all_subs_fail_with_ignore_error() {
             ],
             tolerance: 50,
             ignore_query_error: true,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Ok(None),
+            events: vec![
+                NarResolutionEvent::SubstituterFailed(sub_a_url),
+                NarResolutionEvent::SubstituterFailed(sub_b_url),
+            ],
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn all_subs_offline_treated_as_not_found() {
+    let sub_a_url = Url::new("https://cache-a.example.com").unwrap();
+    let sub_b_url = Url::new("https://cache-b.example.com").unwrap();
+    let sub_a = substituter::make_substituter_normal_with_nar_info_timeout(
+        &sub_a_url,
+        40,
+        Duration::from_millis(10),
+    );
+    let sub_b = substituter::make_substituter_normal_with_nar_info_timeout(
+        &sub_b_url,
+        10,
+        Duration::from_millis(20),
+    );
+    let hash = nar::make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![sub_a, sub_b],
+            nar_info_entries: vec![
+                (
+                    nar::make_nar_info_url(&sub_a_url, &hash),
+                    Ok(nar::make_nar_info_query_data(Duration::from_millis(100))),
+                ),
+                (
+                    nar::make_nar_info_url(&sub_b_url, &hash),
+                    Ok(nar::make_nar_info_query_data(Duration::from_millis(200))),
+                ),
+            ],
+            tolerance: 50,
+            ignore_query_error: false,
         },
         TestCaseInput { hash },
         TestCaseExpectation {


### PR DESCRIPTION
When a substituter is unreachable, treat it as if the store path simply doesn't exist there (404), rather than an infrastructure error. Only service-level errors still trigger a 502 response. This is semantically more appropriate as NARs on an offline machine effectively don't exist at that moment.