### PR TITLE
Add oslog support and adjust service settings for Darwin platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-oslog",
  "tracing-subscriber",
  "url",
 ]
@@ -2016,6 +2017,18 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-oslog"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ snafu = "0.9.0"
 tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "signal", "sync", "time", "test-util"] }
 toml = "1.1.2"
 tracing = "0.1.44"
+tracing-oslog = "0.3.0"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = { version = "2.5.8", features = ["serde"] }
 
@@ -40,6 +41,7 @@ snafu = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+tracing-oslog = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -20,12 +20,13 @@ in
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
       launchd.daemons.selector4nix = {
-        command = "${cfg.package}/bin/selector4nix";
+        command = "${cfg.package}/bin/selector4nix --no-log-timestamp";
         environment = {
           SELECTOR4NIX_CONFIG_FILE = "${configFile}";
           RUST_LOG = "selector4nix=${cfg.logLevel}";
         };
         serviceConfig = {
+          Label = "cc.starryreverie.selector4nix";
           KeepAlive = true;
           RunAtLoad = true;
           ProcessType = "Background";

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -49,7 +49,8 @@ in
           launchd.agents.selector4nix = {
             enable = true;
             config = {
-              ProgramArguments = [ "${cfg.package}/bin/selector4nix" ];
+              Label = "cc.starryreverie.selector4nix";
+              ProgramArguments = [ "${cfg.package}/bin/selector4nix --no-log-timestamp" ];
               EnvironmentVariables = {
                 SELECTOR4NIX_CONFIG_FILE = "${configFile}";
                 RUST_LOG = "selector4nix=${cfg.logLevel}";

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -3,12 +3,6 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result as AnyhowResult};
 use reqwest::Client;
-use selector4nix_actor::registry::{
-    AsyncFactory, CapacityOption, ExpirationOption, RegistryBuilder,
-};
-use tokio::sync::Semaphore;
-use tracing_subscriber::EnvFilter;
-
 use selector4nix::api::AppContext;
 use selector4nix::application::nar::actor::NarActor;
 use selector4nix::application::nar::usecase::{NarResolutionUseCase, NarStreamingUseCase};
@@ -21,24 +15,47 @@ use selector4nix::domain::substituter::service::SubstituterLifecycleService;
 use selector4nix::infrastructure::config::AppConfiguration;
 use selector4nix::infrastructure::index::*;
 use selector4nix::infrastructure::provider::*;
+use selector4nix_actor::registry::{
+    AsyncFactory, CapacityOption, ExpirationOption, RegistryBuilder,
+};
+use tokio::sync::Semaphore;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer, Registry};
 
 use crate::cli::LogLevel;
 
 pub fn init_logger(log_level: Option<LogLevel>, no_timestamp: bool) {
-    let logger = tracing_subscriber::fmt();
+    let registry = tracing_subscriber::registry();
 
     let filter = if let Some(level) = log_level {
         EnvFilter::new(level.to_string())
     } else {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
     };
-    let logger = logger.with_env_filter(filter);
 
-    if no_timestamp {
-        logger.without_time().init();
-    } else {
-        logger.init();
-    }
+    let registry = {
+        let fmt_layer: Box<dyn Layer<Registry> + Send + Sync> = if no_timestamp {
+            let layer = tracing_subscriber::fmt::layer()
+                .without_time()
+                .with_filter(filter.clone());
+            Box::new(layer)
+        } else {
+            let layer = tracing_subscriber::fmt::layer().with_filter(filter.clone());
+            Box::new(layer)
+        };
+        registry.with(fmt_layer)
+    };
+
+    #[cfg(all(target_vendor = "apple", not(debug_assertions)))]
+    let registry = {
+        use tracing_oslog::OsLogger;
+        let oslog_layer =
+            OsLogger::new("cc.starryreverie.selector4nix", "default").with_filter(filter);
+        registry.with(oslog_layer)
+    };
+
+    registry.init();
 }
 
 pub fn init_context(config: &AppConfiguration) -> AnyhowResult<Arc<AppContext>> {


### PR DESCRIPTION
Integrate Darwin oslog API so that `selector4nix` logs are accessible when running as a launchd service. Development builds are unaffected.