### PR TITLE
feat(frontend): add dynamic status dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,6 +1602,7 @@ dependencies = [
  "selector4nix-actor",
  "selector4nix-db",
  "serde",
+ "serde_json",
  "snafu",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,6 @@ url = { workspace = true }
 
 selector4nix-actor = { path = "components/selector4nix-actor" }
 selector4nix-db = { path = "components/selector4nix-db" }
+
+[dev-dependencies]
+serde_json = "1.0.145"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ postcard = { version = "1.1.3", default-features = false, features = ["use-std"]
 redb = "4.1.0"
 reqwest = { version = "0.13.2", features = ["stream"] }
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 snafu = "0.9.0"
 tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "signal", "sync", "time", "test-util"] }
 toml = "1.1.2"
@@ -68,4 +69,4 @@ selector4nix-actor = { path = "components/selector4nix-actor" }
 selector4nix-db = { path = "components/selector4nix-db" }
 
 [dev-dependencies]
-serde_json = "1.0.145"
+serde_json = { workspace = true }

--- a/components/selector4nix-actor/src/registry/container.rs
+++ b/components/selector4nix-actor/src/registry/container.rs
@@ -96,6 +96,10 @@ where
         self.actors.invalidate_all();
         self.actors.run_pending_tasks().await;
     }
+
+    pub async fn entry_count(&self) -> u64 {
+        self.actors.entry_count()
+    }
 }
 
 impl<K, A, F> Registry<K, A, F>

--- a/src/api/handlers/index.html
+++ b/src/api/handlers/index.html
@@ -19,11 +19,14 @@
 
     :root {
       --bg: #0f1117;
+      --surface: #161b22;
       --border: #2a2d3a;
       --text: #c9d1d9;
       --text-dim: #8b949e;
       --accent: #58a6ff;
       --green: #3fb950;
+      --yellow: #d29922;
+      --red: #f85149;
       --font-sans: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
     }
 
@@ -31,11 +34,9 @@
       font-family: var(--font-sans);
       background: var(--bg);
       color: var(--text);
-      display: flex;
-      justify-content: center;
-      align-items: center;
       min-height: 100vh;
       -webkit-font-smoothing: antialiased;
+      padding: 2rem 1.25rem 3rem;
     }
 
     a {
@@ -47,9 +48,14 @@
       text-decoration: underline;
     }
 
-    main {
+    .container {
+      max-width: 760px;
+      margin: 0 auto;
+    }
+
+    header {
       text-align: center;
-      padding: 2rem 1.5rem;
+      margin-bottom: 2rem;
     }
 
     h1 {
@@ -64,23 +70,43 @@
       color: var(--accent);
     }
 
-    p {
+    .subtitle {
       color: var(--text-dim);
       font-size: 0.95rem;
-      margin-bottom: 1.25rem;
+      margin-bottom: 1rem;
+    }
+
+    .header-bar {
+      display: inline-flex;
+      align-items: center;
+      gap: 0;
+      padding: 0.2rem 0.65rem 0.2rem 0.25rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+    }
+
+    .header-bar .version {
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: var(--text-dim);
+      padding: 0.2rem 0.45rem 0.2rem 0.65rem;
+      border-left: 1px solid var(--border);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .header-bar .version.visible {
+      color: var(--text);
     }
 
     .status {
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
-      padding: 0.3rem 0.75rem;
-      background: rgba(63, 185, 80, 0.08);
-      border: 1px solid rgba(63, 185, 80, 0.2);
+      padding: 0.3rem 0.65rem;
       border-radius: 999px;
       font-size: 0.8rem;
-      color: var(--green);
-      margin-bottom: 2rem;
+      border: 1px solid transparent;
     }
 
     .status::before {
@@ -88,8 +114,38 @@
       width: 6px;
       height: 6px;
       border-radius: 50%;
-      background: var(--green);
       animation: pulse 2s ease-in-out infinite;
+    }
+
+    .status.running {
+      background: rgba(63, 185, 80, 0.08);
+      border-color: rgba(63, 185, 80, 0.2);
+      color: var(--green);
+    }
+
+    .status.running::before {
+      background: var(--green);
+    }
+
+    .status.error {
+      background: rgba(248, 81, 73, 0.08);
+      border-color: rgba(248, 81, 73, 0.2);
+      color: var(--red);
+    }
+
+    .status.error::before {
+      background: var(--red);
+      animation: none;
+    }
+
+    .status.loading {
+      background: rgba(139, 148, 158, 0.08);
+      border-color: rgba(139, 148, 158, 0.2);
+      color: var(--text-dim);
+    }
+
+    .status.loading::before {
+      background: var(--text-dim);
     }
 
     @keyframes pulse {
@@ -104,11 +160,185 @@
       }
     }
 
+    section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1rem 1.1rem;
+      margin-bottom: 1rem;
+    }
+
+    section h2 {
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+      margin-bottom: 0.85rem;
+    }
+
+    .grid-2 {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75rem;
+    }
+
+    .stat-card {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.75rem 0.85rem;
+    }
+
+    .stat-card .label {
+      font-size: 0.75rem;
+      color: var(--text-dim);
+      margin-bottom: 0.25rem;
+    }
+
+    .stat-card .value {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #fff;
+    }
+
+    .stat-card .detail {
+      font-size: 0.72rem;
+      color: var(--text-dim);
+      margin-top: 0.2rem;
+    }
+
+    .substituter-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .substituter-item {
+      display: flex;
+      align-items: center;
+      gap: 0.7rem;
+      padding: 0.6rem 0.75rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 0.82rem;
+    }
+
+    .substituter-item:hover {
+      border-color: #3d4455;
+    }
+
+    .status-dot {
+      flex-shrink: 0;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      margin-left: 0.1rem;
+    }
+
+    .status-dot.normal {
+      background: var(--green);
+      box-shadow: 0 0 0 2px rgba(63, 185, 80, 0.2);
+    }
+
+    .status-dot.maybe_ready {
+      background: var(--yellow);
+      box-shadow: 0 0 0 2px rgba(210, 153, 34, 0.2);
+    }
+
+    .status-dot.offline,
+    .status-dot.service_error {
+      background: var(--red);
+      box-shadow: 0 0 0 2px rgba(248, 81, 73, 0.2);
+    }
+
+    .substituter-url {
+      flex: 1;
+      min-width: 0;
+      color: var(--text);
+      font-size: 0.82rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .substituter-tags {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+      flex-shrink: 0;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.18rem 0.45rem;
+      border-radius: 5px;
+      font-size: 0.68rem;
+      font-weight: 700;
+      white-space: nowrap;
+      line-height: 1;
+    }
+
+    .tag.priority {
+      background: rgba(139, 148, 158, 0.12);
+      color: var(--text-dim);
+      font-variant-numeric: tabular-nums;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    .tag.auth {
+      background: rgba(88, 166, 255, 0.14);
+      color: var(--accent);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .tag.status-warn {
+      background: rgba(248, 81, 73, 0.12);
+      color: var(--red);
+      text-transform: lowercase;
+    }
+
+    .tag.status-recover {
+      background: rgba(210, 153, 34, 0.12);
+      color: var(--yellow);
+      text-transform: lowercase;
+    }
+
+    .info-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem 1rem;
+      font-size: 0.82rem;
+      color: var(--text-dim);
+    }
+
+    .info-row strong {
+      color: var(--text);
+      font-weight: 700;
+    }
+
+    .info-row .config-warn strong {
+      color: var(--yellow);
+    }
+
+    .empty {
+      color: var(--text-dim);
+      font-size: 0.82rem;
+      text-align: center;
+      padding: 0.5rem 0;
+    }
+
     nav {
       display: flex;
       gap: 1.5rem;
       justify-content: center;
       flex-wrap: wrap;
+      margin-top: 1.5rem;
     }
 
     nav a {
@@ -127,21 +357,250 @@
       margin-right: 1.5rem;
       color: var(--border);
     }
+
+    @media (max-width: 540px) {
+      .grid-2 {
+        grid-template-columns: 1fr;
+      }
+
+      .substituter-item {
+        flex-wrap: wrap;
+        gap: 0.45rem 0.7rem;
+      }
+
+      .substituter-tags {
+        width: 100%;
+        padding-left: 1.35rem;
+      }
+    }
   </style>
 </head>
 
 <body>
-  <main>
-    <h1><span>selector</span>4nix</h1>
-    <p>A Nix substituter proxy with parallel cache queries and latency-aware selection.</p>
-    <div class="status">Running</div>
+  <div class="container">
+    <header>
+      <h1><span>selector</span>4nix</h1>
+      <p class="subtitle">A Nix substituter proxy with parallel cache queries and latency-aware selection.</p>
+      <div class="header-bar">
+        <div id="health-status" class="status loading">Connecting</div>
+        <span id="runtime-version" class="version"></span>
+      </div>
+    </header>
+
+    <section>
+      <h2>Substituters <span id="substituter-summary"></span></h2>
+      <ul id="substituter-list" class="substituter-list">
+        <li class="empty">Loading…</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Cache Stats</h2>
+      <div id="cache-stats" class="grid-2"></div>
+    </section>
+
+    <section>
+      <h2>Nix Cache Info</h2>
+      <div id="cache-info" class="info-row"></div>
+    </section>
+
+    <section>
+      <h2>Configuration</h2>
+      <div id="config-info" class="info-row"></div>
+    </section>
+
     <nav>
       <a href="https://github.com/StarryReverie/selector4nix">GitHub</a>
       <a href="https://github.com/StarryReverie/selector4nix/blob/main/docs/configuration.md">Configuration</a>
-      <a href="/substituters/available">Substituters</a>
+      <a href="/substituters/available">Substituters API</a>
       <a href="/health">Health</a>
     </nav>
-  </main>
+  </div>
+
+  <script>
+    function statusLabel(status) {
+      return status.replaceAll('_', ' ');
+    }
+
+    function renderStatusDot(status) {
+      return `<span class="status-dot ${status}" title="${statusLabel(status)}"></span>`;
+    }
+
+    function setHealth(ok, text) {
+      const el = document.getElementById('health-status');
+      el.className = `status ${ok ? 'running' : 'error'}`;
+      el.textContent = text;
+    }
+
+    function renderRuntime(data) {
+      const el = document.getElementById('runtime-version');
+      el.textContent = `v${data.version}`;
+      el.classList.add('visible');
+    }
+
+    function renderSubstituters(substituters) {
+      document.getElementById('substituter-summary').textContent =
+        `(${substituters.available}/${substituters.total} available)`;
+
+      const list = document.getElementById('substituter-list');
+      if (substituters.items.length === 0) {
+        list.innerHTML = '<li class="empty">No substituters configured</li>';
+        return;
+      }
+
+      list.innerHTML = substituters.items.map((item) => {
+        const statusTag = item.status !== 'normal'
+          ? `<span class="tag ${item.status === 'maybe_ready' ? 'status-recover' : 'status-warn'}">${statusLabel(item.status)}</span>`
+          : '';
+        const failureTag = item.prev_failures > 0
+          ? `<span class="tag status-warn">${item.prev_failures}×</span>`
+          : '';
+        const authTag = item.has_credential
+          ? '<span class="tag auth">AUTH</span>'
+          : '';
+        return `
+          <li class="substituter-item">
+            ${renderStatusDot(item.status)}
+            <span class="substituter-url" title="${item.url}">${item.url}</span>
+            <div class="substituter-tags">
+              ${statusTag}
+              ${failureTag}
+              ${authTag}
+              <span class="tag priority">pri ${item.priority}</span>
+            </div>
+          </li>
+        `;
+      }).join('');
+    }
+
+    function renderCacheStats(stats, cacheMode) {
+      const el = document.getElementById('cache-stats');
+      const storeDetail = cacheMode === 'persistent' ? 'persistent redb' : 'in_memory redb';
+      const cards = [
+        {
+          label: 'NAR Info Lookup',
+          value: stats.nar_info_lookup.entries,
+          detail: `${stats.nar_info_lookup.entries} / ${stats.nar_info_lookup.capacity} · TTL ${stats.nar_info_lookup.ttl_secs}s`,
+        },
+        {
+          label: 'NAR Location',
+          value: stats.nar_location.entries,
+          detail: `${stats.nar_location.entries} / ${stats.nar_location.capacity} · TTL ${stats.nar_location.ttl_secs}s`,
+        },
+        {
+          label: 'NAR Info Store',
+          value: stats.nar_info_store.entries,
+          detail: storeDetail,
+        },
+        {
+          label: 'NAR File Store',
+          value: stats.nar_file_store.entries,
+          detail: storeDetail,
+        },
+      ];
+
+      el.innerHTML = cards.map((card) => `
+        <div class="stat-card">
+          <div class="label">${card.label}</div>
+          <div class="value">${card.value}</div>
+          <div class="detail">${card.detail}</div>
+        </div>
+      `).join('');
+    }
+
+    function parseNixCacheInfo(text) {
+      return text.trim().split('\n')
+        .filter((line) => line.includes(':'))
+        .map((line) => {
+          const idx = line.indexOf(':');
+          return [line.slice(0, idx).trim(), line.slice(idx + 1).trim()];
+        });
+    }
+
+    function renderCacheInfo(entries) {
+      const el = document.getElementById('cache-info');
+      if (entries.length === 0) {
+        el.innerHTML = '<span class="empty">Unavailable</span>';
+        return;
+      }
+      el.innerHTML = entries
+        .map(([key, value]) => `<span>${key} <strong>${value}</strong></span>`)
+        .join('');
+    }
+
+    function renderConfig(data) {
+      const cacheMode = data.cache_mode === 'persistent' ? 'persistent' : 'in_memory';
+      const proxy = data.proxy;
+      const network = data.network;
+      const items = [
+        ['Cache', cacheMode],
+        ['Rewrite Target', proxy.rewrite_to_target],
+        ['Probing', network.periodic_probing ? 'enabled' : 'disabled'],
+        ['Tolerance', `${network.tolerance_msecs}ms`],
+        ['NAR Info Timeout', `${network.nar_info_timeout_secs}s`],
+        ['NAR Timeout', `${network.nar_timeout_secs}s`],
+        ['Max Concurrent', String(network.max_concurrent_requests)],
+        ['Ignore NAR Error', network.ignore_nar_info_error ? 'enabled' : 'disabled'],
+      ];
+
+      document.getElementById('config-info').innerHTML = items
+        .map(([key, value]) => {
+          const warn = key === 'Ignore NAR Error' && value === 'enabled' ? ' config-warn' : '';
+          return `<span class="${warn.trim()}">${key} <strong>${value}</strong></span>`;
+        })
+        .join('');
+    }
+
+    function setSectionError(id, message) {
+      const el = document.getElementById(id);
+      if (el) {
+        el.innerHTML = `<span class="empty">${message}</span>`;
+      }
+    }
+
+    async function refresh() {
+      let healthOk = false;
+      try {
+        const [healthRes, statusRes, cacheInfoRes] = await Promise.all([
+          fetch('/health'),
+          fetch('/status'),
+          fetch('/nix-cache-info'),
+        ]);
+
+        healthOk = healthRes.ok;
+        setHealth(healthOk, healthOk ? 'Running' : 'Unhealthy');
+        if (!healthOk) {
+          return;
+        }
+
+        if (!statusRes.ok) {
+          setSectionError('substituter-list', `Status unavailable (${statusRes.status})`);
+          setSectionError('cache-stats', 'Unavailable');
+          setSectionError('config-info', 'Unavailable');
+          console.error('failed to load /status', statusRes.status);
+          return;
+        }
+
+        const data = await statusRes.json();
+        renderRuntime(data);
+        renderSubstituters(data.substituters);
+        renderCacheStats(data.cache_stats, data.cache_mode);
+        if (cacheInfoRes.ok) {
+          renderCacheInfo(parseNixCacheInfo(await cacheInfoRes.text()));
+        } else {
+          renderCacheInfo([]);
+        }
+        renderConfig(data);
+      } catch (err) {
+        if (!healthOk) {
+          setHealth(false, 'Unreachable');
+        }
+        console.error('failed to refresh dashboard', err);
+      }
+    }
+
+    refresh();
+  </script>
 </body>
 
 </html>

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -3,4 +3,5 @@ pub mod health;
 pub mod index;
 pub mod nar;
 pub mod nar_info;
+pub mod status;
 pub mod substituter;

--- a/src/api/handlers/status.rs
+++ b/src/api/handlers/status.rs
@@ -1,0 +1,142 @@
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::Json;
+use serde::Serialize;
+
+use crate::api::state::AppContext;
+use crate::application::status::usecase::{CacheMode, StatusSnapshot, availability_status};
+use crate::domain::nar_info::model::NarUrlRewriteOption;
+
+#[derive(Serialize)]
+pub struct StatusResponse {
+    version: &'static str,
+    cache_mode: &'static str,
+    network: NetworkStatus,
+    proxy: ProxyStatus,
+    substituters: SubstitutersStatus,
+    cache_stats: CacheStatsStatus,
+}
+
+#[derive(Serialize)]
+struct NetworkStatus {
+    periodic_probing: bool,
+    tolerance_msecs: u64,
+    nar_info_timeout_secs: u64,
+    nar_timeout_secs: u64,
+    max_concurrent_requests: usize,
+    ignore_nar_info_error: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct ProxyStatus {
+    rewrite_to_target: &'static str,
+}
+
+#[derive(Serialize)]
+struct SubstitutersStatus {
+    total: usize,
+    available: usize,
+    items: Vec<SubstituterStatusItem>,
+}
+
+#[derive(Serialize)]
+struct SubstituterStatusItem {
+    url: String,
+    priority: u32,
+    status: &'static str,
+    prev_failures: usize,
+    has_credential: bool,
+}
+
+#[derive(Serialize)]
+struct CacheStatsStatus {
+    nar_info_lookup: LookupCacheStatus,
+    nar_location: LookupCacheStatus,
+    nar_info_store: StoreCacheStatus,
+    nar_file_store: StoreCacheStatus,
+}
+
+#[derive(Serialize)]
+struct LookupCacheStatus {
+    entries: usize,
+    capacity: usize,
+    ttl_secs: u64,
+}
+
+#[derive(Serialize)]
+struct StoreCacheStatus {
+    entries: usize,
+}
+
+pub async fn get_status(State(ctx): State<Arc<AppContext>>) -> Json<StatusResponse> {
+    Json(to_response(ctx.status_query_usecase().snapshot().await))
+}
+
+fn to_response(snapshot: StatusSnapshot) -> StatusResponse {
+    let runtime = &snapshot.runtime;
+    let config = &runtime.config;
+    let mut substituters: Vec<SubstituterStatusItem> = snapshot
+        .substituters
+        .iter()
+        .map(|sub| SubstituterStatusItem {
+            url: sub.url().to_string(),
+            priority: sub.priority().value(),
+            status: availability_status(sub.availability()),
+            prev_failures: sub.prev_failures(),
+            has_credential: runtime.authenticated_substituter_urls.contains(sub.url()),
+        })
+        .collect();
+    substituters.sort_by_key(|item| item.priority);
+
+    StatusResponse {
+        version: runtime.version,
+        cache_mode: match runtime.cache_mode {
+            CacheMode::Persistent => "persistent",
+            CacheMode::InMemory => "in_memory",
+        },
+        network: NetworkStatus {
+            periodic_probing: config.network.periodic_probing
+                == crate::domain::substituter::model::PeriodicProbingOption::Enabled,
+            tolerance_msecs: config.network.tolerance,
+            nar_info_timeout_secs: config.network.nar_info_timeout.as_secs(),
+            nar_timeout_secs: config.network.nar_timeout.as_secs(),
+            max_concurrent_requests: config.network.max_concurrent_requests,
+            ignore_nar_info_error: config.network.ignore_nar_info_error,
+        },
+        proxy: proxy_status(config.proxy.rewrite_nar_url),
+        substituters: SubstitutersStatus {
+            total: substituters.len(),
+            available: snapshot.available_substituter_count(),
+            items: substituters,
+        },
+        cache_stats: CacheStatsStatus {
+            nar_info_lookup: LookupCacheStatus {
+                entries: snapshot.nar_info_actor_entries,
+                capacity: config.cache.nar_info_lookup_capacity,
+                ttl_secs: config.cache.nar_info_lookup_ttl.as_secs(),
+            },
+            nar_location: LookupCacheStatus {
+                entries: snapshot.nar_file_actor_entries,
+                capacity: config.cache.nar_location_capacity,
+                ttl_secs: config.cache.nar_location_ttl.as_secs(),
+            },
+            nar_info_store: StoreCacheStatus {
+                entries: snapshot.nar_info_persistent_entries,
+            },
+            nar_file_store: StoreCacheStatus {
+                entries: snapshot.nar_file_persistent_entries,
+            },
+        },
+    }
+}
+
+fn proxy_status(proxy: NarUrlRewriteOption) -> ProxyStatus {
+    ProxyStatus {
+        rewrite_to_target: match proxy {
+            NarUrlRewriteOption::Keep => "keep",
+            NarUrlRewriteOption::ToSelf => "self",
+            NarUrlRewriteOption::ToUpstream => "upstream",
+        },
+    }
+}

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -8,6 +8,7 @@ use crate::api::handlers::health::get_health;
 use crate::api::handlers::index::get_index;
 use crate::api::handlers::nar::get_nar;
 use crate::api::handlers::nar_info::get_nar_info;
+use crate::api::handlers::status::get_status;
 use crate::api::handlers::substituter::get_available_substituters;
 use crate::api::state::AppContext;
 
@@ -15,6 +16,7 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
     Router::new()
         .route("/", get(get_index))
         .route("/health", get(get_health))
+        .route("/status", get(get_status))
         .route("/substituters/available", get(get_available_substituters))
         .route("/nix-cache-info", get(get_nix_cache_info))
         .route("/nar/{path}", get(get_nar))

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -4,6 +4,7 @@ use getset::Getters;
 
 use crate::application::nar_file::usecase::NarFileStreamingUseCase;
 use crate::application::nar_info::usecase::NarInfoResolutionUseCase;
+use crate::application::status::usecase::StatusQueryUseCase;
 use crate::application::substituter::usecase::SubstituterQueryUseCase;
 use crate::infrastructure::config::CacheInfoConfiguration;
 
@@ -13,6 +14,7 @@ pub struct AppContext {
     substituter_query_usecase: SubstituterQueryUseCase,
     nar_info_resolution_usecase: NarInfoResolutionUseCase,
     nar_file_streaming_usecase: NarFileStreamingUseCase,
+    status_query_usecase: StatusQueryUseCase,
     cache_info: CacheInfoConfiguration,
 }
 
@@ -21,12 +23,14 @@ impl AppContext {
         substituter_query_usecase: SubstituterQueryUseCase,
         nar_info_resolution_usecase: NarInfoResolutionUseCase,
         nar_file_streaming_usecase: NarFileStreamingUseCase,
+        status_query_usecase: StatusQueryUseCase,
         cache_info: CacheInfoConfiguration,
     ) -> Arc<Self> {
         Arc::new(Self {
             substituter_query_usecase,
             nar_info_resolution_usecase,
             nar_file_streaming_usecase,
+            status_query_usecase,
             cache_info,
         })
     }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,5 +1,6 @@
 pub mod nar_file;
 pub mod nar_info;
+pub mod status;
 pub mod substituter;
 
 mod error;

--- a/src/application/status/mod.rs
+++ b/src/application/status/mod.rs
@@ -1,0 +1,1 @@
+pub mod usecase;

--- a/src/application/status/usecase/mod.rs
+++ b/src/application/status/usecase/mod.rs
@@ -1,0 +1,5 @@
+mod query;
+
+pub use query::{
+    CacheMode, StatusQueryUseCase, StatusRuntimeInfo, StatusSnapshot, availability_status,
+};

--- a/src/application/status/usecase/query.rs
+++ b/src/application/status/usecase/query.rs
@@ -63,9 +63,11 @@ impl StatusQueryUseCase {
     }
 
     pub async fn snapshot(&self) -> StatusSnapshot {
+        tracing::info!("querying status snapshot");
+
         let substituters = self.substituter_repository.query_all().await;
 
-        StatusSnapshot {
+        let snapshot = StatusSnapshot {
             runtime: self.runtime.clone(),
             substituters,
             nar_info_actor_entries: self
@@ -96,7 +98,19 @@ impl StatusQueryUseCase {
                     tracing::warn!(%err, cache = "nar_file", "failed to get cache entry count");
                     0
                 }),
-        }
+        };
+
+        tracing::info!(
+            substituters_total = snapshot.substituters.len(),
+            substituters_available = snapshot.available_substituter_count(),
+            nar_info_actor_entries = snapshot.nar_info_actor_entries,
+            nar_file_actor_entries = snapshot.nar_file_actor_entries,
+            nar_info_persistent_entries = snapshot.nar_info_persistent_entries,
+            nar_file_persistent_entries = snapshot.nar_file_persistent_entries,
+            "queried status snapshot"
+        );
+
+        snapshot
     }
 }
 

--- a/src/application/status/usecase/query.rs
+++ b/src/application/status/usecase/query.rs
@@ -1,0 +1,119 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::application::nar_file::actor::NarFileActorRegistry;
+use crate::application::nar_info::actor::NarInfoActorRegistry;
+use crate::domain::common::url::Url;
+use crate::domain::nar_file::NarFileRepository;
+use crate::domain::nar_info::NarInfoRepository;
+use crate::domain::substituter::SubstituterRepository;
+use crate::domain::substituter::model::{Availability, Substituter};
+use crate::infrastructure::config::AppConfiguration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CacheMode {
+    Persistent,
+    InMemory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusRuntimeInfo {
+    pub version: &'static str,
+    pub cache_mode: CacheMode,
+    pub config: Arc<AppConfiguration>,
+    pub authenticated_substituter_urls: HashSet<Url>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusSnapshot {
+    pub runtime: Arc<StatusRuntimeInfo>,
+    pub substituters: Vec<Substituter>,
+    pub nar_info_actor_entries: usize,
+    pub nar_file_actor_entries: usize,
+    pub nar_info_persistent_entries: usize,
+    pub nar_file_persistent_entries: usize,
+}
+
+pub struct StatusQueryUseCase {
+    substituter_repository: Arc<dyn SubstituterRepository>,
+    runtime: Arc<StatusRuntimeInfo>,
+    nar_info_registry: Arc<NarInfoActorRegistry>,
+    nar_file_registry: Arc<NarFileActorRegistry>,
+    nar_info_repository: Arc<dyn NarInfoRepository>,
+    nar_file_repository: Arc<dyn NarFileRepository>,
+}
+
+impl StatusQueryUseCase {
+    pub fn new(
+        substituter_repository: Arc<dyn SubstituterRepository>,
+        runtime: Arc<StatusRuntimeInfo>,
+        nar_info_registry: Arc<NarInfoActorRegistry>,
+        nar_file_registry: Arc<NarFileActorRegistry>,
+        nar_info_repository: Arc<dyn NarInfoRepository>,
+        nar_file_repository: Arc<dyn NarFileRepository>,
+    ) -> Self {
+        Self {
+            substituter_repository,
+            runtime,
+            nar_info_registry,
+            nar_file_registry,
+            nar_info_repository,
+            nar_file_repository,
+        }
+    }
+
+    pub async fn snapshot(&self) -> StatusSnapshot {
+        let substituters = self.substituter_repository.query_all().await;
+
+        StatusSnapshot {
+            runtime: self.runtime.clone(),
+            substituters,
+            nar_info_actor_entries: self
+                .nar_info_registry
+                .entry_count()
+                .await
+                .try_into()
+                .unwrap_or(usize::MAX),
+            nar_file_actor_entries: self
+                .nar_file_registry
+                .entry_count()
+                .await
+                .try_into()
+                .unwrap_or(usize::MAX),
+            nar_info_persistent_entries: self
+                .nar_info_repository
+                .entry_count()
+                .await
+                .unwrap_or_else(|err| {
+                    tracing::warn!(%err, cache = "nar_info", "failed to get cache entry count");
+                    0
+                }),
+            nar_file_persistent_entries: self
+                .nar_file_repository
+                .entry_count()
+                .await
+                .unwrap_or_else(|err| {
+                    tracing::warn!(%err, cache = "nar_file", "failed to get cache entry count");
+                    0
+                }),
+        }
+    }
+}
+
+impl StatusSnapshot {
+    pub fn available_substituter_count(&self) -> usize {
+        self.substituters
+            .iter()
+            .filter(|sub| !sub.is_unavailable())
+            .count()
+    }
+}
+
+pub fn availability_status(availability: &Availability) -> &'static str {
+    match availability {
+        Availability::Normal => "normal",
+        Availability::Offline { .. } => "offline",
+        Availability::ServiceError { .. } => "service_error",
+        Availability::MaybeReady { .. } => "maybe_ready",
+    }
+}

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -11,6 +11,9 @@ use selector4nix::application::nar_file::actor::NarFileActor;
 use selector4nix::application::nar_file::usecase::NarFileStreamingUseCase;
 use selector4nix::application::nar_info::actor::NarInfoActor;
 use selector4nix::application::nar_info::usecase::NarInfoResolutionUseCase;
+use selector4nix::application::status::usecase::{
+    CacheMode, StatusQueryUseCase, StatusRuntimeInfo,
+};
 use selector4nix::application::substituter::actor::SubstituterActor;
 use selector4nix::application::substituter::usecase::SubstituterQueryUseCase;
 use selector4nix::domain::common::passthrough_headers::SELF_USER_AGENT;
@@ -101,6 +104,7 @@ pub async fn init_context(
     credentials: Arc<AppCredential>,
     cache_dir: Option<PathBuf>,
 ) -> AnyhowResult<Arc<AppContext>> {
+    let persistent_cache = cache_dir.is_some();
     let database = match cache_dir {
         Some(cache_dir) => {
             if !cache_dir.is_dir() {
@@ -170,15 +174,11 @@ pub async fn init_context(
         substituter_repository
     });
 
-    let nar_info_repository = Arc::new({
-        let cache_kv = Arc::new(CacheKv::new(database.clone(), "nar_info".into()));
-        CacheKvNarInfoRepository::new(cache_kv)
-    });
+    let nar_info_cache_kv = Arc::new(CacheKv::new(database.clone(), "nar_info".into()));
+    let nar_file_cache_kv = Arc::new(CacheKv::new(database.clone(), "nar_file".into()));
 
-    let nar_file_repository = Arc::new({
-        let cache_kv = Arc::new(CacheKv::new(database.clone(), "nar_file".into()));
-        CacheKvNarFileRepository::new(cache_kv)
-    });
+    let nar_info_repository = Arc::new(CacheKvNarInfoRepository::new(nar_info_cache_kv.clone()));
+    let nar_file_repository = Arc::new(CacheKvNarFileRepository::new(nar_file_cache_kv.clone()));
 
     let substituter_service = Arc::new(SubstituterService::new(config.network.periodic_probing));
 
@@ -270,13 +270,38 @@ pub async fn init_context(
     let nar_info_resolution_usecase = NarInfoResolutionUseCase::new(
         nar_info_registry.clone(),
         substituter_registry,
+        nar_file_registry.clone(),
+    );
+
+    let status_runtime_info = Arc::new(StatusRuntimeInfo {
+        version: env!("CARGO_PKG_VERSION"),
+        cache_mode: if persistent_cache {
+            CacheMode::Persistent
+        } else {
+            CacheMode::InMemory
+        },
+        config: Arc::new(config.clone()),
+        authenticated_substituter_urls: substituters
+            .iter()
+            .filter(|sub| credentials.lookup(sub.url()).is_some())
+            .map(|sub| sub.url().clone())
+            .collect(),
+    });
+
+    let status_query_usecase = StatusQueryUseCase::new(
+        substituter_repository,
+        status_runtime_info,
+        nar_info_registry,
         nar_file_registry,
+        nar_info_repository,
+        nar_file_repository,
     );
 
     Ok(AppContext::new(
         substituter_query_usecase,
         nar_info_resolution_usecase,
         nar_file_streaming_usecase,
+        status_query_usecase,
         config.cache_info.clone(),
     ))
 }

--- a/src/domain/nar_file/repository.rs
+++ b/src/domain/nar_file/repository.rs
@@ -8,4 +8,6 @@ pub trait NarFileRepository: Send + Sync {
     async fn get(&self, key: &NarFileKey) -> AnyhowResult<Option<NarFile>>;
 
     async fn save(&self, nar_file: NarFile) -> AnyhowResult<()>;
+
+    async fn entry_count(&self) -> AnyhowResult<usize>;
 }

--- a/src/domain/nar_info/repository.rs
+++ b/src/domain/nar_info/repository.rs
@@ -8,4 +8,6 @@ pub trait NarInfoRepository: Send + Sync {
     async fn get(&self, hash: &StorePathHash) -> AnyhowResult<Option<NarInfo>>;
 
     async fn save(&self, nar_info: NarInfo) -> AnyhowResult<()>;
+
+    async fn entry_count(&self) -> AnyhowResult<usize>;
 }

--- a/src/domain/substituter/repository.rs
+++ b/src/domain/substituter/repository.rs
@@ -45,6 +45,8 @@ impl From<&Substituter> for SubstituterCandidate {
 pub trait SubstituterRepository: Send + Sync {
     async fn get(&self, url: &Url) -> Option<Substituter>;
 
+    async fn query_all(&self) -> Vec<Substituter>;
+
     async fn query_all_available(&self) -> Arc<Vec<SubstituterCandidate>>;
 
     async fn save(&self, substituter: Substituter);

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -6,5 +6,5 @@ mod general_raw;
 pub use credential_parsed::{AppCredential, AppCredentialEntry};
 pub use general_parsed::{
     AppConfiguration, CacheConfiguration, CacheInfoConfiguration, NetworkConfiguration,
-    ServerConfiguration, SubstituterConfiguration,
+    ProxyConfiguration, ServerConfiguration, SubstituterConfiguration,
 };

--- a/src/infrastructure/repository/nar_file.rs
+++ b/src/infrastructure/repository/nar_file.rs
@@ -52,4 +52,9 @@ impl NarFileRepository for CacheKvNarFileRepository {
         })
         .await?
     }
+
+    async fn entry_count(&self) -> AnyhowResult<usize> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || db.len()).await?
+    }
 }

--- a/src/infrastructure/repository/nar_info.rs
+++ b/src/infrastructure/repository/nar_info.rs
@@ -52,4 +52,9 @@ impl NarInfoRepository for CacheKvNarInfoRepository {
         })
         .await?
     }
+
+    async fn entry_count(&self) -> AnyhowResult<usize> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || db.len()).await?
+    }
 }

--- a/src/infrastructure/repository/substituter.rs
+++ b/src/infrastructure/repository/substituter.rs
@@ -31,6 +31,13 @@ impl SubstituterRepository for InMemorySubstituterRepository {
         self.substituters.get(url).map(|s| s.clone())
     }
 
+    async fn query_all(&self) -> Vec<Substituter> {
+        self.substituters
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
     async fn query_all_available(&self) -> Arc<Vec<SubstituterCandidate>> {
         self.available_substituters.load_full()
     }
@@ -79,6 +86,23 @@ mod tests {
     fn make_sub(url: &str, availability: Availability) -> Sub {
         let meta = SubstituterMeta::new(Url::new(url).unwrap(), Priority::new(40).unwrap());
         Sub::new(meta, availability)
+    }
+
+    #[tokio::test]
+    async fn query_all_returns_saved_substituters() {
+        let repo = InMemorySubstituterRepository::new();
+        repo.save(make_sub("https://a.example.com", Availability::Normal))
+            .await;
+        repo.save(make_sub(
+            "https://b.example.com",
+            Availability::Offline {
+                detected_at: tokio::time::Instant::now(),
+            },
+        ))
+        .await;
+
+        let all = repo.query_all().await;
+        assert_eq!(all.len(), 2);
     }
 
     #[tokio::test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -4,3 +4,4 @@ pub mod mock;
 mod config_test;
 mod credential_test;
 mod nar_info_service_test;
+mod status_test;

--- a/tests/integration/status_test.rs
+++ b/tests/integration/status_test.rs
@@ -1,0 +1,163 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use redb::Database;
+use redb::backends::InMemoryBackend;
+use selector4nix::api::AppContext;
+use selector4nix::api::handlers::status::get_status;
+use selector4nix::application::nar_file::actor::{NarFileActor, NarFileActorRegistry};
+use selector4nix::application::nar_file::usecase::NarFileStreamingUseCase;
+use selector4nix::application::nar_info::actor::{NarInfoActor, NarInfoActorRegistry};
+use selector4nix::application::nar_info::usecase::NarInfoResolutionUseCase;
+use selector4nix::application::status::usecase::{
+    CacheMode, StatusQueryUseCase, StatusRuntimeInfo,
+};
+use selector4nix::application::substituter::actor::{SubstituterActor, SubstituterActorRegistry};
+use selector4nix::application::substituter::usecase::SubstituterQueryUseCase;
+use selector4nix::domain::common::url::Url;
+use selector4nix::domain::substituter::SubstituterRepository;
+use selector4nix::infrastructure::config::AppConfiguration;
+use selector4nix::infrastructure::repository::{
+    CacheKvNarFileRepository, CacheKvNarInfoRepository, InMemorySubstituterRepository,
+};
+use selector4nix_actor::actor::Address;
+use selector4nix_actor::registry::{AsyncFactory, RegistryBuilder};
+use selector4nix_db::cache_kv::CacheKv;
+
+use crate::fixture::config::make_config_string_minimal;
+use crate::fixture::substituter::{make_substituter_maybe_ready, make_substituter_normal};
+
+fn nar_info_registry() -> Arc<NarInfoActorRegistry> {
+    Arc::new(
+        RegistryBuilder::new()
+            .factory(AsyncFactory::new(|_| async {
+                Address::<NarInfoActor>::mock().0
+            }))
+            .build(),
+    )
+}
+
+fn nar_file_registry() -> Arc<NarFileActorRegistry> {
+    Arc::new(
+        RegistryBuilder::new()
+            .factory(AsyncFactory::new(|_| async {
+                Address::<NarFileActor>::mock().0
+            }))
+            .build(),
+    )
+}
+
+fn substituter_registry() -> Arc<SubstituterActorRegistry> {
+    Arc::new(
+        RegistryBuilder::new()
+            .factory(AsyncFactory::new(|_| async {
+                Address::<SubstituterActor>::mock().0
+            }))
+            .build(),
+    )
+}
+
+#[tokio::test]
+async fn status_endpoint_returns_runtime_config_and_substituters() {
+    let config = Arc::new(AppConfiguration::deserialize(&make_config_string_minimal()).unwrap());
+    let cache_database = Arc::new(
+        Database::builder()
+            .create_with_backend(InMemoryBackend::new())
+            .unwrap(),
+    );
+    let nar_info_repository = Arc::new(CacheKvNarInfoRepository::new(Arc::new(CacheKv::new(
+        cache_database.clone(),
+        "nar_info".into(),
+    ))));
+    let nar_file_repository = Arc::new(CacheKvNarFileRepository::new(Arc::new(CacheKv::new(
+        cache_database,
+        "nar_file".into(),
+    ))));
+
+    let substituter_repository = Arc::new(InMemorySubstituterRepository::new());
+    let cache_url = Url::new("https://cache.nixos.org/").unwrap();
+    let private_url = Url::new("https://private.example.com/cache/").unwrap();
+    substituter_repository
+        .save(make_substituter_normal(&cache_url, 40))
+        .await;
+    substituter_repository
+        .save(make_substituter_maybe_ready(&private_url, 10))
+        .await;
+
+    let nar_info_registry = nar_info_registry();
+    let nar_file_registry = nar_file_registry();
+    let status_query_usecase = StatusQueryUseCase::new(
+        substituter_repository.clone(),
+        Arc::new(StatusRuntimeInfo {
+            version: "0.0.0-test",
+            cache_mode: CacheMode::InMemory,
+            config: config.clone(),
+            authenticated_substituter_urls: [private_url].into_iter().collect(),
+        }),
+        nar_info_registry.clone(),
+        nar_file_registry.clone(),
+        nar_info_repository,
+        nar_file_repository,
+    );
+
+    let ctx = AppContext::new(
+        SubstituterQueryUseCase::new(substituter_repository),
+        NarInfoResolutionUseCase::new(
+            nar_info_registry,
+            substituter_registry(),
+            nar_file_registry.clone(),
+        ),
+        NarFileStreamingUseCase::new(nar_file_registry),
+        status_query_usecase,
+        config.cache_info.clone(),
+    );
+
+    let Json(response) = get_status(State(ctx)).await;
+    let response = serde_json::to_value(response).unwrap();
+
+    assert_eq!(response["version"], "0.0.0-test");
+    assert_eq!(response["cache_mode"], "in_memory");
+    assert_eq!(response["network"]["periodic_probing"], true);
+    assert_eq!(response["network"]["tolerance_msecs"], 50);
+    assert_eq!(response["network"]["nar_info_timeout_secs"], 30);
+    assert_eq!(response["network"]["nar_timeout_secs"], 30);
+    assert_eq!(response["network"]["max_concurrent_requests"], 12);
+    assert_eq!(response["network"]["ignore_nar_info_error"], false);
+    assert_eq!(response["proxy"]["rewrite_to_target"], "self");
+
+    assert_eq!(response["substituters"]["total"], 2);
+    assert_eq!(response["substituters"]["available"], 2);
+    assert_eq!(
+        response["substituters"]["items"][0]["url"],
+        "https://private.example.com/cache/"
+    );
+    assert_eq!(response["substituters"]["items"][0]["priority"], 10);
+    assert_eq!(
+        response["substituters"]["items"][0]["status"],
+        "maybe_ready"
+    );
+    assert_eq!(response["substituters"]["items"][0]["has_credential"], true);
+    assert_eq!(
+        response["substituters"]["items"][1]["url"],
+        "https://cache.nixos.org/"
+    );
+    assert_eq!(response["substituters"]["items"][1]["priority"], 40);
+    assert_eq!(response["substituters"]["items"][1]["status"], "normal");
+    assert_eq!(
+        response["substituters"]["items"][1]["has_credential"],
+        false
+    );
+
+    assert_eq!(response["cache_stats"]["nar_info_lookup"]["entries"], 0);
+    assert_eq!(response["cache_stats"]["nar_info_lookup"]["capacity"], 4096);
+    assert_eq!(
+        response["cache_stats"]["nar_info_lookup"]["ttl_secs"],
+        14400
+    );
+    assert_eq!(response["cache_stats"]["nar_location"]["entries"], 0);
+    assert_eq!(response["cache_stats"]["nar_location"]["capacity"], 4096);
+    assert_eq!(response["cache_stats"]["nar_location"]["ttl_secs"], 14400);
+    assert_eq!(response["cache_stats"]["nar_info_store"]["entries"], 0);
+    assert_eq!(response["cache_stats"]["nar_file_store"]["entries"], 0);
+}


### PR DESCRIPTION
Replace the static landing page with a dashboard that shows substituter health, cache stats, Nix cache info, and runtime network/proxy settings.

Add the supporting /status API and status query wiring needed by the dashboard, keeping the existing substituter API unchanged.

<img width="824" height="1256" src="https://github.com/user-attachments/assets/4018796b-5ad3-4704-8039-4800ecd771d4" />
