### PR TITLE
Fix NAR info request timeout reported by Nix client

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,7 @@ Timeout in seconds for NAR file downloads, also used as connect timeout.
 - Type: Natural
 - Default: `12`
 
-Maximum number of concurrent outgoing HTTP requests.
+Maximum number of concurrent outgoing HTTP requests for NAR file streaming.
 
 ### `network.tolerance_msecs`
 

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -14,7 +14,7 @@ port = 5496
 nar_info_timeout_secs = 30
 # Timeout in seconds for NAR file downloads, also used as connect timeout (default: 30, minimum: 1).
 nar_timeout_secs = 30
-# Maximum number of concurrent outgoing HTTP requests (default: 12).
+# Maximum number of concurrent outgoing HTTP requests for NAR file streaming (default: 12).
 max_concurrent_requests = 12
 # Latency tolerance window in milliseconds. After the fastest substituter responds,
 # others have this many additional milliseconds before being pruned (default: 50, minimum: 1).

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -140,7 +140,6 @@ pub async fn init_context(
     let nar_info_provider = Arc::new(ReqwestNarInfoProvider::new(
         http_client.clone(),
         config.network.nar_info_timeout,
-        concurrency.clone(),
         credentials.clone(),
     ));
 

--- a/src/infrastructure/provider/nar_info_provider.rs
+++ b/src/infrastructure/provider/nar_info_provider.rs
@@ -5,7 +5,6 @@ use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
 use reqwest::{Client, StatusCode};
 use snafu::ResultExt;
-use tokio::sync::Semaphore;
 
 use crate::domain::common::url::Url;
 use crate::domain::nar_info::model::UpstreamNarInfoData;
@@ -16,21 +15,14 @@ use crate::infrastructure::config::AppCredential;
 pub struct ReqwestNarInfoProvider {
     client: Client,
     default_timeout: Duration,
-    concurrency: Arc<Semaphore>,
     credentials: Arc<AppCredential>,
 }
 
 impl ReqwestNarInfoProvider {
-    pub fn new(
-        client: Client,
-        default_timeout: Duration,
-        concurrency: Arc<Semaphore>,
-        credentials: Arc<AppCredential>,
-    ) -> Self {
+    pub fn new(client: Client, default_timeout: Duration, credentials: Arc<AppCredential>) -> Self {
         Self {
             client,
             default_timeout,
-            concurrency,
             credentials,
         }
     }
@@ -44,8 +36,6 @@ impl NarInfoProvider for ReqwestNarInfoProvider {
         timeout: Option<Duration>,
     ) -> Result<Option<NarInfoQueryData>, QueryNarInfoError> {
         tracing::debug!(%url, "fetching nar info from substituter");
-
-        let _permit = self.concurrency.acquire().await.unwrap();
 
         let timeout = timeout.unwrap_or(self.default_timeout);
         let request = self.client.get(url.value()).timeout(timeout);


### PR DESCRIPTION
When querying NAR info from `selector4nix`, the Nix client may cancel requests due to timeout. This is caused by `selector4nix` limits the max concurrent requests of all HTTP requests and multiple requests are sent for one NAR info, which causes a large amount of NAR info requests are blocked and timeout of the Nix client expires.

This PR removes the concurrency throttling of NAR info requests, since these requests are short-lived and typically don't trigger upstream substituters' throttling strategy.