### PR TITLE
Add in-memory repository for `NarInfo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,7 @@ dependencies = [
  "getset",
  "moka",
  "postcard",
+ "redb",
  "reqwest",
  "selector4nix-actor",
  "selector4nix-db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -282,6 +282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +397,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,7 +430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1095,7 +1116,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1162,6 +1183,18 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1434,7 +1467,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1491,7 +1524,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1585,8 +1618,10 @@ dependencies = [
  "futures",
  "getset",
  "moka",
+ "postcard",
  "reqwest",
  "selector4nix-actor",
+ "selector4nix-db",
  "serde",
  "snafu",
  "tokio",
@@ -1774,7 +1809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1863,7 +1898,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2404,7 +2439,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ fastrand = "2.4.1"
 futures = "0.3.32"
 getset = "0.1.6"
 moka = { version = "0.12.15", features = ["future"] }
+postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
 redb = "4.1.0"
 reqwest = { version = "0.13.2", features = ["stream"] }
 serde = { version = "1.0.228", features = ["derive"] }
@@ -49,6 +50,7 @@ dashmap = { workspace = true }
 futures = { workspace = true }
 getset = { workspace = true }
 moka = { workspace = true }
+postcard = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 snafu = { workspace = true }
@@ -60,3 +62,4 @@ tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
 selector4nix-actor = { path = "components/selector4nix-actor" }
+selector4nix-db = { path = "components/selector4nix-db" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ futures = { workspace = true }
 getset = { workspace = true }
 moka = { workspace = true }
 postcard = { workspace = true }
+redb = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 snafu = { workspace = true }

--- a/components/selector4nix-db/src/cache_kv/kv.rs
+++ b/components/selector4nix-db/src/cache_kv/kv.rs
@@ -28,6 +28,12 @@ impl UnixTimestampArg {
     }
 }
 
+impl From<UnixTimestamp> for UnixTimestampArg {
+    fn from(value: UnixTimestamp) -> Self {
+        Self::Pure(value)
+    }
+}
+
 pub struct CacheKv {
     inner: CacheKvInner,
     last_cleanup: AtomicU64,

--- a/components/selector4nix-db/src/cache_kv/mod.rs
+++ b/components/selector4nix-db/src/cache_kv/mod.rs
@@ -2,6 +2,6 @@ mod inner;
 mod kv;
 
 pub use inner::UnixTimestamp;
-pub use kv::CacheKv;
+pub use kv::{CacheKv, UnixTimestampArg};
 
 use inner::CacheKvInner;

--- a/src/application/nar_info/actor/runner.rs
+++ b/src/application/nar_info/actor/runner.rs
@@ -5,8 +5,10 @@ use selector4nix_actor::actor::{Actor, ActorPre, ActorPreBuilder, Context, Empty
 use tokio::sync::oneshot::Sender as OneshotSender;
 
 use crate::domain::common::expire_at::ExpireAt;
-use crate::domain::nar_info::model::{NarInfo, ProxyNarInfoData};
-use crate::domain::nar_info::{NarInfoService, ResolveNarInfoError, ResolveNarInfoEvent};
+use crate::domain::nar_info::model::{NarInfo, ProxyNarInfoData, StorePathHash};
+use crate::domain::nar_info::{
+    NarInfoRepository, NarInfoService, ResolveNarInfoError, ResolveNarInfoEvent,
+};
 
 #[derive(Debug)]
 pub enum NarInfoRequest {
@@ -29,51 +31,59 @@ impl ResolveNarInfoResponse {
 }
 
 pub struct NarInfoActor {
-    init: Option<NarInfo>,
+    init: Option<StorePathHash>,
     context: Context<NarInfoRequest, EmptyInternal>,
     nar_info_service: Arc<NarInfoService>,
+    nar_info_repository: Arc<dyn NarInfoRepository>,
     nar_info_ttl: Duration,
 }
 
 impl NarInfoActor {
     pub fn new(
-        init: NarInfo,
+        init: StorePathHash,
         nar_info_service: Arc<NarInfoService>,
+        nar_info_repository: Arc<dyn NarInfoRepository>,
         nar_info_ttl: Duration,
     ) -> ActorPre<Self> {
         ActorPreBuilder::inject(|context| Self {
             init: Some(init),
             context,
             nar_info_service,
+            nar_info_repository,
             nar_info_ttl,
         })
     }
 
     async fn handle_request_resolve_nar_info(
         &self,
-        nar: NarInfo,
+        nar_info: NarInfo,
         reply_to: OneshotSender<ResolveNarInfoResponse>,
     ) -> NarInfo {
-        let nar = nar.check_expiry_and_update(SystemTime::now());
+        let nar_info = nar_info.check_expiry_and_update(SystemTime::now());
 
-        if let Some(resolution) = nar.resolution() {
+        if let Some(resolution) = nar_info.resolution() {
             let res = Ok(resolution.nar_info().cloned());
             let _ = reply_to.send(ResolveNarInfoResponse::new(res, Vec::new()));
-            return nar;
+            return nar_info;
         }
 
-        let (res, events) = self.nar_info_service.resolve(nar.hash()).await;
+        let (res, events) = self.nar_info_service.resolve(nar_info.hash()).await;
         match res {
             Ok(resolution) => {
                 let res = Ok(resolution.nar_info().cloned());
                 let expire_at = ExpireAt::since(SystemTime::now(), self.nar_info_ttl);
-                let nar = nar.on_resolved(resolution, expire_at);
+                let nar_info = nar_info.on_resolved(resolution, expire_at);
+
                 let _ = reply_to.send(ResolveNarInfoResponse::new(res, events));
-                nar
+                if let Err(err) = self.nar_info_repository.save(nar_info.clone()).await {
+                    tracing::warn!(hash = %nar_info.hash().value(), %err, "failed to write nar info to persistent cache, ignore");
+                }
+
+                nar_info
             }
             Err(err) => {
                 let _ = reply_to.send(ResolveNarInfoResponse::new(Err(err), events));
-                nar
+                nar_info
             }
         }
     }
@@ -89,7 +99,16 @@ impl Actor for NarInfoActor {
     }
 
     async fn on_start(&mut self) -> Option<Self::State> {
-        self.init.take()
+        let hash = self.init.take()?;
+        let nar_info = match self.nar_info_repository.get(&hash).await {
+            Ok(Some(nar_info)) => nar_info,
+            Ok(None) => NarInfo::new(hash),
+            Err(err) => {
+                tracing::warn!(hash = %hash.value(), %err, "failed to get nar info from persistent cache, ignore and use default");
+                NarInfo::new(hash)
+            }
+        };
+        Some(nar_info)
     }
 
     async fn on_request(

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result as AnyhowResult};
+use redb::Database;
+use redb::backends::InMemoryBackend;
 use reqwest::Client;
 use selector4nix::api::AppContext;
 use selector4nix::application::nar_file::actor::NarFileActor;
@@ -14,7 +16,7 @@ use selector4nix::application::substituter::usecase::SubstituterQueryUseCase;
 use selector4nix::domain::nar_file::NarFileService;
 use selector4nix::domain::nar_file::model::NarFileKey;
 use selector4nix::domain::nar_info::NarInfoService;
-use selector4nix::domain::nar_info::model::{NarInfo, StorePathHash};
+use selector4nix::domain::nar_info::model::StorePathHash;
 use selector4nix::domain::substituter::model::{Availability, Substituter, SubstituterMeta};
 use selector4nix::domain::substituter::{SubstituterRepository, SubstituterService};
 use selector4nix::infrastructure::config::{AppConfiguration, AppCredential};
@@ -24,6 +26,7 @@ use selector4nix_actor::actor::Address;
 use selector4nix_actor::registry::{
     AsyncFactory, CapacityOption, ExpirationOption, RegistryBuilder,
 };
+use selector4nix_db::cache_kv::CacheKv;
 use tokio::sync::Semaphore;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -96,6 +99,8 @@ pub async fn init_context(
     config: &AppConfiguration,
     credentials: Arc<AppCredential>,
 ) -> AnyhowResult<Arc<AppContext>> {
+    let database = Arc::new(Database::builder().create_with_backend(InMemoryBackend::new())?);
+
     let http_client = Client::builder()
         .user_agent(format!(
             "curl/8.7.1 Nix/2.24.11 {}/{}",
@@ -145,6 +150,11 @@ pub async fn init_context(
             substituter_repository.save(sub.clone()).await;
         }
         substituter_repository
+    });
+
+    let nar_info_repository = Arc::new({
+        let cache_kv = Arc::new(CacheKv::new(database.clone(), "nar_info".into()));
+        CacheKvNarInfoRepository::new(cache_kv)
     });
 
     let substituter_service = Arc::new(SubstituterService::new(config.network.periodic_probing));
@@ -205,11 +215,13 @@ pub async fn init_context(
             .expiration(ExpirationOption::Ttl(config.cache.nar_info_lookup_ttl))
             .factory(AsyncFactory::new({
                 let nar_info_service = nar_info_service.clone();
+                let nar_info_repository = nar_info_repository.clone();
                 let nar_info_ttl = config.cache.nar_info_lookup_ttl;
                 move |hash: &StorePathHash| {
                     let addr = NarInfoActor::new(
-                        NarInfo::new(hash.clone()),
+                        hash.clone(),
                         nar_info_service.clone(),
+                        nar_info_repository.clone(),
                         nar_info_ttl,
                     )
                     .run();

--- a/src/domain/common/expire_at.rs
+++ b/src/domain/common/expire_at.rs
@@ -1,6 +1,8 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ExpireAt(u64);
 
 impl ExpireAt {

--- a/src/domain/common/url.rs
+++ b/src/domain/common/url.rs
@@ -1,10 +1,10 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu, ensure};
 use url::{ParseError, Url as UrlInner};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Url(UrlInner);
 
 impl Url {

--- a/src/domain/nar_info/mod.rs
+++ b/src/domain/nar_info/mod.rs
@@ -1,9 +1,11 @@
 pub mod model;
 pub mod port;
 
+mod repository;
 mod service;
 mod util;
 
+pub use repository::NarInfoRepository;
 pub use service::{NarInfoService, ResolveNarInfoError, ResolveNarInfoEvent};
 
 use util::DeadlineGroup;

--- a/src/domain/nar_info/model/nar_file_name.rs
+++ b/src/domain/nar_info/model/nar_file_name.rs
@@ -1,8 +1,9 @@
+use serde::{Deserialize, Serialize};
 use snafu::{Snafu, ensure};
 
 use crate::domain::common::url::Url;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NarFileName(String);
 
 impl NarFileName {

--- a/src/domain/nar_info/model/nar_info.rs
+++ b/src/domain/nar_info/model/nar_info.rs
@@ -1,12 +1,13 @@
 use std::time::SystemTime;
 
 use getset::Getters;
+use serde::{Deserialize, Serialize};
 
 use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::common::url::Url;
 use crate::domain::nar_info::model::{NarInfoResolution, ProxyNarInfoData, StorePathHash};
 
-#[derive(Debug, Clone, PartialEq, Eq, Getters)]
+#[derive(Debug, Clone, PartialEq, Eq, Getters, Serialize, Deserialize)]
 pub struct NarInfo {
     #[getset(get = "pub")]
     hash: StorePathHash,

--- a/src/domain/nar_info/model/nar_info_resolution.rs
+++ b/src/domain/nar_info/model/nar_info_resolution.rs
@@ -1,8 +1,10 @@
+use serde::{Deserialize, Serialize};
+
 use crate::domain::common::url::Url;
 use crate::domain::nar_info::model::{ProxyNarInfoData, UpstreamNarInfoData};
 use crate::domain::substituter::model::SubstituterMeta;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum NarInfoResolution {
     Resolved {
         nar_info: ProxyNarInfoData,

--- a/src/domain/nar_info/model/proxy_nar_info_data.rs
+++ b/src/domain/nar_info/model/proxy_nar_info_data.rs
@@ -1,10 +1,11 @@
 use getset::Getters;
+use serde::{Deserialize, Serialize};
 
 use crate::domain::common::url::Url;
 use crate::domain::nar_info::model::{NarFileName, UpstreamNarInfoData};
 use crate::domain::substituter::model::SubstituterMeta;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters, Serialize, Deserialize)]
 #[getset(get = "pub")]
 pub struct ProxyNarInfoData {
     content: String,

--- a/src/domain/nar_info/model/store_path_hash.rs
+++ b/src/domain/nar_info/model/store_path_hash.rs
@@ -1,9 +1,10 @@
+use serde::{Deserialize, Serialize};
 use snafu::{Snafu, ensure};
 
 use crate::domain::common::url::Url;
 use crate::domain::substituter::model::SubstituterMeta;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorePathHash(String);
 
 impl StorePathHash {

--- a/src/domain/nar_info/repository.rs
+++ b/src/domain/nar_info/repository.rs
@@ -1,0 +1,11 @@
+use anyhow::Result as AnyhowResult;
+use async_trait::async_trait;
+
+use crate::domain::nar_info::model::{NarInfo, StorePathHash};
+
+#[async_trait]
+pub trait NarInfoRepository: Send + Sync {
+    async fn get(&self, hash: &StorePathHash) -> AnyhowResult<Option<NarInfo>>;
+
+    async fn save(&self, nar_info: NarInfo) -> AnyhowResult<()>;
+}

--- a/src/domain/substituter/model/priority.rs
+++ b/src/domain/substituter/model/priority.rs
@@ -1,9 +1,9 @@
 use std::num::NonZeroU32;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, Snafu};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Priority(NonZeroU32);
 
 impl Priority {

--- a/src/domain/substituter/model/substituter_meta.rs
+++ b/src/domain/substituter/model/substituter_meta.rs
@@ -1,13 +1,12 @@
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::Duration;
 
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::domain::common::url::Url;
 use crate::domain::substituter::model::Priority;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 struct SubstituterMetaInner {
     url: Url,
     storage_url: Url,
@@ -16,7 +15,7 @@ struct SubstituterMetaInner {
     nar_timeout: Option<Duration>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SubstituterMeta(Arc<SubstituterMetaInner>);
 
 impl SubstituterMeta {
@@ -79,28 +78,22 @@ impl SubstituterMeta {
     }
 }
 
-impl PartialEq for SubstituterMeta {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl Eq for SubstituterMeta {}
-
-impl Hash for SubstituterMeta {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: Hasher,
-    {
-        self.0.hash(state);
-    }
-}
-
 impl Serialize for SubstituterMeta {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SubstituterMeta {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self(Arc::new(SubstituterMetaInner::deserialize(
+            deserializer,
+        )?)))
     }
 }

--- a/src/infrastructure/repository/mod.rs
+++ b/src/infrastructure/repository/mod.rs
@@ -1,3 +1,5 @@
+mod nar_info;
 mod substituter;
 
+pub use nar_info::CacheKvNarInfoRepository;
 pub use substituter::InMemorySubstituterRepository;

--- a/src/infrastructure/repository/nar_info.rs
+++ b/src/infrastructure/repository/nar_info.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use anyhow::Result as AnyhowResult;
+use async_trait::async_trait;
+use selector4nix_db::cache_kv::{CacheKv, UnixTimestampArg};
+
+use crate::domain::nar_info::NarInfoRepository;
+use crate::domain::nar_info::model::{NarInfo, StorePathHash};
+
+pub struct CacheKvNarInfoRepository {
+    db: Arc<CacheKv>,
+}
+
+impl CacheKvNarInfoRepository {
+    pub fn new(db: Arc<CacheKv>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl NarInfoRepository for CacheKvNarInfoRepository {
+    async fn get(&self, hash: &StorePathHash) -> AnyhowResult<Option<NarInfo>> {
+        let db = Arc::clone(&self.db);
+        let key = postcard::to_stdvec(hash).expect("serialize `hash` to bytes should not fail");
+
+        tokio::task::spawn_blocking(move || {
+            let value = db.get(&key, UnixTimestampArg::SystemNow)?;
+            let entity = value.and_then(|(_, value)| {
+                postcard::from_bytes::<NarInfo>(&value)
+                    .inspect_err(|_| tracing::warn!("encountered data of invalid schema, ignore"))
+                    .ok()
+            });
+            Ok(entity)
+        })
+        .await?
+    }
+
+    async fn save(&self, nar_info: NarInfo) -> AnyhowResult<()> {
+        let Some(expire_at) = nar_info.expire_at() else {
+            return Ok(());
+        };
+
+        let db = Arc::clone(&self.db);
+        let key = postcard::to_stdvec(nar_info.hash())
+            .expect("serialize `nar_info.hash()` to bytes should not fail");
+        let value =
+            postcard::to_stdvec(&nar_info).expect("serialize `nar_info` to bytes should not fail");
+
+        tokio::task::spawn_blocking(move || {
+            let expire_at = expire_at.unix_timpstamp();
+            db.save(&key, &value, expire_at, UnixTimestampArg::SystemNow)
+        })
+        .await?
+    }
+}


### PR DESCRIPTION
Add `NarInfoRepository` trait and `CacheKvNarInfoRepository` implementation. Wire the repository with `NarInfoActor`, which loads `NarInfo` from and persists it to the repository. Currently the repository is only an in-memory database.