### PR TITLE
Add a dedicated configuraion file for development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,6 @@
-export SELECTOR4NIX_CONFIG_FILE="$(realpath ./docs/selector4nix.example.toml)"
+export SELECTOR4NIX_CONFIG_FILE="$(realpath ./docs/selector4nix.development.toml)"
 echo '$SELECTOR4NIX_CONFIG_FILE='"$SELECTOR4NIX_CONFIG_FILE"
+echo 'info: selector4nix will listen on port 5497 in this development environment'
 
 echo "direnv: loading .envrc"
 watch_file flake.nix flake.lock

--- a/docs/selector4nix.development.toml
+++ b/docs/selector4nix.development.toml
@@ -1,0 +1,34 @@
+# A development-oriented configuration of selector4nix.
+# The configuration key-value pairs listed here are not exhaustive and not supposed to be used as an
+# example. For a complete reference of all available fields, see docs/configuration.md.
+
+[server]
+ip = "127.0.0.1"
+port = 5497
+
+[[substituters]]
+url = "https://cache.nixos.org/"
+priority = 40
+
+[[substituters]]
+url = "https://mirrors.tuna.tsinghua.edu.cn/nix-channels/store/"
+priority = 45
+nar_info_timeout_secs = 30
+nar_timeout_secs = 30
+
+[[substituters]]
+url = "https://mirrors.ustc.edu.cn/nix-channels/store/"
+priority = 45
+
+[[substituters]]
+url = "https://mirror.sjtu.edu.cn/nix-channels/store/"
+priority = 45
+
+[[substituters]]
+url = "https://nix-community.cachix.org/"
+priority = 40
+
+[[substituters]]
+url = "https://cache.garnix.io/"
+storage_url = "https://garnix-cache.com/"
+priority = 40


### PR DESCRIPTION
Toggling options in the example configuration file for testing and changing it back is inconvenient. So this PR creates a new configuration file, notably with a different port assigned.