### PR TITLE
Refactor by improving `Substituter` aggregate cohesion

### DIFF
--- a/src/application/substituter/actor/runner.rs
+++ b/src/application/substituter/actor/runner.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 use selector4nix_actor::actor::{Actor, ActorPre, ActorPreBuilder, AnyAddress, Context};
 use tokio::time::Instant;
 
+use crate::domain::substituter::SubstituterService;
 use crate::domain::substituter::index::SubstituterAvailabilityEvent;
-use crate::domain::substituter::model::Substituter;
+use crate::domain::substituter::model::{Substituter, UpdateSubstituterEvent};
 use crate::domain::substituter::port::{ProbeSubstituterError, SubstituterProbingProvider};
-use crate::domain::substituter::{SubstituterService, UpdateSubstituterEvent};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SubstituterRequest {
@@ -114,28 +114,24 @@ impl Actor for SubstituterActor {
 
     async fn on_request(
         &mut self,
-        state: Self::State,
+        substituter: Self::State,
         request: Self::Request,
     ) -> Option<Self::State> {
         match request {
             SubstituterRequest::ServiceSuccessful => {
-                let (substituter, events) =
-                    self.substituter_service.update_on_service_successful(state);
+                let (substituter, events) = substituter.update_on_service_successful();
                 self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }
             SubstituterRequest::ServiceOffline => {
                 let now = Instant::now();
-                let (substituter, events) = self
-                    .substituter_service
-                    .update_on_service_offline(state, now);
+                let (substituter, events) = substituter.update_on_service_offline(now);
                 self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }
             SubstituterRequest::ServiceError => {
                 let now = Instant::now();
-                let (substituter, events) =
-                    self.substituter_service.update_on_service_error(state, now);
+                let (substituter, events) = substituter.update_on_service_error(now);
                 self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }
@@ -144,21 +140,20 @@ impl Actor for SubstituterActor {
 
     async fn on_internal(
         &mut self,
-        state: Self::State,
+        substituter: Self::State,
         internal: Self::Internal,
     ) -> Option<Self::State> {
         match internal {
             SubstituterInternal::NextRetryReady => {
-                let (substituter, events) =
-                    self.substituter_service.update_on_next_retry_ready(state);
+                let (substituter, events) = substituter.update_on_next_retry_ready();
                 self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }
             SubstituterInternal::ProbingFinished(res) => {
                 let now = Instant::now();
-                let (substituter, events) = self
-                    .substituter_service
-                    .update_on_probing_finished(state, res, now);
+                let (substituter, events) =
+                    self.substituter_service
+                        .update_on_probing_finished(substituter, res, now);
                 self.exec_all_events(&substituter, events).await;
                 Some(substituter)
             }

--- a/src/domain/substituter/mod.rs
+++ b/src/domain/substituter/mod.rs
@@ -4,4 +4,4 @@ pub mod port;
 
 mod service;
 
-pub use service::{SubstituterService, UpdateSubstituterEvent};
+pub use service::SubstituterService;

--- a/src/domain/substituter/model/availability.rs
+++ b/src/domain/substituter/model/availability.rs
@@ -21,14 +21,14 @@ impl Availability {
     pub const OFFLINE_RETRY_PERIOD: Duration = Duration::from_secs(30);
     pub const REPROBING_PERIOD: Duration = Duration::from_secs(30);
 
-    pub fn change_to_normal(self) -> Self {
+    pub fn try_change_to_normal(self) -> Self {
         match self {
             Self::MaybeReady { .. } => Self::Normal,
             otherwise => otherwise,
         }
     }
 
-    pub fn change_to_offline(self, now: Instant) -> Self {
+    pub fn try_change_to_offline(self, now: Instant) -> Self {
         match self {
             Self::Normal => Self::Offline { detected_at: now },
             s @ Self::Offline { .. } => s,
@@ -37,7 +37,7 @@ impl Availability {
         }
     }
 
-    pub fn change_to_service_error(self, now: Instant) -> Self {
+    pub fn try_change_to_service_error(self, now: Instant) -> Self {
         match self {
             Self::Normal => Self::ServiceError {
                 detected_at: now,
@@ -52,7 +52,7 @@ impl Availability {
         }
     }
 
-    pub fn change_to_maybe_ready(self) -> Self {
+    pub fn try_change_to_maybe_ready(self) -> Self {
         match self {
             Self::Offline { .. } => Self::MaybeReady { prev_failures: 0 },
             Self::ServiceError { prev_failures, .. } => Self::MaybeReady { prev_failures },
@@ -64,7 +64,7 @@ impl Availability {
         match &self {
             Self::Offline { detected_at } => {
                 if *detected_at + Self::OFFLINE_RETRY_PERIOD <= now {
-                    (true, self.change_to_maybe_ready())
+                    (true, self.try_change_to_maybe_ready())
                 } else {
                     (false, self)
                 }
@@ -74,7 +74,7 @@ impl Availability {
                 prev_failures,
             } => {
                 if *detected_at + Self::calc_retry_duration(*prev_failures) <= now {
-                    (true, self.change_to_maybe_ready())
+                    (true, self.try_change_to_maybe_ready())
                 } else {
                     (false, self)
                 }
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn change_to_service_error_succeeds_from_normal() {
         let now = Instant::now();
-        let result = Availability::Normal.change_to_service_error(now);
+        let result = Availability::Normal.try_change_to_service_error(now);
         assert_eq!(
             result,
             Availability::ServiceError {
@@ -134,7 +134,7 @@ mod tests {
             detected_at: now,
             prev_failures: 1,
         };
-        let result = state.change_to_service_error(now);
+        let result = state.try_change_to_service_error(now);
         assert_eq!(
             result,
             Availability::ServiceError {

--- a/src/domain/substituter/model/mod.rs
+++ b/src/domain/substituter/model/mod.rs
@@ -6,6 +6,6 @@ mod url;
 
 pub use availability::Availability;
 pub use priority::{Priority, TryNewPriorityError};
-pub use substituter::{ProbedState, Substituter, UpdateSubstituterEvent};
+pub use substituter::{PeriodicProbingOption, ProbedState, Substituter, UpdateSubstituterEvent};
 pub use substituter_meta::SubstituterMeta;
 pub use url::{TryNewUrlError, Url};

--- a/src/domain/substituter/model/mod.rs
+++ b/src/domain/substituter/model/mod.rs
@@ -6,6 +6,6 @@ mod url;
 
 pub use availability::Availability;
 pub use priority::{Priority, TryNewPriorityError};
-pub use substituter::Substituter;
+pub use substituter::{ProbedState, Substituter, UpdateSubstituterEvent};
 pub use substituter_meta::SubstituterMeta;
 pub use url::{TryNewUrlError, Url};

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -46,7 +46,7 @@ impl Substituter {
     }
 
     pub fn update_on_service_successful(mut self) -> (Self, Vec<UpdateSubstituterEvent>) {
-        self = self.try_change_to_normal();
+        self.availability = self.availability.try_change_to_normal();
         let events = if !self.is_unavailable() {
             vec![UpdateSubstituterEvent::NotifyAvailable]
         } else {
@@ -56,52 +56,55 @@ impl Substituter {
     }
 
     pub fn update_on_service_offline(
-        self,
+        mut self,
         now: Instant,
     ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
         if self.is_unavailable() {
             (self, Vec::new())
         } else {
-            let (retry_instant, substituter) = self.try_change_to_offline(now);
+            self.availability = self.availability.try_change_to_offline(now);
+            let retry_instant = now + self.availability.retry_duration().unwrap();
             let events = vec![
                 UpdateSubstituterEvent::NotifyUnavailable,
                 UpdateSubstituterEvent::ScheduleRetryReady(retry_instant),
             ];
-            (substituter, events)
+            (self, events)
         }
     }
 
     pub fn update_on_service_error(
-        self,
+        mut self,
         now: Instant,
     ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
         if self.is_unavailable() {
             (self, Vec::new())
         } else {
-            let (retry_instant, substituter) = self.try_change_to_service_error(now);
+            self.availability = self.availability.try_change_to_service_error(now);
+            let retry_instant = now + self.availability.retry_duration().unwrap();
             let events = vec![
                 UpdateSubstituterEvent::NotifyUnavailable,
                 UpdateSubstituterEvent::ScheduleRetryReady(retry_instant),
             ];
-            (substituter, events)
+            (self, events)
         }
     }
 
-    pub fn update_on_next_retry_ready(self) -> (Substituter, Vec<UpdateSubstituterEvent>) {
+    pub fn update_on_next_retry_ready(mut self) -> (Substituter, Vec<UpdateSubstituterEvent>) {
+        self.availability = self.availability.try_change_to_maybe_ready();
         let events = vec![UpdateSubstituterEvent::ScheduleProbing(None)];
-        (self.on_next_retry_ready(), events)
+        (self, events)
     }
 
     pub fn update_on_probing_finished(
-        self,
+        mut self,
         probed_state: ProbedState,
         periodic_probing: bool,
         now: Instant,
     ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
         match probed_state {
             ProbedState::Normal => {
-                let substituter = self.try_change_to_normal();
-                let events = match (substituter.is_normal(), periodic_probing) {
+                self.availability = self.availability.try_change_to_normal();
+                let events = match (self.is_normal(), periodic_probing) {
                     (true, true) => vec![
                         UpdateSubstituterEvent::NotifyAvailable,
                         UpdateSubstituterEvent::ScheduleProbing(Some(
@@ -111,33 +114,11 @@ impl Substituter {
                     (true, false) => vec![UpdateSubstituterEvent::NotifyAvailable],
                     (false, _) => Vec::new(),
                 };
-                (substituter, events)
+                (self, events)
             }
             ProbedState::Offline => self.update_on_service_offline(now),
             ProbedState::ServiceError => self.update_on_service_error(now),
         }
-    }
-
-    pub fn try_change_to_offline(mut self, now: Instant) -> (Instant, Self) {
-        self.availability = self.availability.try_change_to_offline(now);
-        let retry_instant = now + self.availability.retry_duration().unwrap();
-        (retry_instant, self)
-    }
-
-    pub fn try_change_to_service_error(mut self, now: Instant) -> (Instant, Self) {
-        self.availability = self.availability.try_change_to_service_error(now);
-        let retry_instant = now + self.availability.retry_duration().unwrap();
-        (retry_instant, self)
-    }
-
-    pub fn on_next_retry_ready(mut self) -> Self {
-        self.availability = self.availability.try_change_to_maybe_ready();
-        self
-    }
-
-    pub fn try_change_to_normal(mut self) -> Self {
-        self.availability = self.availability.try_change_to_normal();
-        self
     }
 }
 

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -98,20 +98,22 @@ impl Substituter {
     pub fn update_on_probing_finished(
         mut self,
         probed_state: ProbedState,
-        periodic_probing: bool,
+        periodic_probing: PeriodicProbingOption,
         now: Instant,
     ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
         match probed_state {
             ProbedState::Normal => {
                 self.availability = self.availability.try_change_to_normal();
                 let events = match (self.is_normal(), periodic_probing) {
-                    (true, true) => vec![
+                    (true, PeriodicProbingOption::Enabled) => vec![
                         UpdateSubstituterEvent::NotifyAvailable,
                         UpdateSubstituterEvent::ScheduleProbing(Some(
                             now + Availability::REPROBING_PERIOD,
                         )),
                     ],
-                    (true, false) => vec![UpdateSubstituterEvent::NotifyAvailable],
+                    (true, PeriodicProbingOption::None) => {
+                        vec![UpdateSubstituterEvent::NotifyAvailable]
+                    }
                     (false, _) => Vec::new(),
                 };
                 (self, events)
@@ -135,6 +137,12 @@ pub enum ProbedState {
     Normal,
     Offline,
     ServiceError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PeriodicProbingOption {
+    Enabled,
+    None,
 }
 
 #[cfg(test)]
@@ -230,8 +238,11 @@ mod tests {
         let substituter = make_substituter(Availability::MaybeReady { prev_failures: 0 });
         let now = Instant::now();
 
-        let (result, events) =
-            substituter.update_on_probing_finished(ProbedState::Normal, true, now);
+        let (result, events) = substituter.update_on_probing_finished(
+            ProbedState::Normal,
+            PeriodicProbingOption::Enabled,
+            now,
+        );
 
         assert!(result.is_normal());
         assert_events_eq(
@@ -248,8 +259,11 @@ mod tests {
         let substituter = make_substituter(Availability::Normal);
         let now = Instant::now();
 
-        let (result, events) =
-            substituter.update_on_probing_finished(ProbedState::Normal, true, now);
+        let (result, events) = substituter.update_on_probing_finished(
+            ProbedState::Normal,
+            PeriodicProbingOption::Enabled,
+            now,
+        );
 
         assert!(result.is_normal());
         assert_events_eq(
@@ -266,8 +280,11 @@ mod tests {
         let substituter = make_substituter(Availability::MaybeReady { prev_failures: 0 });
         let now = Instant::now();
 
-        let (result, events) =
-            substituter.update_on_probing_finished(ProbedState::Offline, true, now);
+        let (result, events) = substituter.update_on_probing_finished(
+            ProbedState::Offline,
+            PeriodicProbingOption::Enabled,
+            now,
+        );
 
         assert!(result.is_unavailable());
         assert_events_eq(
@@ -286,8 +303,11 @@ mod tests {
         let substituter = make_substituter(Availability::MaybeReady { prev_failures: 2 });
         let now = Instant::now();
 
-        let (result, events) =
-            substituter.update_on_probing_finished(ProbedState::ServiceError, true, now);
+        let (result, events) = substituter.update_on_probing_finished(
+            ProbedState::ServiceError,
+            PeriodicProbingOption::Enabled,
+            now,
+        );
 
         assert!(result.is_unavailable());
         assert_events_eq(

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -139,6 +139,7 @@ pub enum ProbedState {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::time::Duration;
 
     use crate::domain::substituter::model::{Availability, Priority, SubstituterMeta, Url};
@@ -152,13 +153,22 @@ mod tests {
         Substituter::new(meta, availability)
     }
 
+    fn assert_events_eq(
+        actual: impl IntoIterator<Item = UpdateSubstituterEvent>,
+        expected: impl IntoIterator<Item = UpdateSubstituterEvent>,
+    ) {
+        assert_eq!(
+            actual.into_iter().collect::<HashSet<_>>(),
+            expected.into_iter().collect::<HashSet<_>>(),
+        );
+    }
+
     #[test]
     fn update_on_service_successful_given_maybe_ready() {
         let substituter = make_substituter(Availability::MaybeReady { prev_failures: 0 });
         let (result, events) = substituter.update_on_service_successful();
         assert!(!result.is_unavailable());
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0], UpdateSubstituterEvent::NotifyAvailable);
+        assert_events_eq(events, vec![UpdateSubstituterEvent::NotifyAvailable]);
     }
 
     #[test]
@@ -169,15 +179,13 @@ mod tests {
         let (result, events) = substituter.update_on_service_error(now);
 
         assert!(result.is_unavailable());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(
-            events[0],
-            UpdateSubstituterEvent::NotifyUnavailable
-        ));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleRetryReady(t) if t == now + Duration::from_millis(500)
-        ));
+        assert_events_eq(
+            events,
+            vec![
+                UpdateSubstituterEvent::NotifyUnavailable,
+                UpdateSubstituterEvent::ScheduleRetryReady(now + Duration::from_millis(500)),
+            ],
+        );
     }
 
     #[test]
@@ -188,7 +196,6 @@ mod tests {
         let (result, events) = substituter.update_on_service_error(now);
 
         assert!(result.is_unavailable());
-        assert_eq!(events.len(), 2);
         assert!(matches!(
             result.availability(),
             Availability::ServiceError {
@@ -196,6 +203,13 @@ mod tests {
                 ..
             }
         ));
+        assert_events_eq(
+            events,
+            vec![
+                UpdateSubstituterEvent::NotifyUnavailable,
+                UpdateSubstituterEvent::ScheduleRetryReady(now + Duration::from_millis(4000)),
+            ],
+        );
     }
 
     #[test]
@@ -208,11 +222,7 @@ mod tests {
         let (result, events) = substituter.update_on_next_retry_ready();
 
         assert!(!result.is_unavailable());
-        assert_eq!(events.len(), 1);
-        assert!(matches!(
-            events[0],
-            UpdateSubstituterEvent::ScheduleProbing(None),
-        ));
+        assert_events_eq(events, vec![UpdateSubstituterEvent::ScheduleProbing(None)]);
     }
 
     #[test]
@@ -224,12 +234,13 @@ mod tests {
             substituter.update_on_probing_finished(ProbedState::Normal, true, now);
 
         assert!(result.is_normal());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(events[0], UpdateSubstituterEvent::NotifyAvailable));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleProbing(Some(_)),
-        ));
+        assert_events_eq(
+            events,
+            vec![
+                UpdateSubstituterEvent::NotifyAvailable,
+                UpdateSubstituterEvent::ScheduleProbing(Some(now + Availability::REPROBING_PERIOD)),
+            ],
+        );
     }
 
     #[test]
@@ -241,12 +252,13 @@ mod tests {
             substituter.update_on_probing_finished(ProbedState::Normal, true, now);
 
         assert!(result.is_normal());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(events[0], UpdateSubstituterEvent::NotifyAvailable));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleProbing(Some(_)),
-        ));
+        assert_events_eq(
+            events,
+            vec![
+                UpdateSubstituterEvent::NotifyAvailable,
+                UpdateSubstituterEvent::ScheduleProbing(Some(now + Availability::REPROBING_PERIOD)),
+            ],
+        );
     }
 
     #[test]
@@ -258,15 +270,15 @@ mod tests {
             substituter.update_on_probing_finished(ProbedState::Offline, true, now);
 
         assert!(result.is_unavailable());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(
-            events[0],
-            UpdateSubstituterEvent::NotifyUnavailable,
-        ));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleRetryReady(_),
-        ));
+        assert_events_eq(
+            events,
+            vec![
+                UpdateSubstituterEvent::NotifyUnavailable,
+                UpdateSubstituterEvent::ScheduleRetryReady(
+                    now + Availability::OFFLINE_RETRY_PERIOD,
+                ),
+            ],
+        );
     }
 
     #[test]
@@ -278,14 +290,12 @@ mod tests {
             substituter.update_on_probing_finished(ProbedState::ServiceError, true, now);
 
         assert!(result.is_unavailable());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(
-            events[0],
-            UpdateSubstituterEvent::NotifyUnavailable,
-        ));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleRetryReady(_),
-        ));
+        assert_events_eq(
+            events,
+            vec![
+                UpdateSubstituterEvent::NotifyUnavailable,
+                UpdateSubstituterEvent::ScheduleRetryReady(now + Duration::from_millis(4000)),
+            ],
+        );
     }
 }

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -45,75 +45,266 @@ impl Substituter {
         )
     }
 
-    pub fn on_detected_offline(mut self, now: Instant) -> (Instant, Self) {
-        self.availability = self.availability.change_to_offline(now);
+    pub fn update_on_service_successful(mut self) -> (Self, Vec<UpdateSubstituterEvent>) {
+        self = self.try_change_to_normal();
+        let events = if !self.is_unavailable() {
+            vec![UpdateSubstituterEvent::NotifyAvailable]
+        } else {
+            Vec::new()
+        };
+        (self, events)
+    }
+
+    pub fn update_on_service_offline(
+        self,
+        now: Instant,
+    ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
+        if self.is_unavailable() {
+            (self, Vec::new())
+        } else {
+            let (retry_instant, substituter) = self.try_change_to_offline(now);
+            let events = vec![
+                UpdateSubstituterEvent::NotifyUnavailable,
+                UpdateSubstituterEvent::ScheduleRetryReady(retry_instant),
+            ];
+            (substituter, events)
+        }
+    }
+
+    pub fn update_on_service_error(
+        self,
+        now: Instant,
+    ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
+        if self.is_unavailable() {
+            (self, Vec::new())
+        } else {
+            let (retry_instant, substituter) = self.try_change_to_service_error(now);
+            let events = vec![
+                UpdateSubstituterEvent::NotifyUnavailable,
+                UpdateSubstituterEvent::ScheduleRetryReady(retry_instant),
+            ];
+            (substituter, events)
+        }
+    }
+
+    pub fn update_on_next_retry_ready(self) -> (Substituter, Vec<UpdateSubstituterEvent>) {
+        let events = vec![UpdateSubstituterEvent::ScheduleProbing(None)];
+        (self.on_next_retry_ready(), events)
+    }
+
+    pub fn update_on_probing_finished(
+        self,
+        probed_state: ProbedState,
+        periodic_probing: bool,
+        now: Instant,
+    ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
+        match probed_state {
+            ProbedState::Normal => {
+                let substituter = self.try_change_to_normal();
+                let events = match (substituter.is_normal(), periodic_probing) {
+                    (true, true) => vec![
+                        UpdateSubstituterEvent::NotifyAvailable,
+                        UpdateSubstituterEvent::ScheduleProbing(Some(
+                            now + Availability::REPROBING_PERIOD,
+                        )),
+                    ],
+                    (true, false) => vec![UpdateSubstituterEvent::NotifyAvailable],
+                    (false, _) => Vec::new(),
+                };
+                (substituter, events)
+            }
+            ProbedState::Offline => self.update_on_service_offline(now),
+            ProbedState::ServiceError => self.update_on_service_error(now),
+        }
+    }
+
+    pub fn try_change_to_offline(mut self, now: Instant) -> (Instant, Self) {
+        self.availability = self.availability.try_change_to_offline(now);
         let retry_instant = now + self.availability.retry_duration().unwrap();
         (retry_instant, self)
     }
 
-    pub fn on_detected_service_error(mut self, now: Instant) -> (Instant, Self) {
-        self.availability = self.availability.change_to_service_error(now);
+    pub fn try_change_to_service_error(mut self, now: Instant) -> (Instant, Self) {
+        self.availability = self.availability.try_change_to_service_error(now);
         let retry_instant = now + self.availability.retry_duration().unwrap();
         (retry_instant, self)
     }
 
     pub fn on_next_retry_ready(mut self) -> Self {
-        self.availability = self.availability.change_to_maybe_ready();
+        self.availability = self.availability.try_change_to_maybe_ready();
         self
     }
 
-    pub fn on_detected_normal(mut self) -> Self {
-        self.availability = self.availability.change_to_normal();
+    pub fn try_change_to_normal(mut self) -> Self {
+        self.availability = self.availability.try_change_to_normal();
         self
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum UpdateSubstituterEvent {
+    ScheduleRetryReady(Instant),
+    ScheduleProbing(Option<Instant>),
+    NotifyUnavailable,
+    NotifyAvailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProbedState {
+    Normal,
+    Offline,
+    ServiceError,
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
+    use crate::domain::substituter::model::{Availability, Priority, SubstituterMeta, Url};
+
     use super::*;
 
-    fn make_substituter() -> Substituter {
+    fn make_substituter(availability: Availability) -> Substituter {
         let url = Url::new("https://cache.nixos.org").unwrap();
         let priority = Priority::new(40).unwrap();
-        Substituter::new(SubstituterMeta::new(url, priority), Availability::Normal)
+        let meta = SubstituterMeta::new(url, priority);
+        Substituter::new(meta, availability)
     }
 
     #[test]
-    fn on_detected_unavailable_transitions_to_unavailable() {
-        let sub = make_substituter();
-        assert!(!sub.is_unavailable());
-
-        let (_, sub) = sub.on_detected_service_error(Instant::now());
-        assert!(sub.is_unavailable());
+    fn update_on_service_successful_given_maybe_ready() {
+        let substituter = make_substituter(Availability::MaybeReady { prev_failures: 0 });
+        let (result, events) = substituter.update_on_service_successful();
+        assert!(!result.is_unavailable());
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0], UpdateSubstituterEvent::NotifyAvailable);
     }
 
     #[test]
-    fn on_detected_unavailable_returns_retry_instant() {
-        let sub = make_substituter();
+    fn update_on_service_failed_changes_state_from_normal() {
+        let substituter = make_substituter(Availability::Normal);
         let now = Instant::now();
-        let (retry, _) = sub.on_detected_service_error(now);
-        assert_eq!(retry, now + Duration::from_millis(500));
+
+        let (result, events) = substituter.update_on_service_error(now);
+
+        assert!(result.is_unavailable());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            UpdateSubstituterEvent::NotifyUnavailable
+        ));
+        assert!(matches!(
+            events[1],
+            UpdateSubstituterEvent::ScheduleRetryReady(t) if t == now + Duration::from_millis(500)
+        ));
     }
 
     #[test]
-    fn on_next_retry_ready_transitions_from_unavailable() {
-        let sub = make_substituter();
-        let (_, sub) = sub.on_detected_service_error(Instant::now());
-        assert!(sub.is_unavailable());
+    fn update_on_service_error_increments_backoff_given_repeated_error() {
+        let substituter = make_substituter(Availability::MaybeReady { prev_failures: 2 });
+        let now = Instant::now();
 
-        let sub = sub.on_next_retry_ready();
-        assert!(!sub.is_unavailable());
+        let (result, events) = substituter.update_on_service_error(now);
+
+        assert!(result.is_unavailable());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            result.availability(),
+            Availability::ServiceError {
+                prev_failures: 3,
+                ..
+            }
+        ));
     }
 
     #[test]
-    fn on_detected_normal_doesnt_reset_availability_given_still_unavailable() {
-        let sub = make_substituter();
-        let (_, sub) = sub.on_detected_service_error(Instant::now());
-        assert!(sub.is_unavailable());
+    fn update_on_next_retry_ready_succeeds() {
+        let substituter = make_substituter(Availability::ServiceError {
+            detected_at: Instant::now(),
+            prev_failures: 0,
+        });
 
-        let sub = sub.on_detected_normal();
-        assert!(sub.is_unavailable());
+        let (result, events) = substituter.update_on_next_retry_ready();
+
+        assert!(!result.is_unavailable());
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            UpdateSubstituterEvent::ScheduleProbing(None),
+        ));
+    }
+
+    #[test]
+    fn update_on_probing_finished_succeeds_given_probed_state_normal() {
+        let substituter = make_substituter(Availability::MaybeReady { prev_failures: 0 });
+        let now = Instant::now();
+
+        let (result, events) =
+            substituter.update_on_probing_finished(ProbedState::Normal, true, now);
+
+        assert!(result.is_normal());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], UpdateSubstituterEvent::NotifyAvailable));
+        assert!(matches!(
+            events[1],
+            UpdateSubstituterEvent::ScheduleProbing(Some(_)),
+        ));
+    }
+
+    #[test]
+    fn update_on_probing_finished_schedules_reprobing_given_already_normal() {
+        let substituter = make_substituter(Availability::Normal);
+        let now = Instant::now();
+
+        let (result, events) =
+            substituter.update_on_probing_finished(ProbedState::Normal, true, now);
+
+        assert!(result.is_normal());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], UpdateSubstituterEvent::NotifyAvailable));
+        assert!(matches!(
+            events[1],
+            UpdateSubstituterEvent::ScheduleProbing(Some(_)),
+        ));
+    }
+
+    #[test]
+    fn update_on_probing_finished_emits_unavailable_given_offline() {
+        let substituter = make_substituter(Availability::MaybeReady { prev_failures: 0 });
+        let now = Instant::now();
+
+        let (result, events) =
+            substituter.update_on_probing_finished(ProbedState::Offline, true, now);
+
+        assert!(result.is_unavailable());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            UpdateSubstituterEvent::NotifyUnavailable,
+        ));
+        assert!(matches!(
+            events[1],
+            UpdateSubstituterEvent::ScheduleRetryReady(_),
+        ));
+    }
+
+    #[test]
+    fn update_on_probing_finished_emits_unavailable_given_service_error() {
+        let substituter = make_substituter(Availability::MaybeReady { prev_failures: 2 });
+        let now = Instant::now();
+
+        let (result, events) =
+            substituter.update_on_probing_finished(ProbedState::ServiceError, true, now);
+
+        assert!(result.is_unavailable());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            UpdateSubstituterEvent::NotifyUnavailable,
+        ));
+        assert!(matches!(
+            events[1],
+            UpdateSubstituterEvent::ScheduleRetryReady(_),
+        ));
     }
 }

--- a/src/domain/substituter/service.rs
+++ b/src/domain/substituter/service.rs
@@ -2,21 +2,23 @@ use std::time::Duration;
 
 use tokio::time::Instant;
 
-use crate::domain::substituter::model::{ProbedState, Substituter, UpdateSubstituterEvent};
+use crate::domain::substituter::model::{
+    PeriodicProbingOption, ProbedState, Substituter, UpdateSubstituterEvent,
+};
 use crate::domain::substituter::port::ProbeSubstituterError;
 
 pub struct SubstituterService {
-    periodic_probing: bool,
+    periodic_probing: PeriodicProbingOption,
 }
 
 impl SubstituterService {
-    pub fn new(periodic_probing: bool) -> Self {
+    pub fn new(periodic_probing: PeriodicProbingOption) -> Self {
         Self { periodic_probing }
     }
 
     pub fn on_initial(&self, now: Instant) -> Vec<UpdateSubstituterEvent> {
         const INITIAL_PROBING_DELAY: Duration = Duration::from_secs(5);
-        if self.periodic_probing {
+        if self.periodic_probing == PeriodicProbingOption::Enabled {
             vec![UpdateSubstituterEvent::ScheduleProbing(Some(
                 now + INITIAL_PROBING_DELAY,
             ))]

--- a/src/domain/substituter/service.rs
+++ b/src/domain/substituter/service.rs
@@ -2,16 +2,8 @@ use std::time::Duration;
 
 use tokio::time::Instant;
 
-use crate::domain::substituter::model::{Availability, Substituter};
+use crate::domain::substituter::model::{ProbedState, Substituter, UpdateSubstituterEvent};
 use crate::domain::substituter::port::ProbeSubstituterError;
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum UpdateSubstituterEvent {
-    ScheduleRetryReady(Instant),
-    ScheduleProbing(Option<Instant>),
-    NotifyUnavailable,
-    NotifyAvailable,
-}
 
 pub struct SubstituterService {
     periodic_probing: bool,
@@ -33,244 +25,17 @@ impl SubstituterService {
         }
     }
 
-    pub fn update_on_service_successful(
-        &self,
-        substituter: Substituter,
-    ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
-        (substituter.on_detected_normal(), Vec::new())
-    }
-
-    pub fn update_on_service_offline(
-        &self,
-        substituter: Substituter,
-        now: Instant,
-    ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
-        if substituter.is_unavailable() {
-            (substituter, Vec::new())
-        } else {
-            let (retry_instant, substituter) = substituter.on_detected_offline(now);
-            let events = vec![
-                UpdateSubstituterEvent::NotifyUnavailable,
-                UpdateSubstituterEvent::ScheduleRetryReady(retry_instant),
-            ];
-            (substituter, events)
-        }
-    }
-
-    pub fn update_on_service_error(
-        &self,
-        substituter: Substituter,
-        now: Instant,
-    ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
-        if substituter.is_unavailable() {
-            (substituter, Vec::new())
-        } else {
-            let (retry_instant, substituter) = substituter.on_detected_service_error(now);
-            let events = vec![
-                UpdateSubstituterEvent::NotifyUnavailable,
-                UpdateSubstituterEvent::ScheduleRetryReady(retry_instant),
-            ];
-            (substituter, events)
-        }
-    }
-
-    pub fn update_on_next_retry_ready(
-        &self,
-        substituter: Substituter,
-    ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
-        let events = vec![UpdateSubstituterEvent::ScheduleProbing(None)];
-        (substituter.on_next_retry_ready(), events)
-    }
-
     pub fn update_on_probing_finished(
         &self,
         substituter: Substituter,
         result: Result<(), ProbeSubstituterError>,
         now: Instant,
     ) -> (Substituter, Vec<UpdateSubstituterEvent>) {
-        match result {
-            Ok(()) => {
-                let substituter = substituter.on_detected_normal();
-                let events = match (substituter.is_normal(), self.periodic_probing) {
-                    (true, true) => vec![
-                        UpdateSubstituterEvent::NotifyAvailable,
-                        UpdateSubstituterEvent::ScheduleProbing(Some(
-                            now + Availability::REPROBING_PERIOD,
-                        )),
-                    ],
-                    (true, false) => vec![UpdateSubstituterEvent::NotifyAvailable],
-                    (false, _) => Vec::new(),
-                };
-                (substituter, events)
-            }
-            Err(ProbeSubstituterError::Offline { .. }) => {
-                self.update_on_service_offline(substituter, now)
-            }
-            Err(ProbeSubstituterError::Service { .. }) => {
-                self.update_on_service_error(substituter, now)
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use crate::domain::substituter::model::{Availability, Priority, SubstituterMeta, Url};
-
-    use super::*;
-
-    fn make_substituter(availability: Availability) -> Substituter {
-        let url = Url::new("https://cache.nixos.org").unwrap();
-        let priority = Priority::new(40).unwrap();
-        let meta = SubstituterMeta::new(url, priority);
-        Substituter::new(meta, availability)
-    }
-
-    #[test]
-    fn update_on_service_successful_succeeds() {
-        let service = SubstituterService::new(true);
-        let sub = make_substituter(Availability::MaybeReady { prev_failures: 0 });
-        let (result, events) = service.update_on_service_successful(sub);
-        assert!(!result.is_unavailable());
-        assert!(events.is_empty());
-    }
-
-    #[test]
-    fn update_on_service_failed_succeeds() {
-        let service = SubstituterService::new(true);
-        let sub = make_substituter(Availability::Normal);
-        let now = Instant::now();
-
-        let (result, events) = service.update_on_service_error(sub, now);
-
-        assert!(result.is_unavailable());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(
-            events[0],
-            UpdateSubstituterEvent::NotifyUnavailable
-        ));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleRetryReady(t) if t == now + Duration::from_millis(500)
-        ));
-    }
-
-    #[test]
-    fn update_on_service_failed_increments_backoff_given_repeated() {
-        let service = SubstituterService::new(true);
-        let sub = make_substituter(Availability::MaybeReady { prev_failures: 2 });
-        let now = Instant::now();
-
-        let (result, events) = service.update_on_service_error(sub, now);
-
-        assert!(result.is_unavailable());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(
-            result.availability(),
-            Availability::ServiceError {
-                prev_failures: 3,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn update_on_next_retry_ready_succeeds() {
-        let service = SubstituterService::new(true);
-        let sub = make_substituter(Availability::ServiceError {
-            detected_at: Instant::now(),
-            prev_failures: 0,
-        });
-
-        let (result, events) = service.update_on_next_retry_ready(sub);
-
-        assert!(!result.is_unavailable());
-        assert_eq!(events.len(), 1);
-        assert!(matches!(
-            events[0],
-            UpdateSubstituterEvent::ScheduleProbing(None),
-        ));
-    }
-
-    #[test]
-    fn update_on_probing_finished_succeeds_given_ok() {
-        let service = SubstituterService::new(true);
-        let sub = make_substituter(Availability::MaybeReady { prev_failures: 0 });
-        let now = Instant::now();
-
-        let (result, events) = service.update_on_probing_finished(sub, Ok(()), now);
-
-        assert!(result.is_normal());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(events[0], UpdateSubstituterEvent::NotifyAvailable,));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleProbing(Some(_)),
-        ));
-    }
-
-    #[test]
-    fn update_on_probing_finished_schedules_reprobing_given_ok_and_already_normal() {
-        let service = SubstituterService::new(true);
-        let sub = make_substituter(Availability::Normal);
-        let now = Instant::now();
-
-        let (result, events) = service.update_on_probing_finished(sub, Ok(()), now);
-
-        assert!(result.is_normal());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(events[0], UpdateSubstituterEvent::NotifyAvailable,));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleProbing(Some(_)),
-        ));
-    }
-
-    #[test]
-    fn update_on_probing_finished_emits_unavailable_given_offline() {
-        let service = SubstituterService::new(true);
-        let sub = make_substituter(Availability::MaybeReady { prev_failures: 0 });
-        let now = Instant::now();
-        let err = ProbeSubstituterError::Offline {
-            source: anyhow::anyhow!("test"),
+        let probed_state = match result {
+            Ok(()) => ProbedState::Normal,
+            Err(ProbeSubstituterError::Offline { .. }) => ProbedState::Offline,
+            Err(ProbeSubstituterError::Service { .. }) => ProbedState::ServiceError,
         };
-
-        let (result, events) = service.update_on_probing_finished(sub, Err(err), now);
-
-        assert!(result.is_unavailable());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(
-            events[0],
-            UpdateSubstituterEvent::NotifyUnavailable,
-        ));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleRetryReady(_),
-        ));
-    }
-
-    #[test]
-    fn update_on_probing_finished_emits_unavailable_given_service_error() {
-        let service = SubstituterService::new(true);
-        let sub = make_substituter(Availability::MaybeReady { prev_failures: 2 });
-        let now = Instant::now();
-        let err = ProbeSubstituterError::Service {
-            source: anyhow::anyhow!("test"),
-        };
-
-        let (result, events) = service.update_on_probing_finished(sub, Err(err), now);
-
-        assert!(result.is_unavailable());
-        assert_eq!(events.len(), 2);
-        assert!(matches!(
-            events[0],
-            UpdateSubstituterEvent::NotifyUnavailable,
-        ));
-        assert!(matches!(
-            events[1],
-            UpdateSubstituterEvent::ScheduleRetryReady(_),
-        ));
+        substituter.update_on_probing_finished(probed_state, self.periodic_probing, now)
     }
 }

--- a/src/infrastructure/config/parsed.rs
+++ b/src/infrastructure/config/parsed.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::{Context, Error as AnyhowError, Result as AnyhowResult};
 
 use crate::domain::nar_info::model::NarUrlRewriteOption;
-use crate::domain::substituter::model::{Priority, Url};
+use crate::domain::substituter::model::{PeriodicProbingOption, Priority, Url};
 use crate::infrastructure::config::raw::{
     AppRawConfiguration, CacheInfoRawConfiguration, CacheRawConfiguration, NetworkRawConfiguration,
     ProxyRawConfiguration, ServerRawConfiguration, SubstituterRawConfiguration,
@@ -103,7 +103,7 @@ pub struct NetworkConfiguration {
     pub max_concurrent_requests: usize,
     pub tolerance: u64,
     pub ignore_nar_info_error: bool,
-    pub periodic_probing: bool,
+    pub periodic_probing: PeriodicProbingOption,
 }
 
 impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
@@ -120,7 +120,11 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
             max_concurrent_requests: raw.max_concurrent_requests.unwrap_or(24),
             tolerance: raw.tolerance_msecs.unwrap_or(50).max(1),
             ignore_nar_info_error: raw.ignore_nar_info_error.unwrap_or(false),
-            periodic_probing: raw.periodic_probing.unwrap_or(true),
+            periodic_probing: if raw.periodic_probing.unwrap_or(true) {
+                PeriodicProbingOption::Enabled
+            } else {
+                PeriodicProbingOption::None
+            },
         })
     }
 }

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use selector4nix::domain::nar_info::model::NarUrlRewriteOption;
+use selector4nix::domain::substituter::model::PeriodicProbingOption;
 use selector4nix::infrastructure::config::AppConfiguration;
 
 use super::fixture;
@@ -22,7 +23,10 @@ fn defaults_are_applied_when_sections_omitted() {
     assert_eq!(config.network.max_concurrent_requests, 24);
     assert_eq!(config.network.tolerance, 50);
     assert_eq!(config.network.ignore_nar_info_error, false);
-    assert_eq!(config.network.periodic_probing, true);
+    assert_eq!(
+        config.network.periodic_probing,
+        PeriodicProbingOption::Enabled
+    );
     assert_eq!(config.proxy.rewrite_nar_url, NarUrlRewriteOption::ToSelf);
     assert_eq!(config.cache_info.store_dir, "/nix/store");
     assert!(config.cache_info.want_mass_query);


### PR DESCRIPTION
Move the logic from `SubstituterService` to `Substituter` to make it more cohesive and ensure domain invariant. Reduce the possibility of false-positive test failures. Use more expressive `enum`s instead of plain boolean flags.