### PR TITLE
Add active substituter health probing before restoring availability

### DIFF
--- a/src/application/substituter/actor/runner.rs
+++ b/src/application/substituter/actor/runner.rs
@@ -6,6 +6,7 @@ use tokio::time::Instant;
 
 use crate::domain::substituter::index::SubstituterAvailabilityEvent;
 use crate::domain::substituter::model::Substituter;
+use crate::domain::substituter::port::{ProbeSubstituterError, SubstituterProbingProvider};
 use crate::domain::substituter::service::{SubstituterLifecycleEvent, SubstituterLifecycleService};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -17,12 +18,14 @@ pub enum SubstituterRequest {
 
 pub enum SubstituterInternal {
     NextRetryReady,
+    ProbingFinished(Result<(), ProbeSubstituterError>),
 }
 
 pub struct SubstituterActor {
     init: Option<Substituter>,
     context: Context<SubstituterRequest, SubstituterInternal>,
     lifecycle_service: Arc<SubstituterLifecycleService>,
+    substituter_probing_provider: Arc<dyn SubstituterProbingProvider>,
     availability_index_pub: AnyAddress<SubstituterAvailabilityEvent>,
 }
 
@@ -30,12 +33,14 @@ impl SubstituterActor {
     pub fn new(
         init: Option<Substituter>,
         lifecycle_service: Arc<SubstituterLifecycleService>,
+        substituter_probing_provider: Arc<dyn SubstituterProbingProvider>,
         availability_index_pub: AnyAddress<SubstituterAvailabilityEvent>,
     ) -> ActorPre<Self> {
         ActorPreBuilder::inject(|context| Self {
             init,
             context,
             lifecycle_service,
+            substituter_probing_provider,
             availability_index_pub,
         })
     }
@@ -58,6 +63,17 @@ impl SubstituterActor {
                     SubstituterInternal::NextRetryReady
                 });
             }
+            SubstituterLifecycleEvent::ScheduleProbing(instant) => {
+                let substituter = substituter.target().clone();
+                let provider = Arc::clone(&self.substituter_probing_provider);
+                self.dispatch_internal(Duration::ZERO, async move {
+                    if let Some(instant) = instant {
+                        tokio::time::sleep_until(instant).await;
+                    }
+                    let res = provider.probe_substituter(&substituter).await;
+                    SubstituterInternal::ProbingFinished(res)
+                });
+            }
             SubstituterLifecycleEvent::NotifyUnavailable => {
                 let url = substituter.url().clone();
                 let prev_failures = substituter.prev_failures();
@@ -67,8 +83,7 @@ impl SubstituterActor {
             }
             SubstituterLifecycleEvent::NotifyAvailable => {
                 let substituter = substituter.clone();
-                let prev_failures = substituter.prev_failures();
-                tracing::debug!(url = %substituter.target().url(), %prev_failures, "assume substituter became available after backoff expired");
+                tracing::debug!(url = %substituter.target().url(), "assume substituter became available after probing");
                 let event = SubstituterAvailabilityEvent::BecameAvailable(substituter);
                 let _ = self.availability_index_pub.tell(event).await;
             }
@@ -127,6 +142,14 @@ impl Actor for SubstituterActor {
             SubstituterInternal::NextRetryReady => {
                 let (substituter, events) =
                     self.lifecycle_service.update_on_next_retry_ready(state);
+                self.exec_all_events(&substituter, events).await;
+                Some(substituter)
+            }
+            SubstituterInternal::ProbingFinished(res) => {
+                let now = Instant::now();
+                let (substituter, events) = self
+                    .lifecycle_service
+                    .update_on_probing_finished(state, res, now);
                 self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -101,6 +101,12 @@ pub fn init_context(config: &AppConfiguration) -> AnyhowResult<Arc<AppContext>> 
 
     let concurrency = Arc::new(Semaphore::new(config.network.max_concurrent_requests));
 
+    let substituter_probing_provider = Arc::new(ReqwestSubstituterProbingProvider::new(
+        http_client.clone(),
+        config.network.nar_info_timeout,
+        concurrency.clone(),
+    ));
+
     let nar_info_provider = Arc::new(ReqwestNarInfoProvider::new(
         http_client.clone(),
         config.network.nar_info_timeout,
@@ -159,8 +165,14 @@ pub fn init_context(config: &AppConfiguration) -> AnyhowResult<Arc<AppContext>> 
                     let substituter = sub_map.get(url).cloned();
                     let avail_pub = avail_pub.clone();
                     let lifecycle_service = lifecycle_service.clone();
-                    let addr =
-                        SubstituterActor::new(substituter, lifecycle_service, avail_pub).run();
+                    let sub_probing_provider = substituter_probing_provider.clone();
+                    let addr = SubstituterActor::new(
+                        substituter,
+                        lifecycle_service,
+                        sub_probing_provider,
+                        avail_pub,
+                    )
+                    .run();
                     async move { addr }
                 }
             }))

--- a/src/domain/substituter/mod.rs
+++ b/src/domain/substituter/mod.rs
@@ -1,3 +1,4 @@
 pub mod index;
 pub mod model;
+pub mod port;
 pub mod service;

--- a/src/domain/substituter/model/availability.rs
+++ b/src/domain/substituter/model/availability.rs
@@ -19,9 +19,13 @@ pub enum Availability {
 
 impl Availability {
     pub const OFFLINE_RETRY_PERIOD: Duration = Duration::from_secs(30);
+    pub const REPROBING_PERIOD: Duration = Duration::from_secs(30);
 
-    pub fn normal() -> Self {
-        Self::Normal
+    pub fn change_to_normal(self) -> Self {
+        match self {
+            Self::MaybeReady { .. } => Self::Normal,
+            otherwise => otherwise,
+        }
     }
 
     pub fn change_to_offline(self, now: Instant) -> Self {

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -63,7 +63,7 @@ impl Substituter {
     }
 
     pub fn on_detected_normal(mut self) -> Self {
-        self.availability = Availability::Normal;
+        self.availability = self.availability.change_to_normal();
         self
     }
 }
@@ -108,12 +108,12 @@ mod tests {
     }
 
     #[test]
-    fn on_detected_normal_resets_availability() {
+    fn on_detected_normal_doesnt_reset_availability_given_still_unavailable() {
         let sub = make_substituter();
         let (_, sub) = sub.on_detected_service_error(Instant::now());
         assert!(sub.is_unavailable());
 
         let sub = sub.on_detected_normal();
-        assert!(!sub.is_unavailable());
+        assert!(sub.is_unavailable());
     }
 }

--- a/src/domain/substituter/port/mod.rs
+++ b/src/domain/substituter/port/mod.rs
@@ -1,0 +1,5 @@
+mod substituter_probing_provider;
+
+pub use substituter_probing_provider::{
+    ProbeSubstituterError, SubstituterProbingProvider, error_ctx,
+};

--- a/src/domain/substituter/port/substituter_probing_provider.rs
+++ b/src/domain/substituter/port/substituter_probing_provider.rs
@@ -1,0 +1,27 @@
+use anyhow::Error as AnyhowError;
+use async_trait::async_trait;
+use snafu::Snafu;
+
+use crate::domain::substituter::model::SubstituterMeta;
+
+#[async_trait]
+pub trait SubstituterProbingProvider: Send + Sync {
+    async fn probe_substituter(
+        &self,
+        substituter: &SubstituterMeta,
+    ) -> Result<(), ProbeSubstituterError>;
+}
+
+#[derive(Snafu, Debug)]
+#[non_exhaustive]
+#[snafu(visibility(pub))]
+pub enum ProbeSubstituterError {
+    #[snafu(display("could not probe offline substituter"))]
+    Offline { source: AnyhowError },
+    #[snafu(display("probing got service error from substituter"))]
+    Service { source: AnyhowError },
+}
+
+pub mod error_ctx {
+    pub use super::{OfflineSnafu, ServiceSnafu};
+}

--- a/src/domain/substituter/service/lifecycle.rs
+++ b/src/domain/substituter/service/lifecycle.rs
@@ -1,10 +1,12 @@
 use tokio::time::Instant;
 
 use crate::domain::substituter::model::Substituter;
+use crate::domain::substituter::port::ProbeSubstituterError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SubstituterLifecycleEvent {
     ScheduleRetryReady(Instant),
+    ScheduleProbing(Option<Instant>),
     NotifyUnavailable,
     NotifyAvailable,
 }
@@ -61,8 +63,33 @@ impl SubstituterLifecycleService {
         &self,
         substituter: Substituter,
     ) -> (Substituter, Vec<SubstituterLifecycleEvent>) {
-        let events = vec![SubstituterLifecycleEvent::NotifyAvailable];
+        let events = vec![SubstituterLifecycleEvent::ScheduleProbing(None)];
         (substituter.on_next_retry_ready(), events)
+    }
+
+    pub fn update_on_probing_finished(
+        &self,
+        substituter: Substituter,
+        result: Result<(), ProbeSubstituterError>,
+        now: Instant,
+    ) -> (Substituter, Vec<SubstituterLifecycleEvent>) {
+        match result {
+            Ok(()) => {
+                let substituter = substituter.on_detected_normal();
+                let events = if substituter.is_normal() {
+                    vec![SubstituterLifecycleEvent::NotifyAvailable]
+                } else {
+                    Vec::new()
+                };
+                (substituter, events)
+            }
+            Err(ProbeSubstituterError::Offline { .. }) => {
+                self.update_on_service_offline(substituter, now)
+            }
+            Err(ProbeSubstituterError::Service { .. }) => {
+                self.update_on_service_error(substituter, now)
+            }
+        }
     }
 }
 
@@ -143,7 +170,69 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(matches!(
             events[0],
-            SubstituterLifecycleEvent::NotifyAvailable
+            SubstituterLifecycleEvent::ScheduleProbing(None),
+        ));
+    }
+
+    #[test]
+    fn update_on_probing_finished_succeeds_given_ok() {
+        let service = SubstituterLifecycleService::new();
+        let sub = make_substituter(Availability::MaybeReady { prev_failures: 0 });
+        let now = Instant::now();
+
+        let (result, events) = service.update_on_probing_finished(sub, Ok(()), now);
+
+        assert!(result.is_normal());
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            SubstituterLifecycleEvent::NotifyAvailable,
+        ));
+    }
+
+    #[test]
+    fn update_on_probing_finished_emits_unavailable_given_offline() {
+        let service = SubstituterLifecycleService::new();
+        let sub = make_substituter(Availability::MaybeReady { prev_failures: 0 });
+        let now = Instant::now();
+        let err = ProbeSubstituterError::Offline {
+            source: anyhow::anyhow!("test"),
+        };
+
+        let (result, events) = service.update_on_probing_finished(sub, Err(err), now);
+
+        assert!(result.is_unavailable());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            SubstituterLifecycleEvent::NotifyUnavailable,
+        ));
+        assert!(matches!(
+            events[1],
+            SubstituterLifecycleEvent::ScheduleRetryReady(_),
+        ));
+    }
+
+    #[test]
+    fn update_on_probing_finished_emits_unavailable_given_service_error() {
+        let service = SubstituterLifecycleService::new();
+        let sub = make_substituter(Availability::MaybeReady { prev_failures: 2 });
+        let now = Instant::now();
+        let err = ProbeSubstituterError::Service {
+            source: anyhow::anyhow!("test"),
+        };
+
+        let (result, events) = service.update_on_probing_finished(sub, Err(err), now);
+
+        assert!(result.is_unavailable());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            SubstituterLifecycleEvent::NotifyUnavailable,
+        ));
+        assert!(matches!(
+            events[1],
+            SubstituterLifecycleEvent::ScheduleRetryReady(_),
         ));
     }
 }

--- a/src/infrastructure/provider/mod.rs
+++ b/src/infrastructure/provider/mod.rs
@@ -1,5 +1,7 @@
 mod nar_info_provider;
 mod nar_stream_provider;
+mod substituter_probing_provider;
 
 pub use nar_info_provider::ReqwestNarInfoProvider;
 pub use nar_stream_provider::ReqwestNarStreamProvider;
+pub use substituter_probing_provider::ReqwestSubstituterProbingProvider;

--- a/src/infrastructure/provider/nar_info_provider.rs
+++ b/src/infrastructure/provider/nar_info_provider.rs
@@ -46,7 +46,7 @@ impl NarInfoProvider for ReqwestNarInfoProvider {
         let response = match request.send().await {
             Ok(response) => response,
             Err(err) => {
-                tracing::trace!(%url, is_timeout = %err.is_timeout(), "failed to send nar info query request");
+                tracing::debug!(%url, is_timeout = %err.is_timeout(), "failed to send nar info query request");
                 if err.is_timeout() || err.is_connect() || err.is_request() {
                     return Err(AnyhowError::new(err)).context(OfflineSnafu);
                 } else {

--- a/src/infrastructure/provider/substituter_probing_provider.rs
+++ b/src/infrastructure/provider/substituter_probing_provider.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Error as AnyhowError;
+use async_trait::async_trait;
+use reqwest::{Client, StatusCode};
+use snafu::ResultExt;
+use tokio::sync::Semaphore;
+
+use crate::domain::substituter::model::SubstituterMeta;
+use crate::domain::substituter::port::error_ctx::{OfflineSnafu, ServiceSnafu};
+use crate::domain::substituter::port::{ProbeSubstituterError, SubstituterProbingProvider};
+
+pub struct ReqwestSubstituterProbingProvider {
+    client: Client,
+    default_timeout: Duration,
+    concurrency: Arc<Semaphore>,
+}
+
+impl ReqwestSubstituterProbingProvider {
+    pub fn new(client: Client, default_timeout: Duration, concurrency: Arc<Semaphore>) -> Self {
+        Self {
+            client,
+            default_timeout,
+            concurrency,
+        }
+    }
+}
+
+#[async_trait]
+impl SubstituterProbingProvider for ReqwestSubstituterProbingProvider {
+    async fn probe_substituter(
+        &self,
+        substituter: &SubstituterMeta,
+    ) -> Result<(), ProbeSubstituterError> {
+        tracing::debug!(substituter = %substituter.url(), "probing substituter's health status");
+
+        let _permit = self.concurrency.acquire().await.unwrap();
+
+        let url = substituter.url().as_dir().join("nix-cache-info").unwrap();
+        let timeout = substituter
+            .nar_info_timeout()
+            .unwrap_or(self.default_timeout);
+        let request = self.client.get(url.value()).timeout(timeout);
+
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(err) => {
+                tracing::debug!(%url, is_timeout = %err.is_timeout(), "failed to send probing request");
+                if err.is_timeout() || err.is_connect() || err.is_request() {
+                    return Err(AnyhowError::new(err)).context(OfflineSnafu);
+                } else {
+                    return Err(AnyhowError::new(err)).context(ServiceSnafu);
+                }
+            }
+        };
+
+        match response.status() {
+            StatusCode::OK => {
+                let _ = (response.text().await)
+                    .map_err(|err| AnyhowError::new(err))
+                    .map_err(|err| err.context(format!("failed to read nix-cache-info from {url}")))
+                    .context(ServiceSnafu)
+                    .inspect_err(|_| tracing::debug!(%url, "failed to read nix-cache-info"))?;
+                tracing::debug!(%url, "probed substituter successfully");
+                Ok(())
+            }
+            status => Err(anyhow::anyhow!("unexpected status {} from {}", status, url))
+                .context(ServiceSnafu)
+                .inspect_err(
+                    |_| tracing::debug!(%url, "encountered bad nix-cache-info response status"),
+                ),
+        }
+    }
+}


### PR DESCRIPTION
When a substituter's retry backoff expires, instead of blindly marking it as available again, proactively probe its /nix-cache-info endpoint. Only restore the substituter to the available pool when the probe succeeds; otherwise, re-enter the unavailable state with an updated retry schedule.