### PR TITLE
Passthrough
curl and Nix client User-Agent to upstream substituters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,9 +680,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1594,6 +1594,7 @@ dependencies = [
  "dashmap",
  "futures",
  "getset",
+ "http",
  "moka",
  "postcard",
  "redb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ dashmap = "6.2.1"
 fastrand = "2.4.1"
 futures = "0.3.32"
 getset = "0.1.6"
+http = "1.4.2"
 moka = { version = "0.12.15", features = ["future"] }
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
 redb = "4.1.0"
@@ -49,6 +50,7 @@ clap = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }
 getset = { workspace = true }
+http = { workspace = true }
 moka = { workspace = true }
 postcard = { workspace = true }
 redb = { workspace = true }

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -1,5 +1,5 @@
-use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use http::StatusCode;
 
 use crate::application::{AppError, AppErrorKind};
 

--- a/src/api/handlers/cache_info.rs
+++ b/src/api/handlers/cache_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::extract::{Query, State};
-use axum::http::{Response, header};
+use http::{Response, header};
 use serde::Deserialize;
 
 use crate::api::state::AppContext;

--- a/src/api/handlers/health.rs
+++ b/src/api/handlers/health.rs
@@ -1,5 +1,5 @@
 use axum::body::Body;
-use axum::http::Response;
+use http::Response;
 
 pub async fn get_health() -> Response<Body> {
     Response::builder().body(Body::from("OK")).unwrap()

--- a/src/api/handlers/nar.rs
+++ b/src/api/handlers/nar.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::extract::{Path, State};
 use futures::StreamExt;
-use http::{Response, header};
+use http::{HeaderMap, Response, header};
 
 use crate::api::state::AppContext;
 use crate::application::AppError;
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::nar_file::model::NarFileKey;
 use crate::domain::nar_file::port::NarStreamData;
 use crate::domain::nar_info::model::NarFileName;
@@ -14,11 +15,16 @@ use crate::domain::nar_info::model::NarFileName;
 pub async fn get_nar(
     State(ctx): State<Arc<AppContext>>,
     Path(path): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Response<Body>, AppError> {
     let nar_file = NarFileName::new(path)?;
     let key = NarFileKey::from_file_name(&nar_file);
 
-    let data = ctx.nar_file_streaming_usecase().stream_nar(key).await?;
+    let headers = PassthroughHeaders::extract(headers).proxyed();
+    let data = ctx
+        .nar_file_streaming_usecase()
+        .stream_nar(key, headers)
+        .await?;
     Ok(build_response(data))
 }
 

--- a/src/api/handlers/nar.rs
+++ b/src/api/handlers/nar.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::{Response, header};
 use futures::StreamExt;
+use http::{Response, header};
 
 use crate::api::state::AppContext;
 use crate::application::AppError;

--- a/src/api/handlers/nar_info.rs
+++ b/src/api/handlers/nar_info.rs
@@ -24,7 +24,7 @@ pub async fn get_nar_info(
         }
     };
 
-    let headers = PassthroughHeaders::extract(headers);
+    let headers = PassthroughHeaders::extract(headers).proxyed();
     let data = ctx
         .nar_info_resolution_usecase()
         .get_nar_info(hash, headers)

--- a/src/api/handlers/nar_info.rs
+++ b/src/api/handlers/nar_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::{Response, header};
+use http::{HeaderMap, Response, header};
 
 use crate::api::state::AppContext;
 use crate::application::{AppError, AppErrorKind};

--- a/src/api/handlers/nar_info.rs
+++ b/src/api/handlers/nar_info.rs
@@ -6,11 +6,13 @@ use http::{HeaderMap, Response, header};
 
 use crate::api::state::AppContext;
 use crate::application::{AppError, AppErrorKind};
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::nar_info::model::StorePathHash;
 
 pub async fn get_nar_info(
     State(ctx): State<Arc<AppContext>>,
     Path(filename): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Response<Body>, AppError> {
     let hash = match filename.strip_suffix(".narinfo") {
         Some(hash) => StorePathHash::new(hash.into())?,
@@ -22,7 +24,11 @@ pub async fn get_nar_info(
         }
     };
 
-    let data = ctx.nar_info_resolution_usecase().get_nar_info(hash).await?;
+    let headers = PassthroughHeaders::extract(headers);
+    let data = ctx
+        .nar_info_resolution_usecase()
+        .get_nar_info(hash, headers)
+        .await?;
     let response = Response::builder()
         .header(header::CONTENT_TYPE, "text/x-nix-narinfo")
         .body(Body::from(data.content().to_string()))

--- a/src/application/nar_file/actor/runner.rs
+++ b/src/application/nar_file/actor/runner.rs
@@ -5,12 +5,16 @@ use selector4nix_actor::actor::{Actor, ActorPre, ActorPreBuilder, Context, Empty
 use tokio::sync::oneshot::Sender as OneshotSender;
 
 use crate::domain::common::expire_at::ExpireAt;
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::nar_file::model::{NarFile, NarFileKey, NarFileLocation};
 use crate::domain::nar_file::port::NarStreamData;
 use crate::domain::nar_file::{NarFileRepository, NarFileService, StreamNarFileError};
 
 pub enum NarFileRequest {
-    StreamNarFile(OneshotSender<Result<Option<NarStreamData>, StreamNarFileError>>),
+    StreamNarFile {
+        reply_to: OneshotSender<Result<Option<NarStreamData>, StreamNarFileError>>,
+        headers: PassthroughHeaders,
+    },
     SetLocation(NarFileLocation),
 }
 
@@ -67,10 +71,10 @@ impl Actor for NarFileActor {
         request: Self::Request,
     ) -> Option<Self::State> {
         match request {
-            NarFileRequest::StreamNarFile(reply_to) => {
+            NarFileRequest::StreamNarFile { reply_to, headers } => {
                 let now = SystemTime::now();
                 let state = state.check_expiry_and_update(now);
-                let (state, result) = self.nar_file_service.stream(state, now).await;
+                let (state, result) = self.nar_file_service.stream(state, headers, now).await;
 
                 let _ = reply_to.send(result);
                 if let Err(err) = self.nar_file_repository.save(state.clone()).await {

--- a/src/application/nar_file/usecase/streaming.rs
+++ b/src/application/nar_file/usecase/streaming.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::application::nar_file::actor::{NarFileActorRegistry, NarFileRequest};
 use crate::application::{AppErrorKind, AppOptionExt, AppResult, AppResultExt};
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::nar_file::model::NarFileKey;
 use crate::domain::nar_file::port::NarStreamData;
 
@@ -14,13 +15,17 @@ impl NarFileStreamingUseCase {
         Self { nar_file_registry }
     }
 
-    pub async fn stream_nar(&self, key: NarFileKey) -> AppResult<NarStreamData> {
+    pub async fn stream_nar(
+        &self,
+        key: NarFileKey,
+        headers: PassthroughHeaders,
+    ) -> AppResult<NarStreamData> {
         tracing::info!(nar_file = %key.to_file_name().value(), "acquiring nar stream from substituter");
 
         let address = self.nar_file_registry.get(&key).await;
 
         let response = address
-            .ask(|reply_to| NarFileRequest::StreamNarFile(reply_to))
+            .ask(|reply_to| NarFileRequest::StreamNarFile { reply_to, headers })
             .await
             .map_err(|_| anyhow::anyhow!("nar file actor terminated unexpectedly"))
             .wrap(AppErrorKind::Unknown)?;

--- a/src/application/nar_info/actor/runner.rs
+++ b/src/application/nar_info/actor/runner.rs
@@ -5,6 +5,7 @@ use selector4nix_actor::actor::{Actor, ActorPre, ActorPreBuilder, Context, Empty
 use tokio::sync::oneshot::Sender as OneshotSender;
 
 use crate::domain::common::expire_at::ExpireAt;
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::nar_info::model::{NarInfo, ProxyNarInfoData, StorePathHash};
 use crate::domain::nar_info::{
     NarInfoRepository, NarInfoService, ResolveNarInfoError, ResolveNarInfoEvent,
@@ -12,7 +13,10 @@ use crate::domain::nar_info::{
 
 #[derive(Debug)]
 pub enum NarInfoRequest {
-    ResolveNarInfo(OneshotSender<ResolveNarInfoResponse>),
+    ResolveNarInfo {
+        reply_to: OneshotSender<ResolveNarInfoResponse>,
+        headers: PassthroughHeaders,
+    },
 }
 
 #[derive(Debug)]
@@ -58,6 +62,7 @@ impl NarInfoActor {
         &self,
         nar_info: NarInfo,
         reply_to: OneshotSender<ResolveNarInfoResponse>,
+        headers: PassthroughHeaders,
     ) -> NarInfo {
         let nar_info = nar_info.check_expiry_and_update(SystemTime::now());
 
@@ -67,7 +72,10 @@ impl NarInfoActor {
             return nar_info;
         }
 
-        let (res, events) = self.nar_info_service.resolve(nar_info.hash()).await;
+        let (res, events) = self
+            .nar_info_service
+            .resolve(nar_info.hash(), headers)
+            .await;
         match res {
             Ok(resolution) => {
                 let res = Ok(resolution.nar_info().cloned());
@@ -117,9 +125,10 @@ impl Actor for NarInfoActor {
         request: Self::Request,
     ) -> Option<Self::State> {
         match request {
-            NarInfoRequest::ResolveNarInfo(reply) => {
-                Some(self.handle_request_resolve_nar_info(state, reply).await)
-            }
+            NarInfoRequest::ResolveNarInfo { reply_to, headers } => Some(
+                self.handle_request_resolve_nar_info(state, reply_to, headers)
+                    .await,
+            ),
         }
     }
 }

--- a/src/application/nar_info/usecase/resolution.rs
+++ b/src/application/nar_info/usecase/resolution.rs
@@ -4,6 +4,7 @@ use crate::application::nar_file::actor::{NarFileActorRegistry, NarFileRequest};
 use crate::application::nar_info::actor::{NarInfoActorRegistry, NarInfoRequest};
 use crate::application::substituter::actor::{SubstituterActorRegistry, SubstituterRequest};
 use crate::application::{AppErrorKind, AppOptionExt, AppResult, AppResultExt};
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::nar_file::model::{NarFileKey, NarFileLocation};
 use crate::domain::nar_info::model::{ProxyNarInfoData, StorePathHash};
 use crate::domain::nar_info::{ResolveNarInfoError, ResolveNarInfoEvent};
@@ -27,13 +28,17 @@ impl NarInfoResolutionUseCase {
         }
     }
 
-    pub async fn get_nar_info(&self, hash: StorePathHash) -> AppResult<ProxyNarInfoData> {
+    pub async fn get_nar_info(
+        &self,
+        hash: StorePathHash,
+        headers: PassthroughHeaders,
+    ) -> AppResult<ProxyNarInfoData> {
         tracing::info!(hash = %hash.value(), "resolving nar info");
 
         let address = self.nar_info_registry.get(&hash).await;
 
         let response = address
-            .ask(|reply_to| NarInfoRequest::ResolveNarInfo(reply_to))
+            .ask(|reply_to| NarInfoRequest::ResolveNarInfo { reply_to, headers })
             .await
             .map_err(|_| anyhow::anyhow!("nar actor terminated unexpectedly"))
             .wrap(AppErrorKind::Unknown)?;

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -13,6 +13,7 @@ use selector4nix::application::nar_info::actor::NarInfoActor;
 use selector4nix::application::nar_info::usecase::NarInfoResolutionUseCase;
 use selector4nix::application::substituter::actor::SubstituterActor;
 use selector4nix::application::substituter::usecase::SubstituterQueryUseCase;
+use selector4nix::domain::common::passthrough_headers::SELF_USER_AGENT;
 use selector4nix::domain::nar_file::NarFileService;
 use selector4nix::domain::nar_file::model::NarFileKey;
 use selector4nix::domain::nar_info::NarInfoService;
@@ -119,11 +120,7 @@ pub async fn init_context(
     };
 
     let http_client = Client::builder()
-        .user_agent(format!(
-            "curl/8.7.1 Nix/2.24.11 {}/{}",
-            env!("CARGO_PKG_NAME"),
-            env!("CARGO_PKG_VERSION"),
-        ))
+        .user_agent(SELF_USER_AGENT.as_str())
         .connect_timeout(config.network.nar_timeout)
         .build()
         .context("could not build HTTP client")?;

--- a/src/domain/common/mod.rs
+++ b/src/domain/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod expire_at;
+pub mod passthrough_headers;
 pub mod url;

--- a/src/domain/common/passthrough_headers.rs
+++ b/src/domain/common/passthrough_headers.rs
@@ -1,0 +1,47 @@
+use std::sync::LazyLock;
+
+use http::{HeaderMap, HeaderValue, header};
+
+pub static SELF_USER_AGENT: LazyLock<String> =
+    LazyLock::new(|| format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"),));
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PassthroughHeaders {
+    user_agent: Option<HeaderValue>,
+}
+
+impl PassthroughHeaders {
+    pub fn empty() -> Self {
+        Self { user_agent: None }
+    }
+
+    pub fn extract(mut headers: HeaderMap) -> Self {
+        Self {
+            user_agent: headers.remove(header::USER_AGENT),
+        }
+    }
+
+    pub fn proxyed(mut self) -> Self {
+        if let Some(value) = &mut self.user_agent
+            && !value.is_empty()
+        {
+            let mut bytes = value.as_bytes().to_owned();
+            bytes.extend(b" ");
+            bytes.extend(SELF_USER_AGENT.as_bytes());
+            *value =
+                HeaderValue::from_bytes(&bytes).expect("`bytes` should be a valid `HeaderValue`");
+        }
+
+        self
+    }
+
+    pub fn to_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+
+        if let Some(value) = &self.user_agent {
+            headers.append(header::USER_AGENT, value.clone());
+        }
+
+        headers
+    }
+}

--- a/src/domain/nar_file/port/nar_stream_provider.rs
+++ b/src/domain/nar_file/port/nar_stream_provider.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::common::url::Url;
 use crate::domain::nar_file::model::NarFileLocation;
 
@@ -13,6 +14,7 @@ pub trait NarStreamProvider: Send + Sync {
     async fn stream_nar(
         &self,
         locations: &[NarFileLocation],
+        headers: &PassthroughHeaders,
     ) -> AnyhowResult<Option<NarStreamData>>;
 }
 

--- a/src/domain/nar_file/service.rs
+++ b/src/domain/nar_file/service.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, SystemTime};
 use snafu::Snafu;
 
 use crate::domain::common::expire_at::ExpireAt;
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::nar_file::model::{NarFile, NarFileLocation};
 use crate::domain::nar_file::port::{NarStreamData, NarStreamProvider};
 use crate::domain::nar_info::model::NarFileName;
@@ -31,6 +32,7 @@ impl NarFileService {
     pub async fn stream(
         &self,
         nar_file: NarFile,
+        headers: PassthroughHeaders,
         now: SystemTime,
     ) -> (NarFile, Result<Option<NarStreamData>, StreamNarFileError>) {
         let nar_file_name = nar_file.key().to_file_name();
@@ -39,7 +41,10 @@ impl NarFileService {
             tracing::trace!(nar_file = %nar_file_name.value(), source_url = %location.source_url(), "use cached nar file location");
 
             let locations = [location.clone()];
-            let outcome = self.nar_stream_provider.stream_nar(&locations).await;
+            let outcome = self
+                .nar_stream_provider
+                .stream_nar(&locations, &headers)
+                .await;
 
             if let Ok(Some(data)) = outcome {
                 return (nar_file, Ok(Some(data)));
@@ -51,16 +56,21 @@ impl NarFileService {
         }
 
         let candidates = self.build_candidates_from_all(&nar_file_name).await;
-        self.stream_from_all(nar_file, candidates, now).await
+        self.stream_from_all(nar_file, headers, candidates, now)
+            .await
     }
 
     async fn stream_from_all(
         &self,
         nar_file: NarFile,
+        headers: PassthroughHeaders,
         candidates: Vec<NarFileLocation>,
         now: SystemTime,
     ) -> (NarFile, Result<Option<NarStreamData>, StreamNarFileError>) {
-        let outcome = self.nar_stream_provider.stream_nar(&candidates).await;
+        let outcome = self
+            .nar_stream_provider
+            .stream_nar(&candidates, &headers)
+            .await;
 
         match outcome {
             Ok(Some(data)) => {

--- a/src/domain/nar_info/port/nar_info_provider.rs
+++ b/src/domain/nar_info/port/nar_info_provider.rs
@@ -4,6 +4,7 @@ use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
 use snafu::Snafu;
 
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::common::url::Url;
 use crate::domain::nar_info::model::UpstreamNarInfoData;
 
@@ -12,6 +13,7 @@ pub trait NarInfoProvider: Send + Sync {
     async fn query_nar_info(
         &self,
         url: &Url,
+        headers: &PassthroughHeaders,
         timeout: Option<Duration>,
     ) -> Result<Option<NarInfoQueryData>, QueryNarInfoError>;
 }

--- a/src/domain/nar_info/service.rs
+++ b/src/domain/nar_info/service.rs
@@ -6,6 +6,7 @@ use snafu::Snafu;
 use tokio::task::JoinSet;
 use tokio::time::Instant;
 
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::common::url::Url;
 use crate::domain::nar_info::DeadlineGroup;
 use crate::domain::nar_info::model::{
@@ -43,11 +44,12 @@ impl NarInfoService {
     pub async fn resolve(
         &self,
         hash: &StorePathHash,
+        headers: PassthroughHeaders,
     ) -> (
         Result<NarInfoResolution, ResolveNarInfoError>,
         Vec<ResolveNarInfoEvent>,
     ) {
-        let (res, mut events) = self.resolve_unknown(hash).await;
+        let (res, mut events) = self.resolve_unknown(hash, headers).await;
         match res {
             Ok(outcome) => {
                 let resolution =
@@ -79,6 +81,7 @@ impl NarInfoService {
     async fn resolve_unknown(
         &self,
         hash: &StorePathHash,
+        headers: PassthroughHeaders,
     ) -> (
         Result<Option<(UpstreamNarInfoData, SubstituterMeta)>, ResolveNarInfoError>,
         Vec<ResolveNarInfoEvent>,
@@ -86,7 +89,7 @@ impl NarInfoService {
         let substituters = self.substituter_repository.query_all_available().await;
 
         let (res, events) = self
-            .query_substituters(hash, substituters, self.tolerance)
+            .query_substituters(hash, headers, substituters, self.tolerance)
             .await;
         (res, events)
     }
@@ -94,12 +97,14 @@ impl NarInfoService {
     async fn query_substituters(
         &self,
         hash: &StorePathHash,
+        headers: PassthroughHeaders,
         substituters: Arc<Vec<SubstituterCandidate>>,
         tolerance: u64,
     ) -> (
         Result<Option<(UpstreamNarInfoData, SubstituterMeta)>, ResolveNarInfoError>,
         Vec<ResolveNarInfoEvent>,
     ) {
+        let headers = Arc::new(headers);
         let mut substituter_graces = HashMap::new();
         for substituter in substituters.iter() {
             substituter_graces.insert(substituter, substituter.grace(tolerance as i64));
@@ -115,8 +120,9 @@ impl NarInfoService {
                 let provider = Arc::clone(&self.nar_info_provider);
                 let sub = substituter.clone();
                 let url = hash.on_substituter(sub.meta());
+                let headers = Arc::clone(&headers);
                 let timeout = sub.meta().nar_info_timeout();
-                async move { (sub, provider.query_nar_info(&url, timeout).await) }
+                async move { (sub, provider.query_nar_info(&url, &headers, timeout).await) }
             });
             query_cancellers.insert(substituter, handle);
         }

--- a/src/infrastructure/provider/nar_info_provider.rs
+++ b/src/infrastructure/provider/nar_info_provider.rs
@@ -7,6 +7,7 @@ use http::StatusCode;
 use reqwest::Client;
 use snafu::ResultExt;
 
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::common::url::Url;
 use crate::domain::nar_info::model::UpstreamNarInfoData;
 use crate::domain::nar_info::port::error_ctx::{OfflineSnafu, ServiceSnafu};
@@ -34,12 +35,17 @@ impl NarInfoProvider for ReqwestNarInfoProvider {
     async fn query_nar_info(
         &self,
         url: &Url,
+        headers: &PassthroughHeaders,
         timeout: Option<Duration>,
     ) -> Result<Option<NarInfoQueryData>, QueryNarInfoError> {
         tracing::debug!(%url, "fetching nar info from substituter");
 
         let timeout = timeout.unwrap_or(self.default_timeout);
-        let request = self.client.get(url.value()).timeout(timeout);
+        let request = self
+            .client
+            .get(url.value())
+            .headers(headers.to_headers())
+            .timeout(timeout);
 
         let request = if let Some(credential) = self.credentials.lookup(url) {
             request.basic_auth(credential.login.clone(), credential.secret.clone())

--- a/src/infrastructure/provider/nar_info_provider.rs
+++ b/src/infrastructure/provider/nar_info_provider.rs
@@ -3,7 +3,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
-use reqwest::{Client, StatusCode};
+use http::StatusCode;
+use reqwest::Client;
 use snafu::ResultExt;
 
 use crate::domain::common::url::Url;

--- a/src/infrastructure/provider/nar_stream_provider.rs
+++ b/src/infrastructure/provider/nar_stream_provider.rs
@@ -8,6 +8,7 @@ use reqwest::{Client, Response};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::common::url::Url;
 use crate::domain::nar_file::model::NarFileLocation;
 use crate::domain::nar_file::port::{NarStreamData, NarStreamHeaders, NarStreamProvider};
@@ -59,6 +60,7 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
     async fn stream_nar(
         &self,
         locations: &[NarFileLocation],
+        headers: &PassthroughHeaders,
     ) -> AnyhowResult<Option<NarStreamData>> {
         if locations.is_empty() {
             return Ok(None);
@@ -69,14 +71,20 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
             let client = self.client.clone();
             let location = location.clone();
             let concurrency = self.concurrency.clone();
+            let headers = headers.clone();
             let credentials = self.credentials.clone();
             set.spawn(async move {
                 let _permit = concurrency.acquire().await.unwrap();
-                let mut request = client.get(location.source_url().value());
+
+                let mut request = client
+                    .get(location.source_url().value())
+                    .headers(headers.to_headers());
+
                 if let Some(credential) = credentials.lookup(location.source_url()) {
                     request =
                         request.basic_auth(credential.login.clone(), credential.secret.clone());
                 }
+
                 let response = if let Some(timeout) = location.timeout() {
                     tokio::time::timeout(timeout, request.send()).await
                 } else {

--- a/src/infrastructure/provider/nar_stream_provider.rs
+++ b/src/infrastructure/provider/nar_stream_provider.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result as AnyhowResult};
 use async_trait::async_trait;
 use futures::StreamExt;
-use reqwest::{Client, Response, StatusCode};
+use http::{StatusCode, header};
+use reqwest::{Client, Response};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
@@ -36,12 +37,12 @@ impl ReqwestNarStreamProvider {
             content_length: response.content_length(),
             content_type: response
                 .headers()
-                .get(reqwest::header::CONTENT_TYPE)
+                .get(header::CONTENT_TYPE)
                 .and_then(|v| v.to_str().ok())
                 .map(ToString::to_string),
             content_encoding: response
                 .headers()
-                .get(reqwest::header::CONTENT_ENCODING)
+                .get(header::CONTENT_ENCODING)
                 .and_then(|v| v.to_str().ok())
                 .map(ToString::to_string),
         };

--- a/src/infrastructure/provider/substituter_probing_provider.rs
+++ b/src/infrastructure/provider/substituter_probing_provider.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 
 use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
-use reqwest::{Client, StatusCode};
+use http::StatusCode;
+use reqwest::Client;
 use snafu::ResultExt;
 use tokio::sync::Semaphore;
 

--- a/tests/integration/mock/nar_info_provider.rs
+++ b/tests/integration/mock/nar_info_provider.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use selector4nix::domain::common::passthrough_headers::PassthroughHeaders;
 use selector4nix::domain::common::url::Url;
 use selector4nix::domain::nar_info::port::error_ctx::{OfflineSnafu, ServiceSnafu};
 use selector4nix::domain::nar_info::port::{NarInfoProvider, NarInfoQueryData, QueryNarInfoError};
@@ -28,6 +29,7 @@ impl NarInfoProvider for MockNarInfoProvider {
     async fn query_nar_info(
         &self,
         url: &Url,
+        _headers: &PassthroughHeaders,
         timeout: Option<Duration>,
     ) -> Result<Option<NarInfoQueryData>, QueryNarInfoError> {
         let Some(data) = self.queries.get(url) else {

--- a/tests/integration/nar_info_service_test.rs
+++ b/tests/integration/nar_info_service_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use selector4nix::domain::common::passthrough_headers::PassthroughHeaders;
 use selector4nix::domain::common::url::Url;
 use selector4nix::domain::nar_info::model::{NarUrlRewriteOption, StorePathHash};
 use selector4nix::domain::nar_info::port::NarInfoQueryData;
@@ -59,7 +60,9 @@ async fn run_test(
         env.ignore_query_error,
     );
 
-    let (res, events) = nar_resolution_service.resolve(&input.hash).await;
+    let (res, events) = nar_resolution_service
+        .resolve(&input.hash, PassthroughHeaders::empty())
+        .await;
 
     assert_eq!(
         res.map(|resolution| resolution.source_url().cloned()),


### PR DESCRIPTION
Currently selector4nix hardcodes curl and Nix versions in its User-Agent. This PR replaces the hardcoded value with the one from the Nix client, with selector4nix's own string appended.