### PR TITLE
Set a more conservative `max_concurrent_requests` default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ In your NixOS, nix-darwin, or Home Manager configuration:
     # Optional: see Credentials section for detials.
     # credentialFile = "/path/to/my/credentials.toml";
 
+    # Optional: see Caching section for detials.
+    # enablePersistentCaching = true;
+
     settings = {
       substituters = [
         {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@ Timeout in seconds for NAR file downloads, also used as connect timeout.
 ### `network.max_concurrent_requests`
 
 - Type: Natural
-- Default: `24`
+- Default: `12`
 
 Maximum number of concurrent outgoing HTTP requests.
 

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -14,8 +14,8 @@ port = 5496
 nar_info_timeout_secs = 30
 # Timeout in seconds for NAR file downloads, also used as connect timeout (default: 30, minimum: 1).
 nar_timeout_secs = 30
-# Maximum number of concurrent outgoing HTTP requests (default: 24).
-max_concurrent_requests = 24
+# Maximum number of concurrent outgoing HTTP requests (default: 12).
+max_concurrent_requests = 12
 # Latency tolerance window in milliseconds. After the fastest substituter responds,
 # others have this many additional milliseconds before being pruned (default: 50, minimum: 1).
 tolerance_msecs = 50

--- a/src/infrastructure/config/general_parsed.rs
+++ b/src/infrastructure/config/general_parsed.rs
@@ -119,7 +119,7 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
             nar_timeout: raw
                 .nar_timeout_secs
                 .map_or(Duration::from_secs(30), to_clamped_duration),
-            max_concurrent_requests: raw.max_concurrent_requests.unwrap_or(24),
+            max_concurrent_requests: raw.max_concurrent_requests.unwrap_or(12),
             tolerance: raw.tolerance_msecs.unwrap_or(50).max(1),
             ignore_nar_info_error: raw.ignore_nar_info_error.unwrap_or(false),
             periodic_probing: if raw.periodic_probing.unwrap_or(true) {

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -20,7 +20,7 @@ fn defaults_are_applied_when_sections_omitted() {
     assert_eq!(config.server.port, 5496);
     assert_eq!(config.network.nar_info_timeout, Duration::from_secs(30));
     assert_eq!(config.network.nar_timeout, Duration::from_secs(30));
-    assert_eq!(config.network.max_concurrent_requests, 24);
+    assert_eq!(config.network.max_concurrent_requests, 12);
     assert_eq!(config.network.tolerance, 50);
     assert_eq!(config.network.ignore_nar_info_error, false);
     assert_eq!(


### PR DESCRIPTION
The default value of `network.max_concurrent_requests` was `24`, which was too aggressive for some upstream substituters and often made `selector4nix` being throttling unexpectedly. A smaller number like 12 makes `selector4nix` more robust and usable, and it seems that this won't limit the speed of large NAR file streaming.