### PR TITLE
Update rust toolchain to 1.95.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ See [Configuration](#configuration) above for details.
 
 ### Cargo
 
-`selector4nix` uses the Rust 2024 edition, which requires Rust 1.85 or later. The toolchain is pinned to 1.93.1 via `rust-toolchain.toml`.
+`selector4nix` uses the Rust 2024 edition, which requires Rust 1.85 or later. The toolchain is pinned to 1.95.0 via `rust-toolchain.toml`.
 
 ```sh
 cargo build --release

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -5,7 +5,3 @@ builds:
     - devShell.aarch64-darwin
     - packages.x86_64-linux.selector4nix
     - packages.aarch64-darwin.selector4nix
-    - packages.x86_64-linux.selector4nix-static
-    # - packages.aarch64-darwin.selector4nix-static # Broken
-    - packages.x86_64-linux.rust-toolchain
-    - packages.aarch64-darwin.rust-toolchain

--- a/nix/flake/devshell.nix
+++ b/nix/flake/devshell.nix
@@ -9,7 +9,7 @@
     {
       devShells.default = pkgs.mkShellNoCC {
         packages = [
-          config.packages.rust-toolchain
+          (pkgs.rust-bin.fromRustupToolchainFile ./../../rust-toolchain.toml)
           pkgs.nix-serve-ng
           pkgs.nixfmt
           pkgs.nixfmt-tree

--- a/nix/flake/package.nix
+++ b/nix/flake/package.nix
@@ -20,18 +20,8 @@
 
       packages = {
         default = config.packages.selector4nix;
-
-        selector4nix = pkgs.callPackage ../package.nix {
-          rustPlatform = pkgs.makeRustPlatform {
-            cargo = config.packages.rust-toolchain;
-            rustc = config.packages.rust-toolchain;
-          };
-        };
-
-        # Build statically linked artifact with `rust-overlay` is broken.
+        selector4nix = pkgs.callPackage ../package.nix { };
         selector4nix-static = pkgs.pkgsStatic.callPackage ../package.nix { };
-
-        rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./../../rust-toolchain.toml;
       };
 
       legacyPackages = config.packages;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 profile = "default"
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["rustc", "cargo", "clippy", "rust-analyzer", "rust-docs", "rust-src", "rustfmt"]


### PR DESCRIPTION
Bump Rust to 1.95.0. To prevent the whole Rust toolchain from being included in the `selector4nix`'s closure, This PR uses the `rustPlatform` from nixpkgs rather than building it with `rust-overlay`.