### PR TITLE
Add system test for NAR info querying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +378,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -409,6 +421,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -964,6 +982,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1399,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1576,18 @@ dependencies = [
  "futures",
  "moka",
  "tokio",
+]
+
+[[package]]
+name = "selector4nix-system-test-nar-info-querying"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "reqwest",
+ "tempfile",
+ "tokio",
+ "which",
 ]
 
 [[package]]
@@ -1765,6 +1814,19 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -2290,6 +2352,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2634,12 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,6 +1584,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "fastrand",
  "reqwest",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "components/*"]
+members = [".", "components/*", "tests/system/*"]
 default-members = ["."]
 
 [workspace.dependencies]
@@ -7,7 +7,7 @@ anyhow = "1.0.102"
 async-trait = "0.1.89"
 axum = { version = "0.8.9", features = ["http2"] }
 bytes = "1.11.1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 futures = "0.3.32"
 getset = "0.1.6"
 moka = { version = "0.12.15", features = ["future"] }
@@ -20,6 +20,8 @@ tracing = "0.1.44"
 tracing-oslog = "0.3.0"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = { version = "2.5.8", features = ["serde"] }
+tempfile = "3.27.0"
+which = "7"
 
 [package]
 name = "selector4nix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ async-trait = "0.1.89"
 axum = { version = "0.8.9", features = ["http2"] }
 bytes = "1.11.1"
 clap = { version = "4", features = ["derive", "env"] }
+fastrand = "2"
 futures = "0.3.32"
 getset = "0.1.6"
 moka = { version = "0.12.15", features = ["future"] }

--- a/nix/flake/devshell.nix
+++ b/nix/flake/devshell.nix
@@ -10,6 +10,7 @@
       devShells.default = pkgs.mkShellNoCC {
         packages = [
           config.packages.rust-toolchain
+          pkgs.nix-serve-ng
           pkgs.nixfmt
           pkgs.nixfmt-tree
         ];

--- a/tests/system/nar-info-querying/Cargo.toml
+++ b/tests/system/nar-info-querying/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "selector4nix-system-test-nar-info-querying"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+reqwest = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+which = { workspace = true }

--- a/tests/system/nar-info-querying/Cargo.toml
+++ b/tests/system/nar-info-querying/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+fastrand = { workspace = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/tests/system/nar-info-querying/run.sh
+++ b/tests/system/nar-info-querying/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+cargo build -p selector4nix "$@"
+exec cargo run -p selector4nix-system-test-nar-info-querying -- \
+  --selector4nix ./target/debug/selector4nix

--- a/tests/system/nar-info-querying/run.sh
+++ b/tests/system/nar-info-querying/run.sh
@@ -3,4 +3,5 @@ set -e
 
 cargo build -p selector4nix "$@"
 exec cargo run -p selector4nix-system-test-nar-info-querying -- \
-  --selector4nix ./target/debug/selector4nix
+  --selector4nix ./target/debug/selector4nix \
+  --repeat 20

--- a/tests/system/nar-info-querying/src/assertions.rs
+++ b/tests/system/nar-info-querying/src/assertions.rs
@@ -1,0 +1,54 @@
+use anyhow::{Context, Result as AnyhowResult, bail};
+use reqwest::Response;
+
+pub async fn fetch_nar_info(
+    client: &reqwest::Client,
+    base_url: &str,
+    hash: &str,
+) -> AnyhowResult<Response> {
+    let url = format!("{base_url}/{hash}.narinfo");
+    client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("HTTP request failed for {hash}"))
+}
+
+pub async fn assert_nar_info_ok(response: Response, expected_hash: &str) -> AnyhowResult<()> {
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        bail!("expected 200 for hash {expected_hash}, got {status}: {body}");
+    }
+
+    let body = response
+        .text()
+        .await
+        .context("failed to read nar info body")?;
+    assert_valid_nar_info(&body, expected_hash)
+}
+
+pub async fn assert_nar_info_not_found(response: Response, hash: &str) -> AnyhowResult<()> {
+    let status = response.status();
+    if status.as_u16() != 404 {
+        let body = response.text().await.unwrap_or_default();
+        bail!("expected 404 for hash {hash}, got {status}: {body}");
+    }
+    Ok(())
+}
+
+fn assert_valid_nar_info(body: &str, expected_hash: &str) -> AnyhowResult<()> {
+    let has_store_path = body
+        .lines()
+        .any(|line| line.starts_with("StorePath:") && line.contains(expected_hash));
+    if !has_store_path {
+        bail!("nar info for {expected_hash} missing valid StorePath line\nbody:\n{body}");
+    }
+
+    let has_url = body.lines().any(|line| line.starts_with("URL:"));
+    if !has_url {
+        bail!("nar info for {expected_hash} missing URL line\nbody:\n{body}");
+    }
+
+    Ok(())
+}

--- a/tests/system/nar-info-querying/src/assertions.rs
+++ b/tests/system/nar-info-querying/src/assertions.rs
@@ -11,14 +11,14 @@ pub async fn fetch_nar_info(
         .get(&url)
         .send()
         .await
-        .with_context(|| format!("HTTP request failed for {hash}"))
+        .with_context(|| format!("HTTP request failed for `{hash}`"))
 }
 
 pub async fn assert_nar_info_ok(response: Response, expected_hash: &str) -> AnyhowResult<()> {
     let status = response.status();
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
-        bail!("expected 200 for hash {expected_hash}, got {status}: {body}");
+        bail!("expected 200 for hash `{expected_hash}`, got {status}: {body}");
     }
 
     let body = response
@@ -28,11 +28,29 @@ pub async fn assert_nar_info_ok(response: Response, expected_hash: &str) -> Anyh
     assert_valid_nar_info(&body, expected_hash)
 }
 
+pub async fn assert_nar_info_ok_get_body(
+    response: Response,
+    expected_hash: &str,
+) -> AnyhowResult<String> {
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        bail!("expected 200 for hash `{expected_hash}`, got {status}: {body}");
+    }
+
+    let body = response
+        .text()
+        .await
+        .context("failed to read nar info body")?;
+    assert_valid_nar_info(&body, expected_hash)?;
+    Ok(body)
+}
+
 pub async fn assert_nar_info_not_found(response: Response, hash: &str) -> AnyhowResult<()> {
     let status = response.status();
     if status.as_u16() != 404 {
         let body = response.text().await.unwrap_or_default();
-        bail!("expected 404 for hash {hash}, got {status}: {body}");
+        bail!("expected 404 for hash `{hash}`, got {status}: {body}");
     }
     Ok(())
 }
@@ -42,12 +60,12 @@ fn assert_valid_nar_info(body: &str, expected_hash: &str) -> AnyhowResult<()> {
         .lines()
         .any(|line| line.starts_with("StorePath:") && line.contains(expected_hash));
     if !has_store_path {
-        bail!("nar info for {expected_hash} missing valid StorePath line\nbody:\n{body}");
+        bail!("nar info for `{expected_hash}` missing valid `StorePath:` line\nbody:\n{body}");
     }
 
     let has_url = body.lines().any(|line| line.starts_with("URL:"));
     if !has_url {
-        bail!("nar info for {expected_hash} missing URL line\nbody:\n{body}");
+        bail!("nar info for `{expected_hash}` missing `URL:` line\nbody:\n{body}");
     }
 
     Ok(())

--- a/tests/system/nar-info-querying/src/cli.rs
+++ b/tests/system/nar-info-querying/src/cli.rs
@@ -1,0 +1,66 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result as AnyhowResult, bail};
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "selector4nix-system-test-nar-info-querying")]
+struct Cli {
+    #[arg(long = "selector4nix", env = "SELECTOR4NIX_BIN")]
+    selector4nix: Option<PathBuf>,
+
+    #[arg(long = "nix", env = "NIX_BIN")]
+    nix: Option<PathBuf>,
+
+    #[arg(long = "nix-serve", env = "NIX_SERVE_BIN")]
+    nix_serve: Option<PathBuf>,
+}
+
+pub struct ResolvedPaths {
+    pub selector4nix: PathBuf,
+    pub nix: PathBuf,
+    pub nix_serve: PathBuf,
+}
+
+pub fn resolve() -> AnyhowResult<ResolvedPaths> {
+    let cli = Cli::parse();
+
+    let selector4nix = resolve_binary(cli.selector4nix, "selector4nix")
+        .context("failed to resolve selector4nix binary")?;
+    let nix = resolve_binary(cli.nix, "nix").context("failed to resolve nix binary")?;
+    let nix_serve =
+        resolve_binary(cli.nix_serve, "nix-serve").context("failed to resolve nix-serve binary")?;
+
+    Ok(ResolvedPaths {
+        selector4nix,
+        nix,
+        nix_serve,
+    })
+}
+
+fn resolve_binary(explicit: Option<PathBuf>, name: &str) -> AnyhowResult<PathBuf> {
+    if let Some(path) = explicit {
+        if path.exists() {
+            return Ok(path);
+        }
+        bail!(
+            "explicitly specified {name} binary not found: {}",
+            path.display()
+        );
+    }
+    which::which(name).with_context(|| {
+        format!(
+            "{name} not found on PATH; specify --{name} or set {} env var",
+            env_var_for(name)
+        )
+    })
+}
+
+fn env_var_for(name: &str) -> &'static str {
+    match name {
+        "selector4nix" => "SELECTOR4NIX_BIN",
+        "nix" => "NIX_BIN",
+        "nix-serve" => "NIX_SERVE_BIN",
+        _ => "UNKNOWN",
+    }
+}

--- a/tests/system/nar-info-querying/src/cli.rs
+++ b/tests/system/nar-info-querying/src/cli.rs
@@ -14,27 +14,42 @@ struct Cli {
 
     #[arg(long = "nix-serve", env = "NIX_SERVE_BIN")]
     nix_serve: Option<PathBuf>,
+
+    #[arg(long = "count", default_value_t = 100)]
+    count: usize,
+
+    #[arg(long = "seed", default_value_t = 42)]
+    seed: u64,
+
+    #[arg(long = "repeat", default_value_t = 1)]
+    repeat: usize,
 }
 
 pub struct ResolvedPaths {
     pub selector4nix: PathBuf,
     pub nix: PathBuf,
     pub nix_serve: PathBuf,
+    pub count: usize,
+    pub seed: u64,
+    pub repeat: usize,
 }
 
 pub fn resolve() -> AnyhowResult<ResolvedPaths> {
     let cli = Cli::parse();
 
     let selector4nix = resolve_binary(cli.selector4nix, "selector4nix")
-        .context("failed to resolve selector4nix binary")?;
-    let nix = resolve_binary(cli.nix, "nix").context("failed to resolve nix binary")?;
-    let nix_serve =
-        resolve_binary(cli.nix_serve, "nix-serve").context("failed to resolve nix-serve binary")?;
+        .context("failed to resolve `selector4nix` binary")?;
+    let nix = resolve_binary(cli.nix, "nix").context("failed to resolve `nix` binary")?;
+    let nix_serve = resolve_binary(cli.nix_serve, "nix-serve")
+        .context("failed to resolve `nix-serve` binary")?;
 
     Ok(ResolvedPaths {
         selector4nix,
         nix,
         nix_serve,
+        count: cli.count,
+        seed: cli.seed,
+        repeat: cli.repeat,
     })
 }
 
@@ -44,13 +59,13 @@ fn resolve_binary(explicit: Option<PathBuf>, name: &str) -> AnyhowResult<PathBuf
             return Ok(path);
         }
         bail!(
-            "explicitly specified {name} binary not found: {}",
+            "explicitly specified `{name}` binary not found: {}",
             path.display()
         );
     }
     which::which(name).with_context(|| {
         format!(
-            "{name} not found on PATH; specify --{name} or set {} env var",
+            "`{name}` not found on PATH; specify `--{name}` or set `{}` env var",
             env_var_for(name)
         )
     })

--- a/tests/system/nar-info-querying/src/context.rs
+++ b/tests/system/nar-info-querying/src/context.rs
@@ -1,0 +1,198 @@
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result as AnyhowResult, bail};
+use reqwest::Client;
+use tempfile::TempDir;
+
+use crate::cli::ResolvedPaths;
+use crate::fixture::TestFixtures;
+
+const READINESS_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+struct SubprocessGuard {
+    child: Child,
+}
+
+impl Drop for SubprocessGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+pub struct TestContext {
+    _tempdir: TempDir,
+    _nix_serve: SubprocessGuard,
+    _selector4nix: SubprocessGuard,
+    proxy_base_url: String,
+    client: Client,
+    fixtures: TestFixtures,
+}
+
+impl TestContext {
+    pub async fn init(mut fixtures: TestFixtures, paths: &ResolvedPaths) -> AnyhowResult<Self> {
+        let tempdir = TempDir::new().context("failed to create temp directory")?;
+        let cache_dir = tempdir.path().join("cache");
+        std::fs::create_dir(&cache_dir).context("failed to create cache directory")?;
+
+        populate_cache(&mut fixtures, &cache_dir, &paths.nix)?;
+
+        let upstream_port = find_free_port();
+        let proxy_port = find_free_port();
+
+        let nix_serve = start_nix_serve(&paths.nix_serve, &cache_dir, upstream_port)?;
+        let selector4nix =
+            start_selector4nix(&paths.selector4nix, &tempdir, upstream_port, proxy_port)?;
+
+        let proxy_base_url = format!("http://127.0.0.1:{proxy_port}");
+        let client = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("failed to build HTTP client")?;
+
+        let context = Self {
+            _tempdir: tempdir,
+            _nix_serve: nix_serve,
+            _selector4nix: selector4nix,
+            proxy_base_url,
+            client,
+            fixtures,
+        };
+
+        context.wait_ready().await?;
+        Ok(context)
+    }
+
+    pub fn proxy_base_url(&self) -> &str {
+        &self.proxy_base_url
+    }
+
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    pub fn fixtures(&self) -> &TestFixtures {
+        &self.fixtures
+    }
+
+    async fn wait_ready(&self) -> AnyhowResult<()> {
+        let start = Instant::now();
+        let url = format!("{}/nix-cache-info", self.proxy_base_url);
+        loop {
+            match self.client.get(&url).send().await {
+                Ok(response) if response.status().is_success() => return Ok(()),
+                _ => {
+                    if start.elapsed() > READINESS_TIMEOUT {
+                        bail!("`selector4nix` did not become ready within {READINESS_TIMEOUT:?}");
+                    }
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
+            }
+        }
+    }
+}
+
+const TEST_FILES: &[(&str, &[u8])] = &[
+    ("hello.txt", b"Hello, system test!"),
+    ("empty.txt", b""),
+    ("multiline.txt", b"line one\nline two\nline three\n"),
+    ("binary.dat", &[0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD]),
+    ("unicode.txt", "系统测试 🦀\n".as_bytes()),
+];
+
+fn populate_cache(
+    fixtures: &mut TestFixtures,
+    cache_dir: &Path,
+    nix_bin: &Path,
+) -> AnyhowResult<()> {
+    for (name, content) in TEST_FILES {
+        let file_path = cache_dir.join(format!("input-{name}"));
+        std::fs::write(&file_path, content)
+            .with_context(|| format!("failed to write test file `{name}`"))?;
+
+        let store_uri = format!("file://{}?compression=none", cache_dir.display());
+        let output = Command::new(nix_bin)
+            .args(["store", "add-file", "--store", &store_uri])
+            .arg(&file_path)
+            .env("NIX_CONFIG", "experimental-features = nix-command")
+            .output()
+            .with_context(|| format!("failed to spawn `nix store add-file` for `{name}`"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("`nix store add-file` failed for {name}: {stderr}");
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let store_path = stdout.trim();
+        let hash = store_path
+            .strip_prefix("/nix/store/")
+            .and_then(|s| s.split_once('-'))
+            .map(|(h, _)| h)
+            .context(format!(
+                "unexpected `nix store add-file` output for {name}: {store_path}"
+            ))?;
+
+        fixtures.add_populated(hash.to_string());
+    }
+    Ok(())
+}
+
+fn find_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind ephemeral port");
+    listener
+        .local_addr()
+        .expect("failed to get local address")
+        .port()
+}
+
+fn start_nix_serve(
+    nix_serve_bin: &Path,
+    cache_dir: &Path,
+    port: u16,
+) -> AnyhowResult<SubprocessGuard> {
+    let store_uri = format!("file://{}", cache_dir.display());
+    let child = Command::new(nix_serve_bin)
+        .args(["--store", &store_uri, "--port", &port.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("failed to spawn `nix-serve`")?;
+
+    Ok(SubprocessGuard { child })
+}
+
+fn start_selector4nix(
+    selector4nix_bin: &Path,
+    tempdir: &TempDir,
+    upstream_port: u16,
+    proxy_port: u16,
+) -> AnyhowResult<SubprocessGuard> {
+    let config_content = format!(
+        r#"[server]
+ip = "127.0.0.1"
+port = {proxy_port}
+
+[network]
+periodic_probing = false
+
+[[substituters]]
+url = "http://127.0.0.1:{upstream_port}/"
+"#,
+    );
+    let config_path = tempdir.path().join("selector4nix.toml");
+    std::fs::write(&config_path, &config_content).context("failed to write config")?;
+
+    let child = Command::new(selector4nix_bin)
+        .args(["--config-file", &config_path.to_string_lossy()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("failed to spawn `selector4nix`")?;
+
+    Ok(SubprocessGuard { child })
+}

--- a/tests/system/nar-info-querying/src/context.rs
+++ b/tests/system/nar-info-querying/src/context.rs
@@ -24,17 +24,23 @@ impl Drop for SubprocessGuard {
     }
 }
 
-pub struct TestContext {
+pub struct SharedContext {
     _tempdir: TempDir,
     _nix_serve: SubprocessGuard,
-    _selector4nix: SubprocessGuard,
-    proxy_base_url: String,
+    upstream_port: u16,
     client: Client,
     fixtures: TestFixtures,
+    selector4nix_bin: std::path::PathBuf,
+    proxy_counter: u64,
 }
 
-impl TestContext {
-    pub async fn init(mut fixtures: TestFixtures, paths: &ResolvedPaths) -> AnyhowResult<Self> {
+pub struct ProxyInstance {
+    _guard: SubprocessGuard,
+    proxy_base_url: String,
+}
+
+impl SharedContext {
+    pub fn init(mut fixtures: TestFixtures, paths: &ResolvedPaths) -> AnyhowResult<Self> {
         let tempdir = TempDir::new().context("failed to create temp directory")?;
         let cache_dir = tempdir.path().join("cache");
         std::fs::create_dir(&cache_dir).context("failed to create cache directory")?;
@@ -42,33 +48,60 @@ impl TestContext {
         populate_cache(&mut fixtures, &cache_dir, &paths.nix)?;
 
         let upstream_port = find_free_port();
-        let proxy_port = find_free_port();
+        let _nix_serve = start_nix_serve(&paths.nix_serve, &cache_dir, upstream_port)?;
 
-        let nix_serve = start_nix_serve(&paths.nix_serve, &cache_dir, upstream_port)?;
-        let selector4nix =
-            start_selector4nix(&paths.selector4nix, &tempdir, upstream_port, proxy_port)?;
-
-        let proxy_base_url = format!("http://127.0.0.1:{proxy_port}");
         let client = Client::builder()
             .timeout(Duration::from_secs(10))
             .build()
             .context("failed to build HTTP client")?;
 
-        let context = Self {
+        Ok(Self {
             _tempdir: tempdir,
-            _nix_serve: nix_serve,
-            _selector4nix: selector4nix,
-            proxy_base_url,
+            _nix_serve,
+            upstream_port,
             client,
             fixtures,
-        };
-
-        context.wait_ready().await?;
-        Ok(context)
+            selector4nix_bin: paths.selector4nix.clone(),
+            proxy_counter: 0,
+        })
     }
 
-    pub fn proxy_base_url(&self) -> &str {
-        &self.proxy_base_url
+    pub async fn start_proxy(&mut self) -> AnyhowResult<ProxyInstance> {
+        let proxy_port = find_free_port();
+        let config_name = format!("selector4nix-{}.toml", self.proxy_counter);
+        self.proxy_counter += 1;
+
+        let config_path = self._tempdir.path().join(&config_name);
+        let config_content = format!(
+            r#"[server]
+ip = "127.0.0.1"
+port = {proxy_port}
+
+[network]
+periodic_probing = false
+
+[[substituters]]
+url = "http://127.0.0.1:{upstream_port}/"
+"#,
+            upstream_port = self.upstream_port,
+        );
+        std::fs::write(&config_path, &config_content).context("failed to write config")?;
+
+        let child = Command::new(&self.selector4nix_bin)
+            .args(["--config-file", &config_path.to_string_lossy()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("failed to spawn `selector4nix`")?;
+
+        let proxy_base_url = format!("http://127.0.0.1:{proxy_port}");
+
+        wait_ready(&self.client, &proxy_base_url).await?;
+
+        Ok(ProxyInstance {
+            _guard: SubprocessGuard { child },
+            proxy_base_url,
+        })
     }
 
     pub fn client(&self) -> &Client {
@@ -78,41 +111,40 @@ impl TestContext {
     pub fn fixtures(&self) -> &TestFixtures {
         &self.fixtures
     }
+}
 
-    async fn wait_ready(&self) -> AnyhowResult<()> {
-        let start = Instant::now();
-        let url = format!("{}/nix-cache-info", self.proxy_base_url);
-        loop {
-            match self.client.get(&url).send().await {
-                Ok(response) if response.status().is_success() => return Ok(()),
-                _ => {
-                    if start.elapsed() > READINESS_TIMEOUT {
-                        bail!("`selector4nix` did not become ready within {READINESS_TIMEOUT:?}");
-                    }
-                    tokio::time::sleep(POLL_INTERVAL).await;
+impl ProxyInstance {
+    pub fn proxy_base_url(&self) -> &str {
+        &self.proxy_base_url
+    }
+}
+
+async fn wait_ready(client: &Client, proxy_base_url: &str) -> AnyhowResult<()> {
+    let start = Instant::now();
+    let url = format!("{proxy_base_url}/nix-cache-info");
+    loop {
+        match client.get(&url).send().await {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            _ => {
+                if start.elapsed() > READINESS_TIMEOUT {
+                    bail!("`selector4nix` did not become ready within {READINESS_TIMEOUT:?}");
                 }
+                tokio::time::sleep(POLL_INTERVAL).await;
             }
         }
     }
 }
-
-const TEST_FILES: &[(&str, &[u8])] = &[
-    ("hello.txt", b"Hello, system test!"),
-    ("empty.txt", b""),
-    ("multiline.txt", b"line one\nline two\nline three\n"),
-    ("binary.dat", &[0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD]),
-    ("unicode.txt", "系统测试 🦀\n".as_bytes()),
-];
 
 fn populate_cache(
     fixtures: &mut TestFixtures,
     cache_dir: &Path,
     nix_bin: &Path,
 ) -> AnyhowResult<()> {
-    for (name, content) in TEST_FILES {
-        let file_path = cache_dir.join(format!("input-{name}"));
+    let contents: Vec<Vec<u8>> = fixtures.contents().to_vec();
+    for (i, content) in contents.into_iter().enumerate() {
+        let file_path = cache_dir.join(format!("input-{i}"));
         std::fs::write(&file_path, content)
-            .with_context(|| format!("failed to write test file `{name}`"))?;
+            .with_context(|| format!("failed to write test file `{i}`"))?;
 
         let store_uri = format!("file://{}?compression=none", cache_dir.display());
         let output = Command::new(nix_bin)
@@ -120,11 +152,11 @@ fn populate_cache(
             .arg(&file_path)
             .env("NIX_CONFIG", "experimental-features = nix-command")
             .output()
-            .with_context(|| format!("failed to spawn `nix store add-file` for `{name}`"))?;
+            .with_context(|| format!("failed to spawn `nix store add-file` for file `{i}`"))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("`nix store add-file` failed for {name}: {stderr}");
+            bail!("`nix store add-file` failed for file `{i}`: {stderr}");
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -134,7 +166,7 @@ fn populate_cache(
             .and_then(|s| s.split_once('-'))
             .map(|(h, _)| h)
             .context(format!(
-                "unexpected `nix store add-file` output for {name}: {store_path}"
+                "unexpected `nix store add-file` output for file `{i}`: {store_path}"
             ))?;
 
         fixtures.add_populated(hash.to_string());
@@ -162,37 +194,6 @@ fn start_nix_serve(
         .stderr(Stdio::null())
         .spawn()
         .context("failed to spawn `nix-serve`")?;
-
-    Ok(SubprocessGuard { child })
-}
-
-fn start_selector4nix(
-    selector4nix_bin: &Path,
-    tempdir: &TempDir,
-    upstream_port: u16,
-    proxy_port: u16,
-) -> AnyhowResult<SubprocessGuard> {
-    let config_content = format!(
-        r#"[server]
-ip = "127.0.0.1"
-port = {proxy_port}
-
-[network]
-periodic_probing = false
-
-[[substituters]]
-url = "http://127.0.0.1:{upstream_port}/"
-"#,
-    );
-    let config_path = tempdir.path().join("selector4nix.toml");
-    std::fs::write(&config_path, &config_content).context("failed to write config")?;
-
-    let child = Command::new(selector4nix_bin)
-        .args(["--config-file", &config_path.to_string_lossy()])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .context("failed to spawn `selector4nix`")?;
 
     Ok(SubprocessGuard { child })
 }

--- a/tests/system/nar-info-querying/src/fixture.rs
+++ b/tests/system/nar-info-querying/src/fixture.rs
@@ -1,22 +1,31 @@
+use fastrand::Rng;
+
 pub struct PopulatedFile {
     pub hash: String,
 }
 
 pub struct TestFixtures {
+    contents: Vec<Vec<u8>>,
     populated: Vec<PopulatedFile>,
 }
 
-pub const INVALID_HASH: &str = "00000000000000000000000000000000";
-
 impl TestFixtures {
-    pub fn new() -> Self {
+    pub fn new(count: usize, seed: u64) -> Self {
+        let mut rng = Rng::with_seed(seed);
+        let mut contents = Vec::with_capacity(count);
+
+        for i in 0..count {
+            contents.push(generate_content(i, count, &mut rng));
+        }
+
         Self {
+            contents,
             populated: Vec::new(),
         }
     }
 
-    pub fn populated(&self) -> &[PopulatedFile] {
-        &self.populated
+    pub fn contents(&self) -> &[Vec<u8>] {
+        &self.contents
     }
 
     pub fn add_populated(&mut self, hash: String) {
@@ -26,4 +35,35 @@ impl TestFixtures {
     pub fn valid_hashes(&self) -> Vec<&str> {
         self.populated.iter().map(|p| p.hash.as_str()).collect()
     }
+}
+
+fn generate_content(index: usize, total: usize, rng: &mut Rng) -> Vec<u8> {
+    if index == 0 {
+        return Vec::new();
+    }
+    if index == 1 {
+        return b"\x00\x01\x02\x03\x04\x05\x06\x07".to_vec();
+    }
+
+    let size_bucket = index * 4 / total;
+    match size_bucket {
+        0 => random_bytes(rng.usize(1..100), rng),
+        1 => random_bytes(rng.usize(100..1_000), rng),
+        2 => random_bytes(rng.usize(1_000..50_000), rng),
+        _ => random_bytes(rng.usize(50_000..500_000), rng),
+    }
+}
+
+fn random_bytes(len: usize, rng: &mut Rng) -> Vec<u8> {
+    (0..len).map(|_| rng.u8(..)).collect()
+}
+
+pub fn generate_invalid_hash(rng: &mut Rng) -> String {
+    const NIX_BASE32: &[u8] = b"0123456789abcdfghijklmnpqrsvwxyz";
+    (0..32)
+        .map(|_| {
+            let idx = rng.usize(..NIX_BASE32.len());
+            NIX_BASE32[idx] as char
+        })
+        .collect()
 }

--- a/tests/system/nar-info-querying/src/fixture.rs
+++ b/tests/system/nar-info-querying/src/fixture.rs
@@ -1,0 +1,29 @@
+pub struct PopulatedFile {
+    pub hash: String,
+}
+
+pub struct TestFixtures {
+    populated: Vec<PopulatedFile>,
+}
+
+pub const INVALID_HASH: &str = "00000000000000000000000000000000";
+
+impl TestFixtures {
+    pub fn new() -> Self {
+        Self {
+            populated: Vec::new(),
+        }
+    }
+
+    pub fn populated(&self) -> &[PopulatedFile] {
+        &self.populated
+    }
+
+    pub fn add_populated(&mut self, hash: String) {
+        self.populated.push(PopulatedFile { hash });
+    }
+
+    pub fn valid_hashes(&self) -> Vec<&str> {
+        self.populated.iter().map(|p| p.hash.as_str()).collect()
+    }
+}

--- a/tests/system/nar-info-querying/src/main.rs
+++ b/tests/system/nar-info-querying/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    todo!("system test implementation")
+}

--- a/tests/system/nar-info-querying/src/main.rs
+++ b/tests/system/nar-info-querying/src/main.rs
@@ -1,3 +1,111 @@
-fn main() {
-    todo!("system test implementation")
+mod assertions;
+mod cli;
+mod context;
+mod fixture;
+
+use anyhow::{Context, Result as AnyhowResult};
+
+use assertions::*;
+use context::TestContext;
+use fixture::INVALID_HASH;
+
+use crate::fixture::TestFixtures;
+
+#[tokio::main]
+async fn main() -> AnyhowResult<()> {
+    let paths = cli::resolve()?;
+    let fixtures = TestFixtures::new();
+    let context = TestContext::init(fixtures, &paths).await?;
+
+    single_nar_info_fetch(&context).await?;
+    eprintln!("testcase `single_nar_info_fetch`: ok");
+    batch_nar_info_fetch(&context).await?;
+    eprintln!("testcase `batch_nar_info_fetch`: ok");
+    not_found_nar_info(&context).await?;
+    eprintln!("testcase `not_found_nar_info`: ok");
+    cached_nar_info(&context).await?;
+    eprintln!("testcase `cached_nar_info`: ok");
+    batch_mixed(&context).await?;
+    eprintln!("testcase `batch_mixed`: ok");
+
+    eprintln!("all testcases passed");
+    Ok(())
+}
+
+async fn single_nar_info_fetch(context: &TestContext) -> AnyhowResult<()> {
+    let hash = context.fixtures().populated()[0].hash.as_str();
+    let response = fetch_nar_info(context.client(), context.proxy_base_url(), hash).await?;
+    assert_nar_info_ok(response, hash)
+        .await
+        .context("`single_nar_info_fetch` failed")
+}
+
+async fn batch_nar_info_fetch(context: &TestContext) -> AnyhowResult<()> {
+    let hashes = context.fixtures().valid_hashes();
+    let mut tasks = Vec::with_capacity(hashes.len());
+
+    for hash in &hashes {
+        let client = context.client().clone();
+        let base_url = context.proxy_base_url().to_string();
+        let hash = hash.to_string();
+        tasks.push(tokio::spawn(async move {
+            let response = fetch_nar_info(&client, &base_url, &hash).await?;
+            assert_nar_info_ok(response, &hash).await
+        }));
+    }
+
+    for task in tasks {
+        task.await
+            .context("batch task panicked")?
+            .context("`batch_nar_info_fetch` failed")?;
+    }
+    Ok(())
+}
+
+async fn not_found_nar_info(context: &TestContext) -> AnyhowResult<()> {
+    let response = fetch_nar_info(context.client(), context.proxy_base_url(), INVALID_HASH).await?;
+    assert_nar_info_not_found(response, INVALID_HASH)
+        .await
+        .context("`not_found_nar_info` failed")
+}
+
+async fn cached_nar_info(context: &TestContext) -> AnyhowResult<()> {
+    let hash = context.fixtures().populated()[0].hash.as_str();
+
+    let response1 = fetch_nar_info(context.client(), context.proxy_base_url(), hash).await?;
+    assert_nar_info_ok(response1, hash).await?;
+
+    let response2 = fetch_nar_info(context.client(), context.proxy_base_url(), hash).await?;
+    assert_nar_info_ok(response2, hash).await?;
+
+    Ok(())
+}
+
+async fn batch_mixed(context: &TestContext) -> AnyhowResult<()> {
+    let valid_hash = context.fixtures().populated()[0].hash.clone();
+    let invalid_hash = INVALID_HASH.to_string();
+    let client = context.client().clone();
+    let base_url = context.proxy_base_url().to_string();
+
+    let valid_client = client.clone();
+    let valid_base_url = base_url.clone();
+    let valid_task = tokio::spawn(async move {
+        let response = fetch_nar_info(&valid_client, &valid_base_url, &valid_hash).await?;
+        assert_nar_info_ok(response, &valid_hash).await
+    });
+
+    let invalid_task = tokio::spawn(async move {
+        let response = fetch_nar_info(&client, &base_url, &invalid_hash).await?;
+        assert_nar_info_not_found(response, &invalid_hash).await
+    });
+
+    valid_task
+        .await
+        .context("valid task panicked")?
+        .context("valid hash case failed")?;
+    invalid_task
+        .await
+        .context("invalid task panicked")?
+        .context("invalid hash case failed")?;
+    Ok(())
 }

--- a/tests/system/nar-info-querying/src/main.rs
+++ b/tests/system/nar-info-querying/src/main.rs
@@ -3,50 +3,149 @@ mod cli;
 mod context;
 mod fixture;
 
+use std::collections::HashSet;
+
 use anyhow::{Context, Result as AnyhowResult};
 
 use assertions::*;
-use context::TestContext;
-use fixture::INVALID_HASH;
-
-use crate::fixture::TestFixtures;
+use context::{ProxyInstance, SharedContext};
+use fastrand::Rng;
+use fixture::TestFixtures;
 
 #[tokio::main]
 async fn main() -> AnyhowResult<()> {
     let paths = cli::resolve()?;
-    let fixtures = TestFixtures::new();
-    let context = TestContext::init(fixtures, &paths).await?;
+    let count = paths.count;
+    let seed = paths.seed;
+    let repeat = paths.repeat;
 
-    single_nar_info_fetch(&context).await?;
-    eprintln!("testcase `single_nar_info_fetch`: ok");
-    batch_nar_info_fetch(&context).await?;
-    eprintln!("testcase `batch_nar_info_fetch`: ok");
-    not_found_nar_info(&context).await?;
-    eprintln!("testcase `not_found_nar_info`: ok");
-    cached_nar_info(&context).await?;
-    eprintln!("testcase `cached_nar_info`: ok");
-    batch_mixed(&context).await?;
-    eprintln!("testcase `batch_mixed`: ok");
+    let fixtures = TestFixtures::new(count, seed);
+    let mut shared = SharedContext::init(fixtures, &paths)?;
+    eprintln!("shared context ready. populated {count} files (seed=`{seed}`, repeat=`{repeat}`)");
+
+    let mut seed_index = 0usize;
+
+    for r in 0..repeat {
+        let testcase_seed = derive_seed(seed, seed_index);
+        eprintln!("testcase `valid_hash_returns_narinfo` [{r}] (seed=`{testcase_seed}`)");
+        let proxy = shared.start_proxy().await?;
+        valid_hash_returns_narinfo(&shared, &proxy).await?;
+        seed_index += 1;
+    }
+
+    for r in 0..repeat {
+        let testcase_seed = derive_seed(seed, seed_index);
+        eprintln!("testcase `invalid_hash_returns_404` [{r}] (seed=`{testcase_seed}`)");
+        let proxy = shared.start_proxy().await?;
+        let mut rng = Rng::with_seed(testcase_seed);
+        invalid_hash_returns_404(&shared, &proxy, &mut rng).await?;
+        seed_index += 1;
+    }
+
+    for r in 0..repeat {
+        let testcase_seed = derive_seed(seed, seed_index);
+        eprintln!("testcase `same_hash_idempotent` [{r}] (seed=`{testcase_seed}`)");
+        let proxy = shared.start_proxy().await?;
+        let mut rng = Rng::with_seed(testcase_seed);
+        same_hash_idempotent(&shared, &proxy, &mut rng).await?;
+        seed_index += 1;
+    }
+
+    for r in 0..repeat {
+        let testcase_seed = derive_seed(seed, seed_index);
+        eprintln!("testcase `concurrent_fetches_correct` [{r}] (seed=`{testcase_seed}`)");
+        let proxy = shared.start_proxy().await?;
+        concurrent_fetches_correct(&shared, &proxy).await?;
+        seed_index += 1;
+    }
+
+    for r in 0..repeat {
+        let testcase_seed = derive_seed(seed, seed_index);
+        eprintln!("testcase `mixed_valid_invalid` [{r}] (seed=`{testcase_seed}`)");
+        let proxy = shared.start_proxy().await?;
+        let mut rng = Rng::with_seed(testcase_seed);
+        mixed_valid_invalid(&shared, &proxy, &mut rng).await?;
+        seed_index += 1;
+    }
 
     eprintln!("all testcases passed");
     Ok(())
 }
 
-async fn single_nar_info_fetch(context: &TestContext) -> AnyhowResult<()> {
-    let hash = context.fixtures().populated()[0].hash.as_str();
-    let response = fetch_nar_info(context.client(), context.proxy_base_url(), hash).await?;
-    assert_nar_info_ok(response, hash)
-        .await
-        .context("`single_nar_info_fetch` failed")
+fn derive_seed(base: u64, index: usize) -> u64 {
+    Rng::with_seed(base).u64(..).wrapping_add(index as u64)
 }
 
-async fn batch_nar_info_fetch(context: &TestContext) -> AnyhowResult<()> {
-    let hashes = context.fixtures().valid_hashes();
+async fn valid_hash_returns_narinfo(
+    shared: &SharedContext,
+    proxy: &ProxyInstance,
+) -> AnyhowResult<()> {
+    for hash in shared.fixtures().valid_hashes() {
+        let response = fetch_nar_info(shared.client(), proxy.proxy_base_url(), hash).await?;
+        assert_nar_info_ok(response, hash)
+            .await
+            .with_context(|| format!("`hash={hash}`"))?;
+    }
+    Ok(())
+}
+
+async fn invalid_hash_returns_404(
+    shared: &SharedContext,
+    proxy: &ProxyInstance,
+    rng: &mut Rng,
+) -> AnyhowResult<()> {
+    let valid_set: HashSet<&str> = shared.fixtures().valid_hashes().into_iter().collect();
+
+    let mut generated = 0;
+    while generated < 100 {
+        let hash = fixture::generate_invalid_hash(rng);
+        if valid_set.contains(hash.as_str()) {
+            continue;
+        }
+        let response = fetch_nar_info(shared.client(), proxy.proxy_base_url(), &hash).await?;
+        assert_nar_info_not_found(response, &hash).await?;
+        generated += 1;
+    }
+    Ok(())
+}
+
+async fn same_hash_idempotent(
+    shared: &SharedContext,
+    proxy: &ProxyInstance,
+    rng: &mut Rng,
+) -> AnyhowResult<()> {
+    let hashes = shared.fixtures().valid_hashes();
+    let sampled = sample_hashes(&hashes, 30, rng);
+
+    for hash in sampled {
+        let response1 = fetch_nar_info(shared.client(), proxy.proxy_base_url(), hash).await?;
+        let body1 = assert_nar_info_ok_get_body(response1, hash).await?;
+
+        let response2 = fetch_nar_info(shared.client(), proxy.proxy_base_url(), hash).await?;
+        let body2 = assert_nar_info_ok_get_body(response2, hash).await?;
+
+        let response3 = fetch_nar_info(shared.client(), proxy.proxy_base_url(), hash).await?;
+        let body3 = assert_nar_info_ok_get_body(response3, hash).await?;
+
+        if body1 != body2 || body2 != body3 {
+            anyhow::bail!(
+                "idempotency violation for `hash={hash}`: responses differ across 3 requests"
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn concurrent_fetches_correct(
+    shared: &SharedContext,
+    proxy: &ProxyInstance,
+) -> AnyhowResult<()> {
+    let hashes = shared.fixtures().valid_hashes();
     let mut tasks = Vec::with_capacity(hashes.len());
 
     for hash in &hashes {
-        let client = context.client().clone();
-        let base_url = context.proxy_base_url().to_string();
+        let client = shared.client().clone();
+        let base_url = proxy.proxy_base_url().to_string();
         let hash = hash.to_string();
         tasks.push(tokio::spawn(async move {
             let response = fetch_nar_info(&client, &base_url, &hash).await?;
@@ -57,55 +156,59 @@ async fn batch_nar_info_fetch(context: &TestContext) -> AnyhowResult<()> {
     for task in tasks {
         task.await
             .context("batch task panicked")?
-            .context("`batch_nar_info_fetch` failed")?;
+            .context("`concurrent_fetches_correct` failed")?;
     }
     Ok(())
 }
 
-async fn not_found_nar_info(context: &TestContext) -> AnyhowResult<()> {
-    let response = fetch_nar_info(context.client(), context.proxy_base_url(), INVALID_HASH).await?;
-    assert_nar_info_not_found(response, INVALID_HASH)
-        .await
-        .context("`not_found_nar_info` failed")
-}
+async fn mixed_valid_invalid(
+    shared: &SharedContext,
+    proxy: &ProxyInstance,
+    rng: &mut Rng,
+) -> AnyhowResult<()> {
+    let valid_hashes = shared.fixtures().valid_hashes();
+    let valid_set: HashSet<&str> = valid_hashes.iter().copied().collect();
+    let total = 200;
+    let mut tasks = Vec::with_capacity(total);
 
-async fn cached_nar_info(context: &TestContext) -> AnyhowResult<()> {
-    let hash = context.fixtures().populated()[0].hash.as_str();
+    for _ in 0..total {
+        let is_valid = rng.bool();
+        let client = shared.client().clone();
+        let base_url = proxy.proxy_base_url().to_string();
 
-    let response1 = fetch_nar_info(context.client(), context.proxy_base_url(), hash).await?;
-    assert_nar_info_ok(response1, hash).await?;
+        if is_valid {
+            let hash = valid_hashes[rng.usize(..valid_hashes.len())].to_string();
+            tasks.push(tokio::spawn(async move {
+                let response = fetch_nar_info(&client, &base_url, &hash).await?;
+                assert_nar_info_ok(response, &hash).await
+            }));
+        } else {
+            let mut hash = fixture::generate_invalid_hash(rng);
+            while valid_set.contains(hash.as_str()) {
+                hash = fixture::generate_invalid_hash(rng);
+            }
+            tasks.push(tokio::spawn(async move {
+                let response = fetch_nar_info(&client, &base_url, &hash).await?;
+                assert_nar_info_not_found(response, &hash).await
+            }));
+        }
+    }
 
-    let response2 = fetch_nar_info(context.client(), context.proxy_base_url(), hash).await?;
-    assert_nar_info_ok(response2, hash).await?;
-
+    for task in tasks {
+        task.await
+            .context("mixed task panicked")?
+            .context("`mixed_valid_invalid` failed")?;
+    }
     Ok(())
 }
 
-async fn batch_mixed(context: &TestContext) -> AnyhowResult<()> {
-    let valid_hash = context.fixtures().populated()[0].hash.clone();
-    let invalid_hash = INVALID_HASH.to_string();
-    let client = context.client().clone();
-    let base_url = context.proxy_base_url().to_string();
-
-    let valid_client = client.clone();
-    let valid_base_url = base_url.clone();
-    let valid_task = tokio::spawn(async move {
-        let response = fetch_nar_info(&valid_client, &valid_base_url, &valid_hash).await?;
-        assert_nar_info_ok(response, &valid_hash).await
-    });
-
-    let invalid_task = tokio::spawn(async move {
-        let response = fetch_nar_info(&client, &base_url, &invalid_hash).await?;
-        assert_nar_info_not_found(response, &invalid_hash).await
-    });
-
-    valid_task
-        .await
-        .context("valid task panicked")?
-        .context("valid hash case failed")?;
-    invalid_task
-        .await
-        .context("invalid task panicked")?
-        .context("invalid hash case failed")?;
-    Ok(())
+fn sample_hashes<'a>(pool: &[&'a str], n: usize, rng: &mut Rng) -> Vec<&'a str> {
+    let n = n.min(pool.len());
+    let mut indices: Vec<usize> = (0..pool.len()).collect();
+    let len = indices.len();
+    for i in (1..len).rev() {
+        let j = rng.usize(..=i);
+        indices.swap(i, j);
+    }
+    indices[..n].iter().map(|&i| pool[i]).collect()
 }


### PR DESCRIPTION
Add a system test for NAR info querying. The test is organized as a separated crate and requires some additional setup to run. In summary, the test spawns a `nix-serve-ng` server, populates a temporary Nix store with randomly generated files using `nix` command, and finally runs dedicated `selector4nix` instance per-testcase, which sends also randomly generated requests to that instance concurrently and asserts the responses.