### PR TITLE
Fix query params dropping and failure of parsing non-compressed NAR URL

### DIFF
--- a/src/domain/nar_file/model/mod.rs
+++ b/src/domain/nar_file/model/mod.rs
@@ -1,5 +1,7 @@
 mod nar_file;
+mod nar_file_key;
 mod nar_file_location;
 
-pub use nar_file::{NarFile, NarFileKey};
+pub use nar_file::NarFile;
+pub use nar_file_key::NarFileKey;
 pub use nar_file_location::NarFileLocation;

--- a/src/domain/nar_file/model/nar_file.rs
+++ b/src/domain/nar_file/model/nar_file.rs
@@ -8,31 +8,42 @@ use super::NarFileLocation;
 #[getset(get = "pub")]
 pub struct NarFileKey {
     nar_hash: String,
-    compression: String,
+    compression: Option<String>,
 }
 
 impl NarFileKey {
-    pub fn new(nar_hash: String, compression: String) -> Self {
+    pub fn new(nar_hash: String) -> Self {
         Self {
             nar_hash,
-            compression,
+            compression: None,
         }
     }
 
-    pub fn from_file_name(file: &NarFileName) -> Self {
-        let (prefix, suffix) = file
+    pub fn with_compression<V>(mut self, compression: V) -> Self
+    where
+        V: Into<Option<String>>,
+    {
+        self.compression = compression.into().filter(|c| !c.is_empty());
+        self
+    }
+
+    pub fn from_file_name(nar_file: &NarFileName) -> Self {
+        let (file_hash, suffix) = nar_file
             .value()
-            .split_once(".nar.")
-            .expect("NarFileName construction guarantees `.nar.` is present");
-        Self {
-            nar_hash: prefix.to_string(),
-            compression: suffix.to_string(),
-        }
+            .split_once(".nar")
+            .expect("`nar_file` should contains `\".nar\"`");
+        let compression = suffix.trim_start_matches(".");
+        Self::new(file_hash.to_string()).with_compression(compression.to_string())
     }
 
     pub fn to_file_name(&self) -> NarFileName {
-        NarFileName::new(format!("{}.nar.{}", self.nar_hash, self.compression))
-            .expect("valid NarFileName from NarFileKey")
+        if let Some(compression) = &self.compression {
+            NarFileName::new(format!("{}.nar.{}", self.nar_hash, compression))
+                .expect("converting `NarFileKey` to `NarFileName` should always be valid")
+        } else {
+            NarFileName::new(format!("{}.nar", self.nar_hash))
+                .expect("converting `NarFileKey` to `NarFileName` should always be valid")
+        }
     }
 }
 

--- a/src/domain/nar_file/model/nar_file.rs
+++ b/src/domain/nar_file/model/nar_file.rs
@@ -1,51 +1,6 @@
 use getset::Getters;
 
-use crate::domain::nar_info::model::NarFileName;
-
-use super::NarFileLocation;
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters)]
-#[getset(get = "pub")]
-pub struct NarFileKey {
-    nar_hash: String,
-    compression: Option<String>,
-}
-
-impl NarFileKey {
-    pub fn new(nar_hash: String) -> Self {
-        Self {
-            nar_hash,
-            compression: None,
-        }
-    }
-
-    pub fn with_compression<V>(mut self, compression: V) -> Self
-    where
-        V: Into<Option<String>>,
-    {
-        self.compression = compression.into().filter(|c| !c.is_empty());
-        self
-    }
-
-    pub fn from_file_name(nar_file: &NarFileName) -> Self {
-        let (file_hash, suffix) = nar_file
-            .value()
-            .split_once(".nar")
-            .expect("`nar_file` should contains `\".nar\"`");
-        let compression = suffix.trim_start_matches(".");
-        Self::new(file_hash.to_string()).with_compression(compression.to_string())
-    }
-
-    pub fn to_file_name(&self) -> NarFileName {
-        if let Some(compression) = &self.compression {
-            NarFileName::new(format!("{}.nar.{}", self.nar_hash, compression))
-                .expect("converting `NarFileKey` to `NarFileName` should always be valid")
-        } else {
-            NarFileName::new(format!("{}.nar", self.nar_hash))
-                .expect("converting `NarFileKey` to `NarFileName` should always be valid")
-        }
-    }
-}
+use crate::domain::nar_file::model::{NarFileKey, NarFileLocation};
 
 #[derive(Debug, Clone, PartialEq, Eq, Getters)]
 #[getset(get = "pub")]

--- a/src/domain/nar_file/model/nar_file_key.rs
+++ b/src/domain/nar_file/model/nar_file_key.rs
@@ -3,8 +3,8 @@ use getset::Getters;
 use crate::domain::nar_info::model::NarFileName;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Getters)]
-#[getset(get = "pub")]
 pub struct NarFileKey {
+    #[getset(get = "pub")]
     file_hash: String,
     compression: Option<String>,
 }
@@ -42,5 +42,39 @@ impl NarFileKey {
             NarFileName::new(format!("{}.nar", self.file_hash))
                 .expect("converting `NarFileKey` to `NarFileName` should always be valid")
         }
+    }
+
+    pub fn compression(&self) -> Option<&str> {
+        self.compression.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_succeeds_given_compression() {
+        let name =
+            NarFileName::new("1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz".into())
+                .unwrap();
+        let key = NarFileKey::from_file_name(&name);
+        assert_eq!(
+            key.file_hash(),
+            "1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3",
+        );
+        assert_eq!(key.compression(), Some("xz"));
+    }
+
+    #[test]
+    fn new_succeeds_given_no_compression() {
+        let name =
+            NarFileName::new("0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd.nar".into())
+                .unwrap();
+        let key = NarFileKey::from_file_name(&name);
+        assert_eq!(
+            key.file_hash(),
+            "0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd",
+        );
     }
 }

--- a/src/domain/nar_file/model/nar_file_key.rs
+++ b/src/domain/nar_file/model/nar_file_key.rs
@@ -1,0 +1,46 @@
+use getset::Getters;
+
+use crate::domain::nar_info::model::NarFileName;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters)]
+#[getset(get = "pub")]
+pub struct NarFileKey {
+    file_hash: String,
+    compression: Option<String>,
+}
+
+impl NarFileKey {
+    pub fn new(file_hash: String) -> Self {
+        Self {
+            file_hash,
+            compression: None,
+        }
+    }
+
+    pub fn with_compression<V>(mut self, compression: V) -> Self
+    where
+        V: Into<Option<String>>,
+    {
+        self.compression = compression.into().filter(|c| !c.is_empty());
+        self
+    }
+
+    pub fn from_file_name(nar_file: &NarFileName) -> Self {
+        let (file_hash, suffix) = nar_file
+            .value()
+            .split_once(".nar")
+            .expect("`nar_file` should contains `\".nar\"`");
+        let compression = suffix.trim_start_matches(".");
+        Self::new(file_hash.to_string()).with_compression(compression.to_string())
+    }
+
+    pub fn to_file_name(&self) -> NarFileName {
+        if let Some(compression) = &self.compression {
+            NarFileName::new(format!("{}.nar.{}", self.file_hash, compression))
+                .expect("converting `NarFileKey` to `NarFileName` should always be valid")
+        } else {
+            NarFileName::new(format!("{}.nar", self.file_hash))
+                .expect("converting `NarFileKey` to `NarFileName` should always be valid")
+        }
+    }
+}

--- a/src/domain/nar_info/model/nar_file_name.rs
+++ b/src/domain/nar_info/model/nar_file_name.rs
@@ -9,7 +9,7 @@ impl NarFileName {
     pub fn new(value: String) -> Result<Self, TryNewNarFileNameError> {
         ensure!(!value.is_empty(), EmptySnafu);
         ensure!(!value.contains('/'), ContainsSlashSnafu);
-        ensure!(value.contains(".nar."), MissingNarExtensionSnafu);
+        ensure!(value.contains(".nar"), MissingNarExtensionSnafu);
         Ok(Self(value))
     }
 
@@ -29,7 +29,7 @@ pub enum TryNewNarFileNameError {
     Empty,
     #[snafu(display("nar file name should not contain `/`"))]
     ContainsSlash,
-    #[snafu(display("nar file name should end with `.nar.{{compression}}`"))]
+    #[snafu(display("nar file name should end with `\".nar\"` or `\".nar.{{compression}}\"`"))]
     MissingNarExtension,
 }
 
@@ -45,6 +45,14 @@ mod tests {
         assert_eq!(
             name.value(),
             "1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
+        );
+
+        let name =
+            NarFileName::new("0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd.nar".into())
+                .unwrap();
+        assert_eq!(
+            name.value(),
+            "0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd.nar"
         );
     }
 

--- a/src/domain/nar_info/model/proxy_nar_info_data.rs
+++ b/src/domain/nar_info/model/proxy_nar_info_data.rs
@@ -55,6 +55,7 @@ impl ProxyNarInfoData {
             .nar_source_url()
             .cloned()
             .unwrap_or_else(|| upstream_data.nar_file().with_storage_prefix(storage_url))
+            .with_query_params(upstream_data.query_params())
     }
 
     fn replace_url(content: &str, new_url_str: &str) -> String {
@@ -79,7 +80,7 @@ mod tests {
     fn make_upstream_relative() -> UpstreamNarInfoData {
         UpstreamNarInfoData::new(
             "StorePath: /nix/store/abc-hello\n\
-             URL: nar/abc.nar.xz\n\
+             URL: nar/abc.nar.xz?query=abc\n\
              Compression: xz\n"
                 .into(),
         )
@@ -108,10 +109,10 @@ mod tests {
         let (proxy, nar_source_url) =
             ProxyNarInfoData::proxy_by_keep_url(&make_upstream_relative(), &make_meta());
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
-        assert!(proxy.content().contains("URL: nar/abc.nar.xz\n"));
+        assert!(proxy.content().contains("URL: nar/abc.nar.xz?query=abc\n"));
         assert_eq!(
             nar_source_url.value(),
-            "https://cache.example.com/nar/abc.nar.xz"
+            "https://cache.example.com/nar/abc.nar.xz?query=abc"
         );
     }
 
@@ -132,14 +133,14 @@ mod tests {
     }
 
     #[test]
-    fn to_self_is_idempotent_given_relative_url() {
+    fn to_self_strips_query_param_given_relative_url() {
         let (proxy, nar_source_url) =
             ProxyNarInfoData::proxy_by_rewrite_url_to_self(&make_upstream_relative(), &make_meta());
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
         assert!(proxy.content().contains("URL: nar/abc.nar.xz\n"));
         assert_eq!(
             nar_source_url.value(),
-            "https://cache.example.com/nar/abc.nar.xz"
+            "https://cache.example.com/nar/abc.nar.xz?query=abc"
         );
     }
 
@@ -166,11 +167,11 @@ mod tests {
         assert!(
             proxy
                 .content()
-                .contains("URL: https://cache.example.com/nar/abc.nar.xz\n")
+                .contains("URL: https://cache.example.com/nar/abc.nar.xz?query=abc\n")
         );
         assert_eq!(
             nar_source_url.value(),
-            "https://cache.example.com/nar/abc.nar.xz"
+            "https://cache.example.com/nar/abc.nar.xz?query=abc"
         );
     }
 

--- a/src/domain/nar_info/model/upstream_nar_info_data.rs
+++ b/src/domain/nar_info/model/upstream_nar_info_data.rs
@@ -11,6 +11,7 @@ pub struct UpstreamNarInfoData {
     #[getset(get = "pub")]
     nar_file: NarFileName,
     nar_source_url: Option<Url>,
+    query_params: Option<String>,
 }
 
 impl UpstreamNarInfoData {
@@ -21,7 +22,7 @@ impl UpstreamNarInfoData {
             .map(|line| line.trim_start_matches("URL:").trim())
             .context(NoUrlFieldSnafu)?;
 
-        let (nar_file, nar_source_url) = if (raw_url.starts_with("http://")
+        let (nar_file, nar_source_url, query_params) = if (raw_url.starts_with("http://")
             || raw_url.starts_with("https://"))
             && let Some(nar_source_url) = Url::new(raw_url).ok()
         {
@@ -32,26 +33,33 @@ impl UpstreamNarInfoData {
                 .unwrap_or("")
                 .to_string();
             let nar_file = NarFileName::new(nar_file).context(InvalidNarFileNameSnafu)?;
-            (nar_file, Some(nar_source_url))
+            let query_params = nar_source_url.inner().query().map(ToString::to_string);
+            (nar_file, Some(nar_source_url), query_params)
         } else {
-            let nar_path = raw_url.split('?').next().unwrap_or(raw_url);
+            let (nar_path, query_params) = raw_url.split_once('?').unwrap_or((raw_url, ""));
             let nar_file = nar_path
                 .rfind('/')
                 .map_or(nar_path, |pos| &nar_path[pos + 1..])
                 .to_string();
             let nar_file = NarFileName::new(nar_file).context(InvalidNarFileNameSnafu)?;
-            (nar_file, None)
+            let query_params = (!query_params.is_empty()).then(|| query_params.to_string());
+            (nar_file, None, query_params)
         };
 
         Ok(Self {
             content,
             nar_file,
             nar_source_url,
+            query_params,
         })
     }
 
     pub fn nar_source_url(&self) -> Option<&Url> {
         self.nar_source_url.as_ref()
+    }
+
+    pub fn query_params(&self) -> Option<&str> {
+        self.query_params.as_deref()
     }
 }
 
@@ -95,7 +103,7 @@ mod tests {
     }
 
     #[test]
-    fn nar_file_strips_query_params() {
+    fn nar_file_splits_query_params() {
         let data = UpstreamNarInfoData::new(
             "StorePath: /nix/store/abc-hello\n\
              URL: nar/abc.nar.xz?X-Amz-Signature=abc123\n"
@@ -104,6 +112,7 @@ mod tests {
         .unwrap();
         assert_eq!(data.nar_file().value(), "abc.nar.xz");
         assert!(data.nar_source_url().is_none());
+        assert_eq!(data.query_params(), Some("X-Amz-Signature=abc123"));
     }
 
     #[test]

--- a/src/domain/substituter/model/url.rs
+++ b/src/domain/substituter/model/url.rs
@@ -20,6 +20,11 @@ impl Url {
         Ok(Self(parsed))
     }
 
+    pub fn with_query_params(mut self, query_params: Option<&str>) -> Self {
+        self.0.set_query(query_params);
+        self
+    }
+
     pub fn inner(&self) -> &UrlInner {
         &self.0
     }


### PR DESCRIPTION
The proxy server fails to handle non-compressed NAR URL with query parameters, such as `URL: nar/0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd.nar?hash=dw19jyi9v8c10kcrvrrbkfsr6w4d0jr8`, in `.narinfo` responses. This PR makes the server remember the query parameters for relative NAR URL, and relaxes the restriction on the NAR URL schema to allow non-compressed files to be proxyed.