### PR TITLE
feat: carry credentials when downloading NAR files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For NixOS, nix-darwin, and Home Manager users, it is recommended to use the modu
 3. `./credentials.toml` in the current directory
 4. `/etc/selector4nix/credentials.toml`
 
-If no credentials file is found, all upstream requests are made without authentication. Credentials are only used for `/nix-cache-info` lookups and `.narinfo` queries; NAR file downloads typically rely on pre-signed URLs.
+If no credentials file is found, all upstream requests are made without authentication. Credentials are used for `/nix-cache-info` lookups, `.narinfo` queries, and NAR file downloads. This is required for private caches such as [Attic](https://github.com/zhaofengli/attic).
 
 An example credentials file is demonstrated below. For a complete reference, see [`docs/credentials.md`](/docs/credentials.md). An annotated example credentials file is also available at [`docs/credentials.example.toml`](/docs/credentials.example.toml).
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -9,7 +9,7 @@
 
 If no credentials file is found, `selector4nix` continues without credentials. All upstream requests will be unauthenticated.
 
-Credentials are only used for `/nix-cache-info` access and NAR info queries. NAR file downloads do not use credentials because they typically rely on pre-signed URLs.
+Credentials are used for `/nix-cache-info` access, NAR info queries, and NAR file downloads. This is required for private caches such as [Attic](https://github.com/zhaofengli/attic) that authenticate all substituter requests.
 
 ## `credentials`
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -143,7 +143,11 @@ pub async fn init_context(
         credentials.clone(),
     ));
 
-    let nar_stream_provider = Arc::new(ReqwestNarStreamProvider::new(http_client, concurrency));
+    let nar_stream_provider = Arc::new(ReqwestNarStreamProvider::new(
+        http_client,
+        concurrency,
+        credentials.clone(),
+    ));
 
     let substituters = config
         .substituters

--- a/src/infrastructure/provider/nar_stream_provider.rs
+++ b/src/infrastructure/provider/nar_stream_provider.rs
@@ -10,17 +10,24 @@ use tokio::task::JoinSet;
 use crate::domain::common::url::Url;
 use crate::domain::nar_file::model::NarFileLocation;
 use crate::domain::nar_file::port::{NarStreamData, NarStreamHeaders, NarStreamProvider};
+use crate::infrastructure::config::AppCredential;
 
 pub struct ReqwestNarStreamProvider {
     client: Client,
     concurrency: Arc<Semaphore>,
+    credentials: Arc<AppCredential>,
 }
 
 impl ReqwestNarStreamProvider {
-    pub fn new(client: Client, concurrency: Arc<Semaphore>) -> Self {
+    pub fn new(
+        client: Client,
+        concurrency: Arc<Semaphore>,
+        credentials: Arc<AppCredential>,
+    ) -> Self {
         Self {
             client,
             concurrency,
+            credentials,
         }
     }
 
@@ -61,9 +68,14 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
             let client = self.client.clone();
             let location = location.clone();
             let concurrency = self.concurrency.clone();
+            let credentials = self.credentials.clone();
             set.spawn(async move {
                 let _permit = concurrency.acquire().await.unwrap();
-                let request = client.get(location.source_url().value());
+                let mut request = client.get(location.source_url().value());
+                if let Some(credential) = credentials.lookup(location.source_url()) {
+                    request =
+                        request.basic_auth(credential.login.clone(), credential.secret.clone());
+                }
                 let response = if let Some(timeout) = location.timeout() {
                     tokio::time::timeout(timeout, request.send()).await
                 } else {

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -22,7 +22,7 @@ fn defaults_are_applied_when_sections_omitted() {
     assert_eq!(config.network.nar_timeout, Duration::from_secs(30));
     assert_eq!(config.network.max_concurrent_requests, 12);
     assert_eq!(config.network.tolerance, 50);
-    assert_eq!(config.network.ignore_nar_info_error, false);
+    assert!(!config.network.ignore_nar_info_error);
     assert_eq!(
         config.network.periodic_probing,
         PeriodicProbingOption::Enabled

--- a/tests/integration/nar_info_service_test.rs
+++ b/tests/integration/nar_info_service_test.rs
@@ -49,7 +49,7 @@ async fn run_test(
         repo.save(sub.clone()).await;
     }
 
-    let nar_info_provider = MockNarInfoProvider::new(env.nar_info_entries.into_iter());
+    let nar_info_provider = MockNarInfoProvider::new(env.nar_info_entries);
 
     let nar_resolution_service = NarInfoService::new(
         Arc::new(nar_info_provider),


### PR DESCRIPTION
Apply the same credential lookup and HTTP Basic Auth used for nix-cache-info and narinfo queries to NAR file downloads, enabling compatibility with private caches such as Attic.