### PR TITLE
Use explicit expiry management for NAR info

### DIFF
--- a/src/application/nar_info/actor/runner.rs
+++ b/src/application/nar_info/actor/runner.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use selector4nix_actor::actor::{Actor, ActorPre, ActorPreBuilder, Context, EmptyInternal};
 use tokio::sync::oneshot::Sender as OneshotSender;
 
+use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::nar_info::model::{NarInfo, ProxyNarInfoData};
 use crate::domain::nar_info::{NarInfoService, ResolveNarInfoError, ResolveNarInfoEvent};
 
@@ -30,14 +32,20 @@ pub struct NarInfoActor {
     init: Option<NarInfo>,
     context: Context<NarInfoRequest, EmptyInternal>,
     nar_info_service: Arc<NarInfoService>,
+    nar_info_ttl: Duration,
 }
 
 impl NarInfoActor {
-    pub fn new(init: NarInfo, nar_info_service: Arc<NarInfoService>) -> ActorPre<Self> {
+    pub fn new(
+        init: NarInfo,
+        nar_info_service: Arc<NarInfoService>,
+        nar_info_ttl: Duration,
+    ) -> ActorPre<Self> {
         ActorPreBuilder::inject(|context| Self {
             init: Some(init),
             context,
             nar_info_service,
+            nar_info_ttl,
         })
     }
 
@@ -46,6 +54,8 @@ impl NarInfoActor {
         nar: NarInfo,
         reply_to: OneshotSender<ResolveNarInfoResponse>,
     ) -> NarInfo {
+        let nar = nar.check_expiry_and_update(SystemTime::now());
+
         if let Some(resolution) = nar.resolution() {
             let res = Ok(resolution.nar_info().cloned());
             let _ = reply_to.send(ResolveNarInfoResponse::new(res, Vec::new()));
@@ -56,7 +66,8 @@ impl NarInfoActor {
         match res {
             Ok(resolution) => {
                 let res = Ok(resolution.nar_info().cloned());
-                let nar = nar.on_resolved(resolution);
+                let expire_at = ExpireAt::since(SystemTime::now(), self.nar_info_ttl);
+                let nar = nar.on_resolved(resolution, expire_at);
                 let _ = reply_to.send(ResolveNarInfoResponse::new(res, events));
                 nar
             }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -205,10 +205,14 @@ pub async fn init_context(
             .expiration(ExpirationOption::Ttl(config.cache.nar_info_lookup_ttl))
             .factory(AsyncFactory::new({
                 let nar_info_service = nar_info_service.clone();
+                let nar_info_ttl = config.cache.nar_info_lookup_ttl;
                 move |hash: &StorePathHash| {
-                    let addr =
-                        NarInfoActor::new(NarInfo::new(hash.clone()), nar_info_service.clone())
-                            .run();
+                    let addr = NarInfoActor::new(
+                        NarInfo::new(hash.clone()),
+                        nar_info_service.clone(),
+                        nar_info_ttl,
+                    )
+                    .run();
                     async move { addr }
                 }
             }))

--- a/src/domain/common/expire_at.rs
+++ b/src/domain/common/expire_at.rs
@@ -1,0 +1,27 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ExpireAt(u64);
+
+impl ExpireAt {
+    pub fn new(time: SystemTime) -> Self {
+        let unix_timestamp = time
+            .duration_since(UNIX_EPOCH)
+            .expect("`UNIX_EPOCH` should be earlier than any other system time")
+            .as_secs();
+        Self(unix_timestamp)
+    }
+
+    pub fn since(created_at: SystemTime, ttl: Duration) -> Self {
+        Self::new(created_at + ttl)
+    }
+
+    pub fn unix_timpstamp(&self) -> u64 {
+        self.0
+    }
+
+    pub fn has_expired(&self, now: SystemTime) -> bool {
+        let expire_at = UNIX_EPOCH + Duration::from_secs(self.unix_timpstamp());
+        expire_at <= now
+    }
+}

--- a/src/domain/common/mod.rs
+++ b/src/domain/common/mod.rs
@@ -1,1 +1,2 @@
+pub mod expire_at;
 pub mod url;

--- a/src/domain/nar_info/model/mod.rs
+++ b/src/domain/nar_info/model/mod.rs
@@ -1,11 +1,13 @@
 mod nar_file_name;
 mod nar_info;
+mod nar_info_resolution;
 mod proxy_nar_info_data;
 mod store_path_hash;
 mod upstream_nar_info_data;
 
 pub use nar_file_name::{NarFileName, TryNewNarFileNameError};
-pub use nar_info::{NarInfo, NarInfoResolution, NarUrlRewriteOption};
+pub use nar_info::NarInfo;
+pub use nar_info_resolution::{NarInfoResolution, NarUrlRewriteOption};
 pub use proxy_nar_info_data::ProxyNarInfoData;
 pub use store_path_hash::{StorePathHash, TryNewStorePathHashError};
 pub use upstream_nar_info_data::{TryUpstreamNewNarInfoData, UpstreamNarInfoData};

--- a/src/domain/nar_info/model/nar_info.rs
+++ b/src/domain/nar_info/model/nar_info.rs
@@ -1,74 +1,16 @@
+use std::time::SystemTime;
+
 use getset::Getters;
 
+use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::common::url::Url;
-use crate::domain::nar_info::model::{ProxyNarInfoData, StorePathHash, UpstreamNarInfoData};
-use crate::domain::substituter::model::SubstituterMeta;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NarInfoResolution {
-    Resolved {
-        nar_info: ProxyNarInfoData,
-        substituter: SubstituterMeta,
-        source_url: Url,
-    },
-    NotFound,
-}
-
-impl NarInfoResolution {
-    pub fn from_completed_query(
-        successful_outcome: Option<(UpstreamNarInfoData, SubstituterMeta)>,
-        rewrite_nar_url: NarUrlRewriteOption,
-    ) -> Self {
-        match successful_outcome {
-            Some((nar_info, substituter)) => {
-                let (nar_info, source_url) = match rewrite_nar_url {
-                    NarUrlRewriteOption::Keep => {
-                        ProxyNarInfoData::proxy_by_keep_url(&nar_info, &substituter)
-                    }
-                    NarUrlRewriteOption::ToSelf => {
-                        ProxyNarInfoData::proxy_by_rewrite_url_to_self(&nar_info, &substituter)
-                    }
-                    NarUrlRewriteOption::ToUpstream => {
-                        ProxyNarInfoData::proxy_by_rewrite_url_to_upstream(&nar_info, &substituter)
-                    }
-                };
-                Self::Resolved {
-                    nar_info,
-                    substituter,
-                    source_url,
-                }
-            }
-            None => Self::NotFound,
-        }
-    }
-
-    pub fn nar_info(&self) -> Option<&ProxyNarInfoData> {
-        match self {
-            Self::Resolved { nar_info, .. } => Some(nar_info),
-            _ => None,
-        }
-    }
-
-    pub fn source_url(&self) -> Option<&Url> {
-        match self {
-            Self::Resolved { source_url, .. } => Some(source_url),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NarUrlRewriteOption {
-    Keep,
-    ToSelf,
-    ToUpstream,
-}
+use crate::domain::nar_info::model::{NarInfoResolution, ProxyNarInfoData, StorePathHash};
 
 #[derive(Debug, Clone, PartialEq, Eq, Getters)]
 pub struct NarInfo {
     #[getset(get = "pub")]
     hash: StorePathHash,
-    resolution: Option<NarInfoResolution>,
+    resolution: Option<(NarInfoResolution, ExpireAt)>,
 }
 
 impl NarInfo {
@@ -79,13 +21,17 @@ impl NarInfo {
         }
     }
 
-    pub fn on_resolved(mut self, resolution: NarInfoResolution) -> Self {
-        self.resolution = Some(resolution);
+    pub fn on_resolved(mut self, resolution: NarInfoResolution, expire_at: ExpireAt) -> Self {
+        self.resolution = Some((resolution, expire_at));
         self
     }
 
     pub fn resolution(&self) -> Option<&NarInfoResolution> {
-        self.resolution.as_ref()
+        self.resolution.as_ref().map(|(r, _)| r)
+    }
+
+    pub fn expire_at(&self) -> Option<ExpireAt> {
+        self.resolution.as_ref().map(|(_, e)| *e)
     }
 
     pub fn nar_info(&self) -> Option<&ProxyNarInfoData> {
@@ -95,11 +41,26 @@ impl NarInfo {
     pub fn source_url(&self) -> Option<&Url> {
         self.resolution().and_then(NarInfoResolution::source_url)
     }
+
+    pub fn check_expiry_and_update(self, now: SystemTime) -> Self {
+        if self.has_expired(now) {
+            Self {
+                hash: self.hash,
+                resolution: None,
+            }
+        } else {
+            self
+        }
+    }
+
+    fn has_expired(&self, now: SystemTime) -> bool {
+        self.expire_at().is_none_or(|e| e.has_expired(now))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::substituter::model::Priority;
+    use std::time::Duration;
 
     use super::*;
 
@@ -107,123 +68,31 @@ mod tests {
         StorePathHash::new("p4pclmv1gyja5kzc26npqpia1qqxrf0l".into()).unwrap()
     }
 
-    fn make_upstream_nar_info_data() -> UpstreamNarInfoData {
-        UpstreamNarInfoData::new(
-            "StorePath: /nix/store/p4pclmv1gyja5kzc26npqpia1qqxrf0l-ruby-2.7.3\n\
-             URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
-                .into(),
-        )
-        .unwrap()
-    }
-
-    fn make_upstream_nar_info_data_with_external_url() -> UpstreamNarInfoData {
-        UpstreamNarInfoData::new(
-            "StorePath: /nix/store/p4pclmv1gyja5kzc26npqpia1qqxrf0l-ruby-2.7.3\n\
-             URL: https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
-                .into(),
-        )
-        .unwrap()
-    }
-
-    fn make_substituter_meta() -> SubstituterMeta {
-        SubstituterMeta::new(
-            Url::new("https://cache.nixos.org").unwrap(),
-            Priority::new(40).unwrap(),
-        )
-    }
-
-    #[test]
-    fn new_succeeds() {
+    fn make_nar_info(expire_at: SystemTime) -> NarInfo {
         let hash = make_hash();
         let nar = NarInfo::new(hash.clone());
-        assert_eq!(nar.hash(), &hash);
-        assert!(nar.resolution().is_none());
+        nar.on_resolved(NarInfoResolution::NotFound, ExpireAt::new(expire_at))
     }
 
     #[test]
-    fn from_completed_query_returns_not_found_given_none() {
-        let resolution = NarInfoResolution::from_completed_query(None, NarUrlRewriteOption::ToSelf);
-        assert!(matches!(resolution, NarInfoResolution::NotFound));
+    fn check_expiry_and_update_changed_to_unknown_given_expired() {
+        let now = SystemTime::now();
+        let expire_at = now - Duration::from_secs(1);
+
+        let nar_info = make_nar_info(expire_at);
+        let nar_info = nar_info.check_expiry_and_update(now);
+
+        assert!(nar_info.resolution().is_none());
     }
 
     #[test]
-    fn from_completed_query_resolves_given_relative_url() {
-        let resolution = NarInfoResolution::from_completed_query(
-            Some((make_upstream_nar_info_data(), make_substituter_meta())),
-            NarUrlRewriteOption::ToSelf,
-        );
+    fn check_expiry_and_update_kept_unchanged_given_not_expired() {
+        let now = SystemTime::now();
+        let expire_at = now + Duration::from_secs(1);
 
-        match resolution {
-            NarInfoResolution::Resolved {
-                nar_info,
-                source_url,
-                ..
-            } => {
-                assert!(nar_info.content().contains(
-                    "URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
-                ));
-                assert_eq!(
-                    source_url.value(),
-                    "https://cache.nixos.org/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
-                );
-            }
-            _ => panic!("expected Resolved"),
-        }
-    }
+        let nar_info = make_nar_info(expire_at);
+        let nar_info = nar_info.check_expiry_and_update(now);
 
-    #[test]
-    fn from_completed_query_resolves_given_external_url_and_rewrite_true() {
-        let resolution = NarInfoResolution::from_completed_query(
-            Some((
-                make_upstream_nar_info_data_with_external_url(),
-                make_substituter_meta(),
-            )),
-            NarUrlRewriteOption::ToSelf,
-        );
-
-        match resolution {
-            NarInfoResolution::Resolved {
-                nar_info,
-                source_url,
-                ..
-            } => {
-                assert!(nar_info.content().contains(
-                    "URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
-                ));
-                assert!(!nar_info.content().contains("https://storage.example.com"));
-                assert_eq!(
-                    source_url.value(),
-                    "https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
-                );
-            }
-            _ => panic!("expected Resolved"),
-        }
-    }
-
-    #[test]
-    fn from_completed_query_preserves_external_url_given_rewrite_false() {
-        let resolution = NarInfoResolution::from_completed_query(
-            Some((
-                make_upstream_nar_info_data_with_external_url(),
-                make_substituter_meta(),
-            )),
-            NarUrlRewriteOption::Keep,
-        );
-
-        match resolution {
-            NarInfoResolution::Resolved {
-                nar_info,
-                source_url,
-                ..
-            } => {
-                assert!(nar_info.content().contains("https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"));
-                assert!(!nar_info.content().contains("URL: nar/"));
-                assert_eq!(
-                    source_url.value(),
-                    "https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
-                );
-            }
-            _ => panic!("expected Resolved"),
-        }
+        assert!(nar_info.resolution().is_some());
     }
 }

--- a/src/domain/nar_info/model/nar_info_resolution.rs
+++ b/src/domain/nar_info/model/nar_info_resolution.rs
@@ -1,0 +1,182 @@
+use crate::domain::common::url::Url;
+use crate::domain::nar_info::model::{ProxyNarInfoData, UpstreamNarInfoData};
+use crate::domain::substituter::model::SubstituterMeta;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NarInfoResolution {
+    Resolved {
+        nar_info: ProxyNarInfoData,
+        substituter: SubstituterMeta,
+        source_url: Url,
+    },
+    NotFound,
+}
+
+impl NarInfoResolution {
+    pub fn from_completed_query(
+        successful_outcome: Option<(UpstreamNarInfoData, SubstituterMeta)>,
+        rewrite_nar_url: NarUrlRewriteOption,
+    ) -> Self {
+        match successful_outcome {
+            Some((nar_info, substituter)) => {
+                let (nar_info, source_url) = match rewrite_nar_url {
+                    NarUrlRewriteOption::Keep => {
+                        ProxyNarInfoData::proxy_by_keep_url(&nar_info, &substituter)
+                    }
+                    NarUrlRewriteOption::ToSelf => {
+                        ProxyNarInfoData::proxy_by_rewrite_url_to_self(&nar_info, &substituter)
+                    }
+                    NarUrlRewriteOption::ToUpstream => {
+                        ProxyNarInfoData::proxy_by_rewrite_url_to_upstream(&nar_info, &substituter)
+                    }
+                };
+                Self::Resolved {
+                    nar_info,
+                    substituter,
+                    source_url,
+                }
+            }
+            None => Self::NotFound,
+        }
+    }
+
+    pub fn nar_info(&self) -> Option<&ProxyNarInfoData> {
+        match self {
+            Self::Resolved { nar_info, .. } => Some(nar_info),
+            Self::NotFound => None,
+        }
+    }
+
+    pub fn source_url(&self) -> Option<&Url> {
+        match self {
+            Self::Resolved { source_url, .. } => Some(source_url),
+            Self::NotFound => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NarUrlRewriteOption {
+    Keep,
+    ToSelf,
+    ToUpstream,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::substituter::model::Priority;
+
+    use super::*;
+
+    fn make_upstream_nar_info_data() -> UpstreamNarInfoData {
+        UpstreamNarInfoData::new(
+            "StorePath: /nix/store/p4pclmv1gyja5kzc26npqpia1qqxrf0l-ruby-2.7.3\n\
+             URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
+                .into(),
+        )
+        .unwrap()
+    }
+
+    fn make_upstream_nar_info_data_with_external_url() -> UpstreamNarInfoData {
+        UpstreamNarInfoData::new(
+            "StorePath: /nix/store/p4pclmv1gyja5kzc26npqpia1qqxrf0l-ruby-2.7.3\n\
+             URL: https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
+                .into(),
+        )
+        .unwrap()
+    }
+
+    fn make_substituter_meta() -> SubstituterMeta {
+        SubstituterMeta::new(
+            Url::new("https://cache.nixos.org").unwrap(),
+            Priority::new(40).unwrap(),
+        )
+    }
+
+    #[test]
+    fn from_completed_query_returns_not_found_given_none() {
+        let resolution = NarInfoResolution::from_completed_query(None, NarUrlRewriteOption::ToSelf);
+        assert!(matches!(resolution, NarInfoResolution::NotFound));
+    }
+
+    #[test]
+    fn from_completed_query_resolves_given_relative_url() {
+        let resolution = NarInfoResolution::from_completed_query(
+            Some((make_upstream_nar_info_data(), make_substituter_meta())),
+            NarUrlRewriteOption::ToSelf,
+        );
+
+        match resolution {
+            NarInfoResolution::Resolved {
+                nar_info,
+                source_url,
+                ..
+            } => {
+                assert!(nar_info.content().contains(
+                    "URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
+                ));
+                assert_eq!(
+                    source_url.value(),
+                    "https://cache.nixos.org/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
+                );
+            }
+            _ => panic!("expected Resolved"),
+        }
+    }
+
+    #[test]
+    fn from_completed_query_resolves_given_external_url_and_rewrite_true() {
+        let resolution = NarInfoResolution::from_completed_query(
+            Some((
+                make_upstream_nar_info_data_with_external_url(),
+                make_substituter_meta(),
+            )),
+            NarUrlRewriteOption::ToSelf,
+        );
+
+        match resolution {
+            NarInfoResolution::Resolved {
+                nar_info,
+                source_url,
+                ..
+            } => {
+                assert!(nar_info.content().contains(
+                    "URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
+                ));
+                assert!(!nar_info.content().contains("https://storage.example.com"));
+                assert_eq!(
+                    source_url.value(),
+                    "https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
+                );
+            }
+            _ => panic!("expected Resolved"),
+        }
+    }
+
+    #[test]
+    fn from_completed_query_preserves_external_url_given_rewrite_false() {
+        let resolution = NarInfoResolution::from_completed_query(
+            Some((
+                make_upstream_nar_info_data_with_external_url(),
+                make_substituter_meta(),
+            )),
+            NarUrlRewriteOption::Keep,
+        );
+
+        match resolution {
+            NarInfoResolution::Resolved {
+                nar_info,
+                source_url,
+                ..
+            } => {
+                assert!(nar_info.content().contains("https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"));
+                assert!(!nar_info.content().contains("URL: nar/"));
+                assert_eq!(
+                    source_url.value(),
+                    "https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
+                );
+            }
+            _ => panic!("expected Resolved"),
+        }
+    }
+}


### PR DESCRIPTION
Add `ExpireAt` domain model and `expire_at` field to `NarInfo`. Explicitly encode `NarInfo`'s expiry management as domain logic to decouple it from actor registry's TTL mechanism.