### PR TITLE
Add explicit expiry management for NAR file and optionally use persistent caching

### DIFF
--- a/src/application/nar_file/actor/runner.rs
+++ b/src/application/nar_file/actor/runner.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use selector4nix_actor::actor::{Actor, ActorPre, ActorPreBuilder, Context, EmptyInternal};
 use tokio::sync::oneshot::Sender as OneshotSender;
 
+use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::nar_file::model::{NarFile, NarFileKey, NarFileLocation};
 use crate::domain::nar_file::port::NarStreamData;
 use crate::domain::nar_file::{NarFileService, StreamNarFileError};
@@ -16,14 +18,20 @@ pub struct NarFileActor {
     init: Option<NarFileKey>,
     context: Context<NarFileRequest, EmptyInternal>,
     nar_file_service: Arc<NarFileService>,
+    nar_file_ttl: Duration,
 }
 
 impl NarFileActor {
-    pub fn new(key: NarFileKey, nar_file_service: Arc<NarFileService>) -> ActorPre<Self> {
+    pub fn new(
+        key: NarFileKey,
+        nar_file_service: Arc<NarFileService>,
+        nar_file_ttl: Duration,
+    ) -> ActorPre<Self> {
         ActorPreBuilder::inject(|context| Self {
             init: Some(key),
             context,
             nar_file_service,
+            nar_file_ttl,
         })
     }
 }
@@ -48,13 +56,16 @@ impl Actor for NarFileActor {
     ) -> Option<Self::State> {
         match request {
             NarFileRequest::StreamNarFile(reply_to) => {
-                let (state, result) = self.nar_file_service.stream(state).await;
+                let now = SystemTime::now();
+                let state = state.check_expiry_and_update(now);
+                let (state, result) = self.nar_file_service.stream(state, now).await;
                 let _ = reply_to.send(result);
                 Some(state)
             }
             NarFileRequest::SetLocation(location) => {
-                let state = state.with_location(location);
-                Some(state)
+                let now = SystemTime::now();
+                let expire_at = ExpireAt::since(now, self.nar_file_ttl);
+                Some(state.on_located(location, expire_at))
             }
         }
     }

--- a/src/application/nar_file/actor/runner.rs
+++ b/src/application/nar_file/actor/runner.rs
@@ -7,7 +7,7 @@ use tokio::sync::oneshot::Sender as OneshotSender;
 use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::nar_file::model::{NarFile, NarFileKey, NarFileLocation};
 use crate::domain::nar_file::port::NarStreamData;
-use crate::domain::nar_file::{NarFileService, StreamNarFileError};
+use crate::domain::nar_file::{NarFileRepository, NarFileService, StreamNarFileError};
 
 pub enum NarFileRequest {
     StreamNarFile(OneshotSender<Result<Option<NarStreamData>, StreamNarFileError>>),
@@ -18,6 +18,7 @@ pub struct NarFileActor {
     init: Option<NarFileKey>,
     context: Context<NarFileRequest, EmptyInternal>,
     nar_file_service: Arc<NarFileService>,
+    nar_file_repository: Arc<dyn NarFileRepository>,
     nar_file_ttl: Duration,
 }
 
@@ -25,12 +26,14 @@ impl NarFileActor {
     pub fn new(
         key: NarFileKey,
         nar_file_service: Arc<NarFileService>,
+        nar_file_repository: Arc<dyn NarFileRepository>,
         nar_file_ttl: Duration,
     ) -> ActorPre<Self> {
         ActorPreBuilder::inject(|context| Self {
             init: Some(key),
             context,
             nar_file_service,
+            nar_file_repository,
             nar_file_ttl,
         })
     }
@@ -46,7 +49,16 @@ impl Actor for NarFileActor {
     }
 
     async fn on_start(&mut self) -> Option<Self::State> {
-        Some(NarFile::new(self.init.take()?))
+        let key = self.init.take()?;
+        let nar_file = match self.nar_file_repository.get(&key).await {
+            Ok(Some(nar_file)) => nar_file,
+            Ok(None) => NarFile::new(key),
+            Err(err) => {
+                tracing::warn!(file_hash = %key.file_hash(), %err, "failed to get nar file from persistent cache, ignore and use default");
+                NarFile::new(key)
+            }
+        };
+        Some(nar_file)
     }
 
     async fn on_request(
@@ -59,13 +71,24 @@ impl Actor for NarFileActor {
                 let now = SystemTime::now();
                 let state = state.check_expiry_and_update(now);
                 let (state, result) = self.nar_file_service.stream(state, now).await;
+
                 let _ = reply_to.send(result);
+                if let Err(err) = self.nar_file_repository.save(state.clone()).await {
+                    tracing::warn!(file_hash = %state.key().file_hash(), %err, "failed to write nar file to persistent cache, ignore");
+                }
+
                 Some(state)
             }
             NarFileRequest::SetLocation(location) => {
                 let now = SystemTime::now();
                 let expire_at = ExpireAt::since(now, self.nar_file_ttl);
-                Some(state.on_located(location, expire_at))
+                let state = state.on_located(location, expire_at);
+
+                if let Err(err) = self.nar_file_repository.save(state.clone()).await {
+                    tracing::warn!(file_hash = %state.key().file_hash(), %err, "failed to write nar file to persistent cache, ignore");
+                }
+
+                Some(state)
             }
         }
     }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -179,6 +179,7 @@ pub async fn init_context(
     let nar_file_service = Arc::new(NarFileService::new(
         nar_stream_provider,
         substituter_repository.clone(),
+        config.cache.nar_location_ttl,
     ));
 
     let nar_info_service = Arc::new(NarInfoService::new(
@@ -218,8 +219,9 @@ pub async fn init_context(
             .expiration(ExpirationOption::Ttl(config.cache.nar_location_ttl))
             .factory(AsyncFactory::new({
                 let svc = nar_file_service.clone();
+                let ttl = config.cache.nar_location_ttl;
                 move |key: &NarFileKey| {
-                    let addr = NarFileActor::new(key.clone(), svc.clone()).run();
+                    let addr = NarFileActor::new(key.clone(), svc.clone(), ttl).run();
                     async move { addr }
                 }
             }))

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -174,6 +174,11 @@ pub async fn init_context(
         CacheKvNarInfoRepository::new(cache_kv)
     });
 
+    let nar_file_repository = Arc::new({
+        let cache_kv = Arc::new(CacheKv::new(database.clone(), "nar_file".into()));
+        CacheKvNarFileRepository::new(cache_kv)
+    });
+
     let substituter_service = Arc::new(SubstituterService::new(config.network.periodic_probing));
 
     let nar_file_service = Arc::new(NarFileService::new(
@@ -213,21 +218,6 @@ pub async fn init_context(
         registry
     });
 
-    let nar_file_registry = Arc::new(
-        RegistryBuilder::new()
-            .capacity(CapacityOption::Lru(config.cache.nar_location_capacity))
-            .expiration(ExpirationOption::Ttl(config.cache.nar_location_ttl))
-            .factory(AsyncFactory::new({
-                let svc = nar_file_service.clone();
-                let ttl = config.cache.nar_location_ttl;
-                move |key: &NarFileKey| {
-                    let addr = NarFileActor::new(key.clone(), svc.clone(), ttl).run();
-                    async move { addr }
-                }
-            }))
-            .build(),
-    );
-
     let nar_info_registry = Arc::new(
         RegistryBuilder::new()
             .capacity(CapacityOption::Lru(config.cache.nar_info_lookup_capacity))
@@ -242,6 +232,28 @@ pub async fn init_context(
                         nar_info_service.clone(),
                         nar_info_repository.clone(),
                         nar_info_ttl,
+                    )
+                    .run();
+                    async move { addr }
+                }
+            }))
+            .build(),
+    );
+
+    let nar_file_registry = Arc::new(
+        RegistryBuilder::new()
+            .capacity(CapacityOption::Lru(config.cache.nar_location_capacity))
+            .expiration(ExpirationOption::Ttl(config.cache.nar_location_ttl))
+            .factory(AsyncFactory::new({
+                let nar_file_servicee = nar_file_service.clone();
+                let nar_file_repository = nar_file_repository.clone();
+                let nar_file_ttl = config.cache.nar_location_ttl;
+                move |key: &NarFileKey| {
+                    let addr = NarFileActor::new(
+                        key.clone(),
+                        nar_file_servicee.clone(),
+                        nar_file_repository.clone(),
+                        nar_file_ttl,
                     )
                     .run();
                     async move { addr }

--- a/src/domain/nar_file/mod.rs
+++ b/src/domain/nar_file/mod.rs
@@ -1,6 +1,8 @@
 pub mod model;
 pub mod port;
 
+mod repository;
 mod service;
 
+pub use repository::NarFileRepository;
 pub use service::{NarFileService, StreamNarFileError};

--- a/src/domain/nar_file/model/nar_file.rs
+++ b/src/domain/nar_file/model/nar_file.rs
@@ -1,12 +1,15 @@
+use std::time::SystemTime;
+
 use getset::Getters;
 
+use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::nar_file::model::{NarFileKey, NarFileLocation};
 
-#[derive(Debug, Clone, PartialEq, Eq, Getters)]
-#[getset(get = "pub")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters)]
 pub struct NarFile {
+    #[getset(get = "pub")]
     key: NarFileKey,
-    location: Option<NarFileLocation>,
+    location: Option<(NarFileLocation, ExpireAt)>,
 }
 
 impl NarFile {
@@ -17,8 +20,72 @@ impl NarFile {
         }
     }
 
-    pub fn with_location(mut self, location: NarFileLocation) -> Self {
-        self.location = Some(location);
+    pub fn on_located(mut self, location: NarFileLocation, expire_at: ExpireAt) -> Self {
+        self.location = Some((location, expire_at));
         self
+    }
+
+    pub fn on_relocated(mut self, location: NarFileLocation) -> Self {
+        self.location = self.location.map(|(_, expire_at)| (location, expire_at));
+        self
+    }
+
+    pub fn location(&self) -> Option<&NarFileLocation> {
+        self.location.as_ref().map(|(location, _)| location)
+    }
+
+    pub fn expire_at(&self) -> Option<ExpireAt> {
+        self.location.as_ref().map(|(_, expire_at)| *expire_at)
+    }
+
+    pub fn check_expiry_and_update(mut self, now: SystemTime) -> Self {
+        if self.has_expired(now) {
+            self.location = None;
+        }
+        self
+    }
+
+    fn has_expired(&self, now: SystemTime) -> bool {
+        self.expire_at().is_none_or(|e| e.has_expired(now))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::domain::common::url::Url;
+    use crate::domain::nar_info::model::NarFileName;
+
+    use super::*;
+
+    fn make_nar_file(expire_at: SystemTime) -> NarFile {
+        let nar_file_name = NarFileName::new("abc123.nar.xz".into()).unwrap();
+        let key = NarFileKey::from_file_name(&nar_file_name);
+        let location =
+            NarFileLocation::new(Url::new("https://example.com/abc123.nar.xz").unwrap(), None);
+        NarFile::new(key).on_located(location, ExpireAt::new(expire_at))
+    }
+
+    #[test]
+    fn check_expiry_and_update_clears_location_given_expired() {
+        let now = SystemTime::now();
+        let expire_at = now - Duration::from_secs(1);
+
+        let nar_file = make_nar_file(expire_at);
+        let nar_file = nar_file.check_expiry_and_update(now);
+
+        assert!(nar_file.location().is_none());
+    }
+
+    #[test]
+    fn check_expiry_and_update_preserves_location_given_not_expired() {
+        let now = SystemTime::now();
+        let expire_at = now + Duration::from_secs(1);
+
+        let nar_file = make_nar_file(expire_at);
+        let nar_file = nar_file.check_expiry_and_update(now);
+
+        assert!(nar_file.location().is_some());
     }
 }

--- a/src/domain/nar_file/model/nar_file.rs
+++ b/src/domain/nar_file/model/nar_file.rs
@@ -1,11 +1,12 @@
 use std::time::SystemTime;
 
 use getset::Getters;
+use serde::{Deserialize, Serialize};
 
 use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::nar_file::model::{NarFileKey, NarFileLocation};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters, Serialize, Deserialize)]
 pub struct NarFile {
     #[getset(get = "pub")]
     key: NarFileKey,

--- a/src/domain/nar_file/model/nar_file_key.rs
+++ b/src/domain/nar_file/model/nar_file_key.rs
@@ -1,8 +1,9 @@
 use getset::Getters;
+use serde::{Deserialize, Serialize};
 
 use crate::domain::nar_info::model::NarFileName;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters, Serialize, Deserialize)]
 pub struct NarFileKey {
     #[getset(get = "pub")]
     file_hash: String,

--- a/src/domain/nar_file/model/nar_file_location.rs
+++ b/src/domain/nar_file/model/nar_file_location.rs
@@ -1,10 +1,11 @@
 use std::time::Duration;
 
 use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
 
 use crate::domain::common::url::Url;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters, CopyGetters)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Getters, CopyGetters, Serialize, Deserialize)]
 pub struct NarFileLocation {
     #[getset(get = "pub")]
     source_url: Url,

--- a/src/domain/nar_file/repository.rs
+++ b/src/domain/nar_file/repository.rs
@@ -1,0 +1,11 @@
+use anyhow::Result as AnyhowResult;
+use async_trait::async_trait;
+
+use crate::domain::nar_file::model::{NarFile, NarFileKey};
+
+#[async_trait]
+pub trait NarFileRepository: Send + Sync {
+    async fn get(&self, key: &NarFileKey) -> AnyhowResult<Option<NarFile>>;
+
+    async fn save(&self, nar_file: NarFile) -> AnyhowResult<()>;
+}

--- a/src/domain/nar_file/service.rs
+++ b/src/domain/nar_file/service.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use snafu::Snafu;
 
+use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::nar_file::model::{NarFile, NarFileLocation};
 use crate::domain::nar_file::port::{NarStreamData, NarStreamProvider};
 use crate::domain::nar_info::model::NarFileName;
@@ -10,22 +12,26 @@ use crate::domain::substituter::SubstituterRepository;
 pub struct NarFileService {
     nar_stream_provider: Arc<dyn NarStreamProvider>,
     substituter_repository: Arc<dyn SubstituterRepository>,
+    nar_file_ttl: Duration,
 }
 
 impl NarFileService {
     pub fn new(
         nar_stream_provider: Arc<dyn NarStreamProvider>,
         substituter_repository: Arc<dyn SubstituterRepository>,
+        nar_file_ttl: Duration,
     ) -> Self {
         Self {
             nar_stream_provider,
             substituter_repository,
+            nar_file_ttl,
         }
     }
 
     pub async fn stream(
         &self,
         nar_file: NarFile,
+        now: SystemTime,
     ) -> (NarFile, Result<Option<NarStreamData>, StreamNarFileError>) {
         let nar_file_name = nar_file.key().to_file_name();
 
@@ -45,13 +51,14 @@ impl NarFileService {
         }
 
         let candidates = self.build_candidates_from_all(&nar_file_name).await;
-        self.stream_from_all(nar_file, candidates).await
+        self.stream_from_all(nar_file, candidates, now).await
     }
 
     async fn stream_from_all(
         &self,
         nar_file: NarFile,
         candidates: Vec<NarFileLocation>,
+        now: SystemTime,
     ) -> (NarFile, Result<Option<NarStreamData>, StreamNarFileError>) {
         let outcome = self.nar_stream_provider.stream_nar(&candidates).await;
 
@@ -61,7 +68,14 @@ impl NarFileService {
                     .into_iter()
                     .find(|loc| loc.source_url() == &data.source_url)
                     .expect("returned `source_url` should match a candidate");
-                (nar_file.with_location(location), Ok(Some(data)))
+                let nar_file = match nar_file.location() {
+                    Some(_) => nar_file.on_relocated(location),
+                    None => {
+                        let expire_at = ExpireAt::since(now, self.nar_file_ttl);
+                        nar_file.on_located(location, expire_at)
+                    }
+                };
+                (nar_file, Ok(Some(data)))
             }
             Ok(None) => (nar_file, Ok(None)),
             Err(_) => (nar_file, Err(StreamNarFileError::Infrastructure)),

--- a/src/infrastructure/repository/mod.rs
+++ b/src/infrastructure/repository/mod.rs
@@ -1,5 +1,7 @@
+mod nar_file;
 mod nar_info;
 mod substituter;
 
+pub use nar_file::CacheKvNarFileRepository;
 pub use nar_info::CacheKvNarInfoRepository;
 pub use substituter::InMemorySubstituterRepository;

--- a/src/infrastructure/repository/nar_file.rs
+++ b/src/infrastructure/repository/nar_file.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use anyhow::Result as AnyhowResult;
+use async_trait::async_trait;
+use selector4nix_db::cache_kv::{CacheKv, UnixTimestampArg};
+
+use crate::domain::nar_file::NarFileRepository;
+use crate::domain::nar_file::model::{NarFile, NarFileKey};
+
+pub struct CacheKvNarFileRepository {
+    db: Arc<CacheKv>,
+}
+
+impl CacheKvNarFileRepository {
+    pub fn new(db: Arc<CacheKv>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl NarFileRepository for CacheKvNarFileRepository {
+    async fn get(&self, key: &NarFileKey) -> AnyhowResult<Option<NarFile>> {
+        let db = Arc::clone(&self.db);
+        let key = postcard::to_stdvec(key).expect("serialize `key` to bytes should not fail");
+
+        tokio::task::spawn_blocking(move || {
+            let value = db.get(&key, UnixTimestampArg::SystemNow)?;
+            let entity = value.and_then(|(_, value)| {
+                postcard::from_bytes::<NarFile>(&value)
+                    .inspect_err(|_| tracing::warn!("encountered data of invalid schema, ignore"))
+                    .ok()
+            });
+            Ok(entity)
+        })
+        .await?
+    }
+
+    async fn save(&self, nar_file: NarFile) -> AnyhowResult<()> {
+        let Some(expire_at) = nar_file.expire_at() else {
+            return Ok(());
+        };
+
+        let db = Arc::clone(&self.db);
+        let key = postcard::to_stdvec(nar_file.key())
+            .expect("serialize `nar_file.key()` to bytes should not fail");
+        let value =
+            postcard::to_stdvec(&nar_file).expect("serialize `nar_file` to bytes should not fail");
+
+        tokio::task::spawn_blocking(move || {
+            let expire_at = expire_at.unix_timpstamp();
+            db.save(&key, &value, expire_at, UnixTimestampArg::SystemNow)
+        })
+        .await?
+    }
+}


### PR DESCRIPTION
Explicitly control `NarFile`'s expiry, without relying on the internal actor runtime's TTL mechanism. Optionally persist `NarFile`'s state to a local cache database, if enabled.