### PR TITLE
Apply different retry strategies based on substituter error type

### DIFF
--- a/src/application/nar/usecase/resolution.rs
+++ b/src/application/nar/usecase/resolution.rs
@@ -61,7 +61,11 @@ impl NarResolutionUseCase {
                 let sender = self.substituter_registry.get(&url).await;
                 let _ = sender.tell(SubstituterRequest::ServiceSuccessful).await;
             }
-            NarResolutionEvent::SubstituterFailed(url) => {
+            NarResolutionEvent::SubstituterOffline(url) => {
+                let sender = self.substituter_registry.get(&url).await;
+                let _ = sender.tell(SubstituterRequest::ServiceOffline).await;
+            }
+            NarResolutionEvent::SubstituterError(url) => {
                 let sender = self.substituter_registry.get(&url).await;
                 let _ = sender.tell(SubstituterRequest::ServiceError).await;
             }

--- a/src/application/nar/usecase/resolution.rs
+++ b/src/application/nar/usecase/resolution.rs
@@ -63,7 +63,7 @@ impl NarResolutionUseCase {
             }
             NarResolutionEvent::SubstituterFailed(url) => {
                 let sender = self.substituter_registry.get(&url).await;
-                let _ = sender.tell(SubstituterRequest::ServiceFailed).await;
+                let _ = sender.tell(SubstituterRequest::ServiceError).await;
             }
         }
     }

--- a/src/application/substituter/actor/runner.rs
+++ b/src/application/substituter/actor/runner.rs
@@ -11,6 +11,7 @@ use crate::domain::substituter::service::{SubstituterLifecycleEvent, Substituter
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SubstituterRequest {
     ServiceSuccessful,
+    ServiceOffline,
     ServiceError,
 }
 
@@ -97,6 +98,13 @@ impl Actor for SubstituterActor {
             SubstituterRequest::ServiceSuccessful => {
                 let (substituter, events) =
                     self.lifecycle_service.update_on_service_successful(state);
+                self.exec_all_events(&substituter, events).await;
+                Some(substituter)
+            }
+            SubstituterRequest::ServiceOffline => {
+                let now = Instant::now();
+                let (substituter, events) =
+                    self.lifecycle_service.update_on_service_offline(state, now);
                 self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }

--- a/src/application/substituter/actor/runner.rs
+++ b/src/application/substituter/actor/runner.rs
@@ -11,7 +11,7 @@ use crate::domain::substituter::service::{SubstituterLifecycleEvent, Substituter
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SubstituterRequest {
     ServiceSuccessful,
-    ServiceFailed,
+    ServiceError,
 }
 
 pub enum SubstituterInternal {
@@ -95,14 +95,15 @@ impl Actor for SubstituterActor {
     ) -> Option<Self::State> {
         match request {
             SubstituterRequest::ServiceSuccessful => {
-                let (substituter, _events) =
+                let (substituter, events) =
                     self.lifecycle_service.update_on_service_successful(state);
+                self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }
-            SubstituterRequest::ServiceFailed => {
+            SubstituterRequest::ServiceError => {
                 let now = Instant::now();
                 let (substituter, events) =
-                    self.lifecycle_service.update_on_service_failed(state, now);
+                    self.lifecycle_service.update_on_service_error(state, now);
                 self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }

--- a/src/domain/nar/service/resolution.rs
+++ b/src/domain/nar/service/resolution.rs
@@ -163,7 +163,14 @@ impl NarResolutionService {
                     query_deadlines.remove(&substituter);
                     substituter_graces.remove(&substituter);
                     let url = substituter.url().clone();
-                    events.push(NarResolutionEvent::SubstituterFailed(url));
+                    match e {
+                        QueryNarInfoError::Offline { .. } => {
+                            events.push(NarResolutionEvent::SubstituterOffline(url));
+                        }
+                        QueryNarInfoError::Service { .. } => {
+                            events.push(NarResolutionEvent::SubstituterError(url));
+                        }
+                    }
                 }
                 Some(Err(_)) => (),
                 None => break,
@@ -181,7 +188,8 @@ impl NarResolutionService {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum NarResolutionEvent {
     SubstituterSucceeded(Url),
-    SubstituterFailed(Url),
+    SubstituterOffline(Url),
+    SubstituterError(Url),
 }
 
 #[derive(Snafu, Debug, Clone, PartialEq, Eq)]

--- a/src/domain/substituter/model/availability.rs
+++ b/src/domain/substituter/model/availability.rs
@@ -5,7 +5,7 @@ use tokio::time::Instant;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Availability {
     Normal,
-    Unavailable {
+    ServiceError {
         detected_at: Instant,
         prev_failures: usize,
     },
@@ -19,14 +19,14 @@ impl Availability {
         Self::Normal
     }
 
-    pub fn change_to_unavailable(self, now: Instant) -> Self {
+    pub fn change_to_service_error(self, now: Instant) -> Self {
         match self {
-            Self::Normal => Self::Unavailable {
+            Self::Normal => Self::ServiceError {
                 detected_at: now,
                 prev_failures: 0,
             },
-            s @ Self::Unavailable { .. } => s,
-            Self::MaybeReady { prev_failures } => Self::Unavailable {
+            s @ Self::ServiceError { .. } => s,
+            Self::MaybeReady { prev_failures } => Self::ServiceError {
                 detected_at: now,
                 prev_failures: prev_failures + 1,
             },
@@ -35,14 +35,14 @@ impl Availability {
 
     pub fn change_to_maybe_ready(self) -> Self {
         match self {
-            Self::Unavailable { prev_failures, .. } => Self::MaybeReady { prev_failures },
+            Self::ServiceError { prev_failures, .. } => Self::MaybeReady { prev_failures },
             otherwise => otherwise,
         }
     }
 
     pub fn update_and_check_availability(self, now: Instant) -> (bool, Self) {
         match &self {
-            Availability::Unavailable {
+            Availability::ServiceError {
                 detected_at,
                 prev_failures,
             } => {
@@ -58,7 +58,7 @@ impl Availability {
 
     pub fn retry_duration(&self) -> Option<Duration> {
         match self {
-            Self::Unavailable { prev_failures, .. } => {
+            Self::ServiceError { prev_failures, .. } => {
                 Some(Self::calc_retry_duration(*prev_failures))
             }
             _ => None,
@@ -75,7 +75,7 @@ impl Availability {
     pub fn prev_failures(&self) -> usize {
         match self {
             Availability::Normal => 0,
-            Availability::Unavailable { prev_failures, .. } => *prev_failures,
+            Availability::ServiceError { prev_failures, .. } => *prev_failures,
             Availability::MaybeReady { prev_failures } => *prev_failures,
         }
     }
@@ -86,12 +86,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn change_to_unavailable_succeeds_from_normal() {
+    fn change_to_service_error_succeeds_from_normal() {
         let now = Instant::now();
-        let result = Availability::Normal.change_to_unavailable(now);
+        let result = Availability::Normal.change_to_service_error(now);
         assert_eq!(
             result,
-            Availability::Unavailable {
+            Availability::ServiceError {
                 detected_at: now,
                 prev_failures: 0,
             }
@@ -99,16 +99,16 @@ mod tests {
     }
 
     #[test]
-    fn change_to_unavailable_doesnt_change_prev_failures() {
+    fn change_to_service_error_doesnt_change_prev_failures() {
         let now = Instant::now();
-        let state = Availability::Unavailable {
+        let state = Availability::ServiceError {
             detected_at: now,
             prev_failures: 1,
         };
-        let result = state.change_to_unavailable(now);
+        let result = state.change_to_service_error(now);
         assert_eq!(
             result,
-            Availability::Unavailable {
+            Availability::ServiceError {
                 detected_at: now,
                 prev_failures: 1,
             }
@@ -124,9 +124,9 @@ mod tests {
     }
 
     #[test]
-    fn update_and_check_availability_returns_false_when_unavailable_before_timeout() {
+    fn update_and_check_availability_returns_false_when_service_error_before_timeout() {
         let now = Instant::now();
-        let state = Availability::Unavailable {
+        let state = Availability::ServiceError {
             detected_at: now,
             prev_failures: 0,
         };
@@ -135,9 +135,9 @@ mod tests {
     }
 
     #[test]
-    fn update_and_check_availability_returns_true_when_unavailable_after_timeout() {
+    fn update_and_check_availability_returns_true_when_service_error_after_timeout() {
         let now = Instant::now();
-        let state = Availability::Unavailable {
+        let state = Availability::ServiceError {
             detected_at: now,
             prev_failures: 0,
         };

--- a/src/domain/substituter/model/availability.rs
+++ b/src/domain/substituter/model/availability.rs
@@ -5,6 +5,9 @@ use tokio::time::Instant;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Availability {
     Normal,
+    Offline {
+        detected_at: Instant,
+    },
     ServiceError {
         detected_at: Instant,
         prev_failures: usize,
@@ -15,8 +18,19 @@ pub enum Availability {
 }
 
 impl Availability {
+    pub const OFFLINE_RETRY_PERIOD: Duration = Duration::from_secs(30);
+
     pub fn normal() -> Self {
         Self::Normal
+    }
+
+    pub fn change_to_offline(self, now: Instant) -> Self {
+        match self {
+            Self::Normal => Self::Offline { detected_at: now },
+            s @ Self::Offline { .. } => s,
+            s @ Self::ServiceError { .. } => s,
+            Self::MaybeReady { .. } => Self::Offline { detected_at: now },
+        }
     }
 
     pub fn change_to_service_error(self, now: Instant) -> Self {
@@ -25,6 +39,7 @@ impl Availability {
                 detected_at: now,
                 prev_failures: 0,
             },
+            s @ Self::Offline { .. } => s,
             s @ Self::ServiceError { .. } => s,
             Self::MaybeReady { prev_failures } => Self::ServiceError {
                 detected_at: now,
@@ -35,6 +50,7 @@ impl Availability {
 
     pub fn change_to_maybe_ready(self) -> Self {
         match self {
+            Self::Offline { .. } => Self::MaybeReady { prev_failures: 0 },
             Self::ServiceError { prev_failures, .. } => Self::MaybeReady { prev_failures },
             otherwise => otherwise,
         }
@@ -42,7 +58,14 @@ impl Availability {
 
     pub fn update_and_check_availability(self, now: Instant) -> (bool, Self) {
         match &self {
-            Availability::ServiceError {
+            Self::Offline { detected_at } => {
+                if *detected_at + Self::OFFLINE_RETRY_PERIOD <= now {
+                    (true, self.change_to_maybe_ready())
+                } else {
+                    (false, self)
+                }
+            }
+            Self::ServiceError {
                 detected_at,
                 prev_failures,
             } => {
@@ -58,6 +81,7 @@ impl Availability {
 
     pub fn retry_duration(&self) -> Option<Duration> {
         match self {
+            Self::Offline { .. } => Some(Self::OFFLINE_RETRY_PERIOD),
             Self::ServiceError { prev_failures, .. } => {
                 Some(Self::calc_retry_duration(*prev_failures))
             }
@@ -74,9 +98,10 @@ impl Availability {
 
     pub fn prev_failures(&self) -> usize {
         match self {
-            Availability::Normal => 0,
-            Availability::ServiceError { prev_failures, .. } => *prev_failures,
-            Availability::MaybeReady { prev_failures } => *prev_failures,
+            Self::Normal => 0,
+            Self::Offline { .. } => 0,
+            Self::ServiceError { prev_failures, .. } => *prev_failures,
+            Self::MaybeReady { prev_failures } => *prev_failures,
         }
     }
 }
@@ -142,6 +167,25 @@ mod tests {
             prev_failures: 0,
         };
         let retry_at = now + Duration::from_millis(500);
+        let (available, new_state) = state.update_and_check_availability(retry_at);
+        assert!(available);
+        assert_eq!(new_state, Availability::MaybeReady { prev_failures: 0 });
+    }
+
+    #[test]
+    fn update_and_check_availability_returns_true_when_offline_before_timeout() {
+        let now = Instant::now();
+        let state = Availability::Offline { detected_at: now };
+        let retry_at = now + Availability::OFFLINE_RETRY_PERIOD - Duration::from_millis(1);
+        let (available, _) = state.update_and_check_availability(retry_at);
+        assert!(!available);
+    }
+
+    #[test]
+    fn update_and_check_availability_returns_true_when_offline_after_timeout() {
+        let now = Instant::now();
+        let state = Availability::Offline { detected_at: now };
+        let retry_at = now + Availability::OFFLINE_RETRY_PERIOD + Duration::from_millis(1);
         let (available, new_state) = state.update_and_check_availability(retry_at);
         assert!(available);
         assert_eq!(new_state, Availability::MaybeReady { prev_failures: 0 });

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -39,11 +39,11 @@ impl Substituter {
     }
 
     pub fn is_unavailable(&self) -> bool {
-        matches!(&self.availability, Availability::Unavailable { .. })
+        matches!(&self.availability, Availability::ServiceError { .. })
     }
 
-    pub fn on_detected_unavailable(mut self, now: Instant) -> (Instant, Self) {
-        self.availability = self.availability.change_to_unavailable(now);
+    pub fn on_detected_service_error(mut self, now: Instant) -> (Instant, Self) {
+        self.availability = self.availability.change_to_service_error(now);
         let retry_instant = now + self.availability.retry_duration().unwrap();
         (retry_instant, self)
     }
@@ -76,7 +76,7 @@ mod tests {
         let sub = make_substituter();
         assert!(!sub.is_unavailable());
 
-        let (_, sub) = sub.on_detected_unavailable(Instant::now());
+        let (_, sub) = sub.on_detected_service_error(Instant::now());
         assert!(sub.is_unavailable());
     }
 
@@ -84,14 +84,14 @@ mod tests {
     fn on_detected_unavailable_returns_retry_instant() {
         let sub = make_substituter();
         let now = Instant::now();
-        let (retry, _) = sub.on_detected_unavailable(now);
+        let (retry, _) = sub.on_detected_service_error(now);
         assert_eq!(retry, now + Duration::from_millis(500));
     }
 
     #[test]
     fn on_next_retry_ready_transitions_from_unavailable() {
         let sub = make_substituter();
-        let (_, sub) = sub.on_detected_unavailable(Instant::now());
+        let (_, sub) = sub.on_detected_service_error(Instant::now());
         assert!(sub.is_unavailable());
 
         let sub = sub.on_next_retry_ready();
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn on_detected_normal_resets_availability() {
         let sub = make_substituter();
-        let (_, sub) = sub.on_detected_unavailable(Instant::now());
+        let (_, sub) = sub.on_detected_service_error(Instant::now());
         assert!(sub.is_unavailable());
 
         let sub = sub.on_detected_normal();

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -39,7 +39,16 @@ impl Substituter {
     }
 
     pub fn is_unavailable(&self) -> bool {
-        matches!(&self.availability, Availability::ServiceError { .. })
+        matches!(
+            &self.availability,
+            Availability::Offline { .. } | Availability::ServiceError { .. },
+        )
+    }
+
+    pub fn on_detected_offline(mut self, now: Instant) -> (Instant, Self) {
+        self.availability = self.availability.change_to_offline(now);
+        let retry_instant = now + self.availability.retry_duration().unwrap();
+        (retry_instant, self)
     }
 
     pub fn on_detected_service_error(mut self, now: Instant) -> (Instant, Self) {

--- a/src/domain/substituter/service/lifecycle.rs
+++ b/src/domain/substituter/service/lifecycle.rs
@@ -23,7 +23,7 @@ impl SubstituterLifecycleService {
         (substituter.on_detected_normal(), Vec::new())
     }
 
-    pub fn update_on_service_failed(
+    pub fn update_on_service_error(
         &self,
         substituter: Substituter,
         now: Instant,
@@ -31,7 +31,7 @@ impl SubstituterLifecycleService {
         if substituter.is_unavailable() {
             (substituter, Vec::new())
         } else {
-            let (retry_instant, substituter) = substituter.on_detected_unavailable(now);
+            let (retry_instant, substituter) = substituter.on_detected_service_error(now);
             let events = vec![
                 SubstituterLifecycleEvent::NotifyUnavailable,
                 SubstituterLifecycleEvent::ScheduleRetryReady(retry_instant),
@@ -79,7 +79,7 @@ mod tests {
         let sub = make_substituter(Availability::Normal);
         let now = Instant::now();
 
-        let (result, events) = service.update_on_service_failed(sub, now);
+        let (result, events) = service.update_on_service_error(sub, now);
 
         assert!(result.is_unavailable());
         assert_eq!(events.len(), 2);
@@ -99,13 +99,13 @@ mod tests {
         let sub = make_substituter(Availability::MaybeReady { prev_failures: 2 });
         let now = Instant::now();
 
-        let (result, events) = service.update_on_service_failed(sub, now);
+        let (result, events) = service.update_on_service_error(sub, now);
 
         assert!(result.is_unavailable());
         assert_eq!(events.len(), 2);
         assert!(matches!(
             result.availability(),
-            Availability::Unavailable {
+            Availability::ServiceError {
                 prev_failures: 3,
                 ..
             }
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn update_on_next_retry_ready_succeeds() {
         let service = SubstituterLifecycleService::new();
-        let sub = make_substituter(Availability::Unavailable {
+        let sub = make_substituter(Availability::ServiceError {
             detected_at: Instant::now(),
             prev_failures: 0,
         });

--- a/src/domain/substituter/service/lifecycle.rs
+++ b/src/domain/substituter/service/lifecycle.rs
@@ -23,6 +23,23 @@ impl SubstituterLifecycleService {
         (substituter.on_detected_normal(), Vec::new())
     }
 
+    pub fn update_on_service_offline(
+        &self,
+        substituter: Substituter,
+        now: Instant,
+    ) -> (Substituter, Vec<SubstituterLifecycleEvent>) {
+        if substituter.is_unavailable() {
+            (substituter, Vec::new())
+        } else {
+            let (retry_instant, substituter) = substituter.on_detected_offline(now);
+            let events = vec![
+                SubstituterLifecycleEvent::NotifyUnavailable,
+                SubstituterLifecycleEvent::ScheduleRetryReady(retry_instant),
+            ];
+            (substituter, events)
+        }
+    }
+
     pub fn update_on_service_error(
         &self,
         substituter: Substituter,

--- a/src/infrastructure/provider/nar_info_provider.rs
+++ b/src/infrastructure/provider/nar_info_provider.rs
@@ -46,7 +46,7 @@ impl NarInfoProvider for ReqwestNarInfoProvider {
         let response = match request.send().await {
             Ok(response) => response,
             Err(err) => {
-                tracing::trace!(%url, "failed to send nar info query request");
+                tracing::trace!(%url, is_timeout = %err.is_timeout(), "failed to send nar info query request");
                 if err.is_timeout() || err.is_connect() || err.is_request() {
                     return Err(AnyhowError::new(err)).context(OfflineSnafu);
                 } else {

--- a/tests/integration/nar_resolution_service_test.rs
+++ b/tests/integration/nar_resolution_service_test.rs
@@ -124,8 +124,8 @@ async fn all_subs_fail() {
         TestCaseExpectation {
             source_url: Err(ResolveNarInfoError::Fetch),
             events: vec![
-                NarResolutionEvent::SubstituterFailed(sub_a_url),
-                NarResolutionEvent::SubstituterFailed(sub_b_url),
+                NarResolutionEvent::SubstituterError(sub_a_url),
+                NarResolutionEvent::SubstituterError(sub_b_url),
             ],
         },
     )
@@ -250,7 +250,7 @@ async fn partial_error_with_success() {
         TestCaseInput { hash },
         TestCaseExpectation {
             source_url: Ok(Some(nar::make_source_url(&success_sub_url, 10))),
-            events: vec![NarResolutionEvent::SubstituterFailed(error_sub_url)],
+            events: vec![NarResolutionEvent::SubstituterError(error_sub_url)],
         },
     )
     .await;
@@ -284,8 +284,8 @@ async fn all_subs_service_fail_with_ignore_error() {
         TestCaseExpectation {
             source_url: Ok(None),
             events: vec![
-                NarResolutionEvent::SubstituterFailed(sub_a_url),
-                NarResolutionEvent::SubstituterFailed(sub_b_url),
+                NarResolutionEvent::SubstituterError(sub_a_url),
+                NarResolutionEvent::SubstituterError(sub_b_url),
             ],
         },
     )
@@ -328,8 +328,8 @@ async fn all_subs_offline_treated_as_not_found() {
         TestCaseExpectation {
             source_url: Ok(None),
             events: vec![
-                NarResolutionEvent::SubstituterFailed(sub_a_url),
-                NarResolutionEvent::SubstituterFailed(sub_b_url),
+                NarResolutionEvent::SubstituterOffline(sub_a_url),
+                NarResolutionEvent::SubstituterOffline(sub_b_url),
             ],
         },
     )


### PR DESCRIPTION
Propagate the offline/service error distinction (from #12) through to the substituter lifecycle. Offline substituters use a fixed 30s retry period, while service errors continue using exponential backoff.