### PR TITLE
Apply NAR file streaming throttling per substituter host 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,7 @@ Timeout in seconds for NAR file downloads, also used as connect timeout.
 - Type: Natural
 - Default: `12`
 
-Maximum number of concurrent outgoing HTTP requests for NAR file streaming.
+Maximum number of concurrent outgoing NAR file streaming requests, applied per distinct substituter host. The overall ceiling across the proxy is `max_concurrent_requests` multiplied by the number of distinct substituter hosts.
 
 ### `network.tolerance_msecs`
 

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -14,7 +14,7 @@ port = 5496
 nar_info_timeout_secs = 30
 # Timeout in seconds for NAR file downloads, also used as connect timeout (default: 30, minimum: 1).
 nar_timeout_secs = 30
-# Maximum number of concurrent outgoing HTTP requests for NAR file streaming (default: 12).
+# Maximum number of concurrent NAR file streaming requests per distinct substituter host (default: 12).
 max_concurrent_requests = 12
 # Latency tolerance window in milliseconds. After the fastest substituter responds,
 # others have this many additional milliseconds before being pruned (default: 50, minimum: 1).

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -23,12 +23,12 @@ use selector4nix::domain::substituter::{SubstituterRepository, SubstituterServic
 use selector4nix::infrastructure::config::{AppConfiguration, AppCredential};
 use selector4nix::infrastructure::provider::*;
 use selector4nix::infrastructure::repository::*;
+use selector4nix::infrastructure::util::PerHostHttpThrottler;
 use selector4nix_actor::actor::Address;
 use selector4nix_actor::registry::{
     AsyncFactory, CapacityOption, ExpirationOption, RegistryBuilder,
 };
 use selector4nix_db::cache_kv::CacheKv;
-use tokio::sync::Semaphore;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer, Registry};
@@ -125,7 +125,9 @@ pub async fn init_context(
         .build()
         .context("could not build HTTP client")?;
 
-    let concurrency = Arc::new(Semaphore::new(config.network.max_concurrent_requests));
+    let throttler = Arc::new(PerHostHttpThrottler::new(
+        config.network.max_concurrent_requests,
+    ));
 
     let substituter_probing_provider = Arc::new(ReqwestSubstituterProbingProvider::new(
         http_client.clone(),
@@ -141,7 +143,7 @@ pub async fn init_context(
 
     let nar_stream_provider = Arc::new(ReqwestNarStreamProvider::new(
         http_client,
-        concurrency,
+        throttler,
         credentials.clone(),
     ));
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -130,7 +130,6 @@ pub async fn init_context(
     let substituter_probing_provider = Arc::new(ReqwestSubstituterProbingProvider::new(
         http_client.clone(),
         config.network.nar_info_timeout,
-        concurrency.clone(),
         credentials.clone(),
     ));
 

--- a/src/domain/common/url.rs
+++ b/src/domain/common/url.rs
@@ -46,6 +46,10 @@ impl Url {
         }
         Self(inner)
     }
+
+    pub fn host(&self) -> &str {
+        self.0.host_str().expect("`Url` should have a host")
+    }
 }
 
 impl Display for Url {

--- a/src/domain/common/url.rs
+++ b/src/domain/common/url.rs
@@ -46,10 +46,6 @@ impl Url {
         }
         Self(inner)
     }
-
-    pub fn get_dir(&self) -> Self {
-        Self::new(self.0.as_str().trim_end_matches(|c| c != '/')).unwrap()
-    }
 }
 
 impl Display for Url {
@@ -144,26 +140,6 @@ mod tests {
         assert_eq!(
             joined.value(),
             "https://mirrors.ustc.edu.cn/nix-channels/store/abc.narinfo"
-        );
-    }
-
-    #[test]
-    fn get_dir_returns_dir_given_url_of_file() {
-        let url = Url::new("https://mirrors.ustc.edu.cn/nix-channels/store/abc.narinfo").unwrap();
-        let dir = url.get_dir();
-        assert_eq!(
-            dir.value(),
-            "https://mirrors.ustc.edu.cn/nix-channels/store/",
-        );
-    }
-
-    #[test]
-    fn get_dir_returns_self_given_url_of_dir() {
-        let url = Url::new("https://mirrors.ustc.edu.cn/nix-channels/store/").unwrap();
-        let dir = url.get_dir();
-        assert_eq!(
-            dir.value(),
-            "https://mirrors.ustc.edu.cn/nix-channels/store/",
         );
     }
 }

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod provider;
 pub mod repository;
+pub mod util;

--- a/src/infrastructure/provider/nar_stream_provider.rs
+++ b/src/infrastructure/provider/nar_stream_provider.rs
@@ -1,11 +1,12 @@
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use anyhow::{Context, Result as AnyhowResult};
+use anyhow::{Context as _, Result as AnyhowResult};
 use async_trait::async_trait;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use http::{StatusCode, header};
 use reqwest::{Client, Response};
-use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
@@ -13,27 +14,32 @@ use crate::domain::common::url::Url;
 use crate::domain::nar_file::model::NarFileLocation;
 use crate::domain::nar_file::port::{NarStreamData, NarStreamHeaders, NarStreamProvider};
 use crate::infrastructure::config::AppCredential;
+use crate::infrastructure::util::{PerHostHttpThrottler, ThrottlerPermit};
 
 pub struct ReqwestNarStreamProvider {
     client: Client,
-    concurrency: Arc<Semaphore>,
+    throttler: Arc<PerHostHttpThrottler>,
     credentials: Arc<AppCredential>,
 }
 
 impl ReqwestNarStreamProvider {
     pub fn new(
         client: Client,
-        concurrency: Arc<Semaphore>,
+        throttler: Arc<PerHostHttpThrottler>,
         credentials: Arc<AppCredential>,
     ) -> Self {
         Self {
             client,
-            concurrency,
+            throttler,
             credentials,
         }
     }
 
-    fn wrap_ok_response(url: Url, response: Response) -> AnyhowResult<Option<NarStreamData>> {
+    fn wrap_ok_response(
+        url: Url,
+        response: Response,
+        permit: ThrottlerPermit,
+    ) -> AnyhowResult<Option<NarStreamData>> {
         let headers = NarStreamHeaders {
             content_length: response.content_length(),
             content_type: response
@@ -48,9 +54,12 @@ impl ReqwestNarStreamProvider {
                 .map(ToString::to_string),
         };
 
-        let stream = response
-            .bytes_stream()
-            .map(|chunk| chunk.with_context(|| "failed to read nar stream"));
+        let stream = ThrottledStream {
+            inner: response
+                .bytes_stream()
+                .map(|chunk| chunk.with_context(|| "failed to read nar stream")),
+            _permit: permit,
+        };
         Ok(Some(NarStreamData::new(headers, Box::pin(stream), url)))
     }
 }
@@ -68,13 +77,15 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
 
         let mut set = JoinSet::new();
         for location in locations {
-            let client = self.client.clone();
             let location = location.clone();
-            let concurrency = self.concurrency.clone();
             let headers = headers.clone();
-            let credentials = self.credentials.clone();
+
+            let client = self.client.clone();
+            let throttler = Arc::clone(&self.throttler);
+            let credentials = Arc::clone(&self.credentials);
+
             set.spawn(async move {
-                let _permit = concurrency.acquire().await.unwrap();
+                let permit = throttler.acquire(location.source_url().host()).await;
 
                 let mut request = client
                     .get(location.source_url().value())
@@ -90,14 +101,14 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
                 } else {
                     Ok(request.send().await)
                 };
-                (location.clone(), response)
+                (location.clone(), response, permit)
             });
         }
 
         let mut not_found_count = 0;
 
         while let Some(result) = set.join_next().await {
-            let Ok((location, response)) = result else {
+            let Ok((location, response, permit)) = result else {
                 continue;
             };
             let url = location.source_url();
@@ -105,7 +116,7 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
             match response {
                 Ok(Ok(response)) => match response.status() {
                     StatusCode::OK => {
-                        return Self::wrap_ok_response(url.clone(), response);
+                        return Self::wrap_ok_response(url.clone(), response, permit);
                     }
                     StatusCode::NOT_FOUND | StatusCode::FORBIDDEN => {
                         not_found_count += 1;
@@ -130,5 +141,21 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
         } else {
             Err(anyhow::anyhow!("could not fetch nar from any substituter"))
         }
+    }
+}
+
+struct ThrottledStream<S> {
+    inner: S,
+    _permit: ThrottlerPermit,
+}
+
+impl<S> Stream for ThrottledStream<S>
+where
+    S: Stream + Unpin,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().inner.poll_next_unpin(cx)
     }
 }

--- a/src/infrastructure/provider/substituter_probing_provider.rs
+++ b/src/infrastructure/provider/substituter_probing_provider.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use http::StatusCode;
 use reqwest::Client;
 use snafu::ResultExt;
-use tokio::sync::Semaphore;
 
 use crate::domain::substituter::model::SubstituterMeta;
 use crate::domain::substituter::port::error_ctx::{OfflineSnafu, ServiceSnafu};
@@ -16,21 +15,14 @@ use crate::infrastructure::config::AppCredential;
 pub struct ReqwestSubstituterProbingProvider {
     client: Client,
     default_timeout: Duration,
-    concurrency: Arc<Semaphore>,
     credentials: Arc<AppCredential>,
 }
 
 impl ReqwestSubstituterProbingProvider {
-    pub fn new(
-        client: Client,
-        default_timeout: Duration,
-        concurrency: Arc<Semaphore>,
-        credentials: Arc<AppCredential>,
-    ) -> Self {
+    pub fn new(client: Client, default_timeout: Duration, credentials: Arc<AppCredential>) -> Self {
         Self {
             client,
             default_timeout,
-            concurrency,
             credentials,
         }
     }
@@ -43,8 +35,6 @@ impl SubstituterProbingProvider for ReqwestSubstituterProbingProvider {
         substituter: &SubstituterMeta,
     ) -> Result<(), ProbeSubstituterError> {
         tracing::debug!(substituter = %substituter.url(), "probing substituter's health status");
-
-        let _permit = self.concurrency.acquire().await.unwrap();
 
         let url = substituter.url().as_dir().join("nix-cache-info").unwrap();
         let timeout = substituter

--- a/src/infrastructure/util/mod.rs
+++ b/src/infrastructure/util/mod.rs
@@ -1,0 +1,3 @@
+mod per_host_http_throttler;
+
+pub use per_host_http_throttler::{PerHostHttpThrottler, ThrottlerPermit};

--- a/src/infrastructure/util/per_host_http_throttler.rs
+++ b/src/infrastructure/util/per_host_http_throttler.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+pub struct PerHostHttpThrottler {
+    max_concurrent_requests: usize,
+    semaphores: DashMap<String, Arc<Semaphore>>,
+}
+
+impl PerHostHttpThrottler {
+    pub fn new(max_concurrent_requests: usize) -> Self {
+        Self {
+            max_concurrent_requests,
+            semaphores: DashMap::new(),
+        }
+    }
+
+    pub async fn acquire(&self, host: &str) -> ThrottlerPermit {
+        let semaphore = if let Some(semaphore) = self.semaphores.get(host) {
+            Arc::clone(semaphore.value())
+        } else {
+            loop {
+                // Dashmap is not async-aware, so directly calling `entry()` may cause deadlock if
+                // another task locked the entry in the same thread.
+                if let Some(entry) = self.semaphores.try_entry(host.into()) {
+                    // Use `or_insert()` to prevent duplicated insertion.
+                    let entry = entry
+                        .or_insert_with(|| Arc::new(Semaphore::new(self.max_concurrent_requests)));
+                    // Explicitly exit the write transaction and get the readonly entry later.
+                    drop(entry);
+
+                    let semaphore = self
+                        .semaphores
+                        .get(host)
+                        .expect("the semaphore should have already been inserted");
+                    break Arc::clone(semaphore.value());
+                } else {
+                    tokio::task::yield_now().await;
+                }
+            }
+        };
+
+        let permit = semaphore
+            .acquire_owned()
+            .await
+            .expect("the semaphore should not be closed");
+        ThrottlerPermit(permit)
+    }
+}
+
+#[expect(dead_code)]
+pub struct ThrottlerPermit(OwnedSemaphorePermit);


### PR DESCRIPTION
The current throttling strategy applies to all requests globally, which is unnecessarily restrictive if requests are sent to different hosts. This PR implements per-host throttling and removes that restriction.