### PR TITLE
Add periodically substituter probing for early failure detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Nix substituter proxy with parallel cache queries and latency-aware selection.
 - Queries all configured substituters in parallel for `.narinfo` lookups
 - Selects the fastest responding substituter based on latency and priority
 - Automatically detects and skips unavailable substituters, retrying them with exponential backoff
+- Continuously probes substituters to detect failures early and verify recovery
 
 Note that `selector4nix` only intends to work as a proxy rather than a full-featured cache substituter. NAR files are streamed directly from the best substituter without being cached locally. However, it does cache `.narinfo` files for better responsiveness.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,13 @@ When enabled, NAR info lookup errors from substituters are treated as not-found 
 
 > **Warning:** This may cause incorrect judgments about whether a NAR info actually exists. A substituter returning an error will be interpreted as "not found", which may not be the case.
 
+### `network.periodic_probing`
+
+- Type: Boolean
+- Default: `true`
+
+When enabled, `selector4nix` continuously probes substituters every 30 seconds to detect failures early. Probing during retry recovery always occurs regardless of this setting.
+
 ## `proxy`
 
 Proxy behavior settings.

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -22,6 +22,9 @@ tolerance_msecs = 50
 # Treat NAR info lookup errors as not-found (default: false).
 # WARNING: setting this to true may cause incorrect judgments about whether a NAR info actually exists.
 ignore_nar_info_error = false
+# Whether to continuously probe substituters for health every 30 seconds (default: true).
+# Probing during retry recovery is always enabled regardless of this setting.
+periodic_probing = true
 
 # Proxy behavior settings.
 [proxy]

--- a/src/application/substituter/actor/runner.rs
+++ b/src/application/substituter/actor/runner.rs
@@ -83,7 +83,7 @@ impl SubstituterActor {
             }
             SubstituterLifecycleEvent::NotifyAvailable => {
                 let substituter = substituter.clone();
-                tracing::debug!(url = %substituter.target().url(), "assume substituter became available after probing");
+                tracing::debug!(url = %substituter.target().url(), "substituter became or stayed available after probing");
                 let event = SubstituterAvailabilityEvent::BecameAvailable(substituter);
                 let _ = self.availability_index_pub.tell(event).await;
             }
@@ -101,7 +101,15 @@ impl Actor for SubstituterActor {
     }
 
     async fn on_start(&mut self) -> Option<Self::State> {
-        self.init.take()
+        match self.init.take() {
+            Some(init) => {
+                let now = Instant::now();
+                let events = self.lifecycle_service.on_initial(now);
+                self.exec_all_events(&init, events).await;
+                Some(init)
+            }
+            None => None,
+        }
     }
 
     async fn on_request(

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -142,7 +142,9 @@ pub async fn init_context(config: &AppConfiguration) -> AnyhowResult<Arc<AppCont
     nar_file_index_pre.run();
     let nar_file_index = Arc::new(nar_file_index_view);
 
-    let substituter_lifecycle_service = Arc::new(SubstituterLifecycleService::new());
+    let substituter_lifecycle_service = Arc::new(SubstituterLifecycleService::new(
+        config.network.periodic_probing,
+    ));
 
     let nar_info_query_service = Arc::new(NarResolutionService::new(
         nar_info_provider,

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -17,6 +16,7 @@ use selector4nix::domain::substituter::service::SubstituterLifecycleService;
 use selector4nix::infrastructure::config::AppConfiguration;
 use selector4nix::infrastructure::index::*;
 use selector4nix::infrastructure::provider::*;
+use selector4nix_actor::actor::Address;
 use selector4nix_actor::registry::{
     AsyncFactory, CapacityOption, ExpirationOption, RegistryBuilder,
 };
@@ -88,7 +88,7 @@ pub fn init_logger(
     Ok(())
 }
 
-pub fn init_context(config: &AppConfiguration) -> AnyhowResult<Arc<AppContext>> {
+pub async fn init_context(config: &AppConfiguration) -> AnyhowResult<Arc<AppContext>> {
     let http_client = Client::builder()
         .user_agent(format!(
             "curl/8.7.1 Nix/2.24.11 {}/{}",
@@ -152,32 +152,28 @@ pub fn init_context(config: &AppConfiguration) -> AnyhowResult<Arc<AppContext>> 
         config.network.ignore_nar_info_error,
     ));
 
-    let substituter_registry = Arc::new(
-        RegistryBuilder::new()
-            .factory(AsyncFactory::new({
-                let sub_map = substituters
-                    .iter()
-                    .map(|s| (s.url().clone(), s.clone()))
-                    .collect::<HashMap<_, _>>();
-                let avail_pub = substituter_availability_pub.clone();
-                let lifecycle_service = substituter_lifecycle_service.clone();
-                move |url| {
-                    let substituter = sub_map.get(url).cloned();
-                    let avail_pub = avail_pub.clone();
-                    let lifecycle_service = lifecycle_service.clone();
-                    let sub_probing_provider = substituter_probing_provider.clone();
-                    let addr = SubstituterActor::new(
-                        substituter,
-                        lifecycle_service,
-                        sub_probing_provider,
-                        avail_pub,
-                    )
-                    .run();
-                    async move { addr }
-                }
+    let substituter_registry = Arc::new({
+        let registry = RegistryBuilder::new()
+            .factory(AsyncFactory::new(|_| async {
+                // No additional actor will be loaded here as those actors are created eagerly
+                Address::mock().0
             }))
-            .build(),
-    );
+            .build();
+        for sub in &substituters {
+            let avail_pub = substituter_availability_pub.clone();
+            let lifecycle_service = substituter_lifecycle_service.clone();
+            let sub_probing_provider = substituter_probing_provider.clone();
+            let addr = SubstituterActor::new(
+                Some(sub.clone()),
+                lifecycle_service,
+                sub_probing_provider,
+                avail_pub,
+            )
+            .run();
+            registry.insert(sub.url().clone(), addr).await;
+        }
+        registry
+    });
 
     let nar_registry = Arc::new(
         RegistryBuilder::new()

--- a/src/domain/substituter/service/lifecycle.rs
+++ b/src/domain/substituter/service/lifecycle.rs
@@ -1,6 +1,8 @@
+use std::time::Duration;
+
 use tokio::time::Instant;
 
-use crate::domain::substituter::model::Substituter;
+use crate::domain::substituter::model::{Availability, Substituter};
 use crate::domain::substituter::port::ProbeSubstituterError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -16,6 +18,13 @@ pub struct SubstituterLifecycleService;
 impl SubstituterLifecycleService {
     pub fn new() -> Self {
         Self
+    }
+
+    pub fn on_initial(&self, now: Instant) -> Vec<SubstituterLifecycleEvent> {
+        const INITIAL_PROBING_DELAY: Duration = Duration::from_secs(5);
+        vec![SubstituterLifecycleEvent::ScheduleProbing(Some(
+            now + INITIAL_PROBING_DELAY,
+        ))]
     }
 
     pub fn update_on_service_successful(
@@ -77,7 +86,12 @@ impl SubstituterLifecycleService {
             Ok(()) => {
                 let substituter = substituter.on_detected_normal();
                 let events = if substituter.is_normal() {
-                    vec![SubstituterLifecycleEvent::NotifyAvailable]
+                    vec![
+                        SubstituterLifecycleEvent::NotifyAvailable,
+                        SubstituterLifecycleEvent::ScheduleProbing(Some(
+                            now + Availability::REPROBING_PERIOD,
+                        )),
+                    ]
                 } else {
                     Vec::new()
                 };
@@ -183,10 +197,34 @@ mod tests {
         let (result, events) = service.update_on_probing_finished(sub, Ok(()), now);
 
         assert!(result.is_normal());
-        assert_eq!(events.len(), 1);
+        assert_eq!(events.len(), 2);
         assert!(matches!(
             events[0],
             SubstituterLifecycleEvent::NotifyAvailable,
+        ));
+        assert!(matches!(
+            events[1],
+            SubstituterLifecycleEvent::ScheduleProbing(Some(_)),
+        ));
+    }
+
+    #[test]
+    fn update_on_probing_finished_schedules_reprobing_given_ok_and_already_normal() {
+        let service = SubstituterLifecycleService::new();
+        let sub = make_substituter(Availability::Normal);
+        let now = Instant::now();
+
+        let (result, events) = service.update_on_probing_finished(sub, Ok(()), now);
+
+        assert!(result.is_normal());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            SubstituterLifecycleEvent::NotifyAvailable,
+        ));
+        assert!(matches!(
+            events[1],
+            SubstituterLifecycleEvent::ScheduleProbing(Some(_)),
         ));
     }
 

--- a/src/domain/substituter/service/lifecycle.rs
+++ b/src/domain/substituter/service/lifecycle.rs
@@ -13,18 +13,24 @@ pub enum SubstituterLifecycleEvent {
     NotifyAvailable,
 }
 
-pub struct SubstituterLifecycleService;
+pub struct SubstituterLifecycleService {
+    periodic_probing: bool,
+}
 
 impl SubstituterLifecycleService {
-    pub fn new() -> Self {
-        Self
+    pub fn new(periodic_probing: bool) -> Self {
+        Self { periodic_probing }
     }
 
     pub fn on_initial(&self, now: Instant) -> Vec<SubstituterLifecycleEvent> {
         const INITIAL_PROBING_DELAY: Duration = Duration::from_secs(5);
-        vec![SubstituterLifecycleEvent::ScheduleProbing(Some(
-            now + INITIAL_PROBING_DELAY,
-        ))]
+        if self.periodic_probing {
+            vec![SubstituterLifecycleEvent::ScheduleProbing(Some(
+                now + INITIAL_PROBING_DELAY,
+            ))]
+        } else {
+            Vec::new()
+        }
     }
 
     pub fn update_on_service_successful(
@@ -85,15 +91,15 @@ impl SubstituterLifecycleService {
         match result {
             Ok(()) => {
                 let substituter = substituter.on_detected_normal();
-                let events = if substituter.is_normal() {
-                    vec![
+                let events = match (substituter.is_normal(), self.periodic_probing) {
+                    (true, true) => vec![
                         SubstituterLifecycleEvent::NotifyAvailable,
                         SubstituterLifecycleEvent::ScheduleProbing(Some(
                             now + Availability::REPROBING_PERIOD,
                         )),
-                    ]
-                } else {
-                    Vec::new()
+                    ],
+                    (true, false) => vec![SubstituterLifecycleEvent::NotifyAvailable],
+                    (false, _) => Vec::new(),
                 };
                 (substituter, events)
             }
@@ -124,7 +130,7 @@ mod tests {
 
     #[test]
     fn update_on_service_successful_succeeds() {
-        let service = SubstituterLifecycleService::new();
+        let service = SubstituterLifecycleService::new(true);
         let sub = make_substituter(Availability::MaybeReady { prev_failures: 0 });
         let (result, events) = service.update_on_service_successful(sub);
         assert!(!result.is_unavailable());
@@ -133,7 +139,7 @@ mod tests {
 
     #[test]
     fn update_on_service_failed_succeeds() {
-        let service = SubstituterLifecycleService::new();
+        let service = SubstituterLifecycleService::new(true);
         let sub = make_substituter(Availability::Normal);
         let now = Instant::now();
 
@@ -153,7 +159,7 @@ mod tests {
 
     #[test]
     fn update_on_service_failed_increments_backoff_given_repeated() {
-        let service = SubstituterLifecycleService::new();
+        let service = SubstituterLifecycleService::new(true);
         let sub = make_substituter(Availability::MaybeReady { prev_failures: 2 });
         let now = Instant::now();
 
@@ -172,7 +178,7 @@ mod tests {
 
     #[test]
     fn update_on_next_retry_ready_succeeds() {
-        let service = SubstituterLifecycleService::new();
+        let service = SubstituterLifecycleService::new(true);
         let sub = make_substituter(Availability::ServiceError {
             detected_at: Instant::now(),
             prev_failures: 0,
@@ -190,7 +196,7 @@ mod tests {
 
     #[test]
     fn update_on_probing_finished_succeeds_given_ok() {
-        let service = SubstituterLifecycleService::new();
+        let service = SubstituterLifecycleService::new(true);
         let sub = make_substituter(Availability::MaybeReady { prev_failures: 0 });
         let now = Instant::now();
 
@@ -210,7 +216,7 @@ mod tests {
 
     #[test]
     fn update_on_probing_finished_schedules_reprobing_given_ok_and_already_normal() {
-        let service = SubstituterLifecycleService::new();
+        let service = SubstituterLifecycleService::new(true);
         let sub = make_substituter(Availability::Normal);
         let now = Instant::now();
 
@@ -230,7 +236,7 @@ mod tests {
 
     #[test]
     fn update_on_probing_finished_emits_unavailable_given_offline() {
-        let service = SubstituterLifecycleService::new();
+        let service = SubstituterLifecycleService::new(true);
         let sub = make_substituter(Availability::MaybeReady { prev_failures: 0 });
         let now = Instant::now();
         let err = ProbeSubstituterError::Offline {
@@ -253,7 +259,7 @@ mod tests {
 
     #[test]
     fn update_on_probing_finished_emits_unavailable_given_service_error() {
-        let service = SubstituterLifecycleService::new();
+        let service = SubstituterLifecycleService::new(true);
         let sub = make_substituter(Availability::MaybeReady { prev_failures: 2 });
         let now = Instant::now();
         let err = ProbeSubstituterError::Service {

--- a/src/infrastructure/config/parsed.rs
+++ b/src/infrastructure/config/parsed.rs
@@ -103,6 +103,7 @@ pub struct NetworkConfiguration {
     pub max_concurrent_requests: usize,
     pub tolerance: u64,
     pub ignore_nar_info_error: bool,
+    pub periodic_probing: bool,
 }
 
 impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
@@ -119,6 +120,7 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
             max_concurrent_requests: raw.max_concurrent_requests.unwrap_or(24),
             tolerance: raw.tolerance_msecs.unwrap_or(50).max(1),
             ignore_nar_info_error: raw.ignore_nar_info_error.unwrap_or(false),
+            periodic_probing: raw.periodic_probing.unwrap_or(true),
         })
     }
 }

--- a/src/infrastructure/config/raw.rs
+++ b/src/infrastructure/config/raw.rs
@@ -32,6 +32,7 @@ pub struct NetworkRawConfiguration {
     pub max_concurrent_requests: Option<usize>,
     pub tolerance_msecs: Option<u64>,
     pub ignore_nar_info_error: Option<bool>,
+    pub periodic_probing: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> AnyhowResult<()> {
 
     match cli.command.unwrap_or(Commands::Serve) {
         Commands::Serve => {
-            let context = bootstrap::init_context(&config)?;
+            let context = bootstrap::init_context(&config).await?;
             serve(config, context).await
         }
         Commands::Check => {

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -22,6 +22,7 @@ fn defaults_are_applied_when_sections_omitted() {
     assert_eq!(config.network.max_concurrent_requests, 24);
     assert_eq!(config.network.tolerance, 50);
     assert_eq!(config.network.ignore_nar_info_error, false);
+    assert_eq!(config.network.periodic_probing, true);
     assert_eq!(config.proxy.rewrite_nar_url, NarUrlRewriteOption::ToSelf);
     assert_eq!(config.cache_info.store_dir, "/nix/store");
     assert!(config.cache_info.want_mass_query);


### PR DESCRIPTION
Periodically probe substituters to detect failures early. This behavior is configurable via `network.periodic_probing`.