### PR TITLE
Fix race condition in `NarInfo` query task cancellation

### DIFF
--- a/src/domain/nar_info/service/resolution.rs
+++ b/src/domain/nar_info/service/resolution.rs
@@ -147,7 +147,9 @@ impl NarInfoResolutionService {
                 Some(Ok((substituter, Ok(outcome)))) => {
                     query_cancellers.remove(&substituter);
                     query_deadlines.remove(&substituter);
-                    let current_grace = substituter_graces.remove(&substituter).unwrap();
+                    let Some(current_grace) = substituter_graces.remove(&substituter) else {
+                        continue;
+                    };
                     if !substituter.is_normal() {
                         let url = substituter.url().clone();
                         events.push(ResolveNarInfoEvent::SubstituterSucceeded(url));


### PR DESCRIPTION
Cancellation of task in `JoinSet` is cooperative and has no effect if the task has already finished. The current code assumed that the task is cancelable even if it was finished. Given a query has already finished its computation but has been pruned by another query with corresponded context removed, the subsequent code handled that query result by retrieving those removed context with `unwrap()`, causing a panicking.