### PR TITLE
Add `enablePersistentCaching` option for NixOS/nix-darwin/Home Manager modules

### DIFF
--- a/nix/flake/dev/flake.nix
+++ b/nix/flake/dev/flake.nix
@@ -26,4 +26,3 @@
 
   outputs = inputs: { };
 }
-

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -88,6 +88,13 @@ in
       example = "/path/to/your/credentials.toml";
     };
 
+    enablePersistentCaching = lib.mkOption {
+      type = lib.types.bool;
+      description = "Whether to enable persistent caching";
+      default = false;
+      example = true;
+    };
+
     configureSubstituter = lib.mkOption {
       type = lib.types.enum [
         "keep"

--- a/nix/modules/darwin.nix
+++ b/nix/modules/darwin.nix
@@ -20,7 +20,14 @@ in
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
       launchd.daemons.selector4nix = {
-        command = "${cfg.package}/bin/selector4nix --no-log-timestamp";
+        script =
+          (lib.optionalString cfg.enablePersistentCaching ''
+            mkdir -p /Library/Caches/selector4nix
+            export SELECTOR4NIX_CACHE_DIR=/Library/Caches/selector4nix
+          '')
+          + ''
+            exec ${cfg.package}/bin/selector4nix --no-log-timestamp
+          '';
 
         environment = {
           SELECTOR4NIX_CONFIG_FILE = "${configFile}";

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -49,12 +49,20 @@ in
             Service = {
               Type = "simple";
               ExecStart = "${cfg.package}/bin/selector4nix --no-log-timestamp";
+
               Environment = [
                 "SELECTOR4NIX_CONFIG_FILE=${configFile}"
                 "RUST_LOG=selector4nix=${cfg.logLevel}"
               ]
               ++ lib.optionals (cfg.credentialFile != null) [
                 "SELECTOR4NIX_CREDENTIAL_FILE=${cfg.credentialFile}"
+              ]
+              ++ lib.optionals cfg.enablePersistentCaching [
+                "SELECTOR4NIX_CACHE_DIR=%C/selector4nix"
+              ];
+
+              CacheDirectory = lib.optionals cfg.enablePersistentCaching [
+                "selector4nix"
               ];
 
               Restart = "on-failure";

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -77,10 +77,17 @@ in
             config = {
               Label = "cc.starryreverie.selector4nix";
 
-              ProgramArguments = [
-                "${cfg.package}/bin/selector4nix"
-                "--no-log-timestamp"
-              ];
+              ProgramArguments = lib.singleton (
+                "${pkgs.writeShellScript "launch-selector4nix" (
+                  (lib.optionalString cfg.enablePersistentCaching ''
+                    mkdir -p "$HOME/Library/Caches/selector4nix"
+                    export SELECTOR4NIX_CACHE_DIR="$HOME/Library/Caches/selector4nix"
+                  '')
+                  + ''
+                    exec ${cfg.package}/bin/selector4nix --no-log-timestamp
+                  ''
+                )}"
+              );
 
               EnvironmentVariables = {
                 SELECTOR4NIX_CONFIG_FILE = "${configFile}";

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -35,10 +35,17 @@ in
           ]
           ++ lib.optionals (cfg.credentialFile != null) [
             "SELECTOR4NIX_CREDENTIAL_FILE=%d/credentials.toml"
+          ]
+          ++ lib.optionals cfg.enablePersistentCaching [
+            "SELECTOR4NIX_CACHE_DIR=%C/selector4nix"
           ];
 
           LoadCredential = lib.optionals (cfg.credentialFile != null) [
             "credentials.toml:${cfg.credentialFile}"
+          ];
+
+          CacheDirectory = lib.optionals cfg.enablePersistentCaching [
+            "selector4nix"
           ];
 
           Restart = "on-failure";


### PR DESCRIPTION
Add a `services.selector4nix.enablePersistentCaching` boolean option which controls whether to set up a cache directory for `selector4nix`. When such directory exists and is specified, `selector4nix` will automatically use it to persist query results, which can endure across service restarts.