### PR TITLE
Fix no read permission for credential file when running as systemd dynamic user service

### DIFF
--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -34,7 +34,11 @@ in
             "RUST_LOG=selector4nix=${cfg.logLevel}"
           ]
           ++ lib.optionals (cfg.credentialFile != null) [
-            "SELECTOR4NIX_CREDENTIAL_FILE=${cfg.credentialFile}"
+            "SELECTOR4NIX_CREDENTIAL_FILE=%d/credentials.toml"
+          ];
+
+          LoadCredential = lib.optionals (cfg.credentialFile != null) [
+            "credentials.toml:${cfg.credentialFile}"
           ];
 
           Restart = "on-failure";


### PR DESCRIPTION
When `selector4nix` is running as a systemd dynamic user service, it has no read permission for those credential files owned by other users. The NixOS module for `selector4nix` should explicitly use systemd's `LoadCredential` option to provide the desired credential file.