### PR TITLE
[vibe-coded] feat(download): add optional segmented NAR download for low-load 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,8 @@ selector4nix-db = { path = "components/selector4nix-db" }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+axum = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A Nix substituter proxy with parallel cache queries and latency-aware selection.
 
 Note that `selector4nix` only intends to work as a proxy rather than a full-featured cache substituter. NAR files are streamed directly from the best substituter without being cached locally. However, it does cache `.narinfo` files for better responsiveness.
 
+When configured, large NAR downloads can optionally use multiple HTTP range connections per file while overall download load is low, improving throughput on high-latency links without increasing memory usage beyond a bounded reassembly buffer.
+
 The recommended way to use `selector4nix` is deploying it locally on each host. Since no large NAR file caching is used, `selector4nix` is pretty lightweight in terms of both memory footprint and CPU usage. In contrast, hosting `selector4nix` on a central node in your LAN for other machines doesn't scale well.
 
 ## Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ Segmented download is only used while the number of in-flight NAR downloads is l
 - Type: Natural
 - Default: `16777216` (16 MiB)
 
-Maximum in-memory buffer budget for out-of-order segment reassembly. Applies backpressure to workers that run ahead of the client.
+Maximum in-memory buffer budget for out-of-order segment reassembly. The leading segment is streamed to the client as soon as its bytes arrive, before the whole file is reassembled. This value bounds how far ahead trailing segments may be buffered past the client's current position: workers fetching bytes further ahead are throttled until the client catches up, so memory usage stays bounded regardless of file size.
 
 ### HTTP Range support (substituter compatibility)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,46 @@ When enabled, NAR info lookup errors from substituters are treated as not-found 
 
 When enabled, `selector4nix` continuously probes substituters every 30 seconds to detect failures early. Probing during retry recovery always occurs regardless of this setting.
 
+## `download`
+
+Optional segmented NAR download settings. When enabled, large NAR files may be fetched over multiple HTTP `Range` connections from the winning substituter when overall download load is low.
+
+### `download.segmented`
+
+- Type: Boolean
+- Default: `false`
+
+When enabled, eligible NAR downloads use multiple parallel range requests instead of a single streaming connection. Falls back to single-stream download when ineligible or when the substituter does not support byte ranges.
+
+### `download.segmented_min_file_bytes`
+
+- Type: Natural
+- Default: `8388608` (8 MiB)
+
+Minimum uncompressed-on-the-wire object size required before segmented download is considered.
+
+### `download.segmented_max_connections`
+
+- Type: Natural
+- Default: `4`
+- Minimum: `2`
+
+Maximum number of parallel HTTP connections used for a single segmented NAR download.
+
+### `download.segmented_load_threshold`
+
+- Type: Natural
+- Default: `3`
+
+Segmented download is only used while the number of in-flight NAR downloads is less than or equal to this threshold. Additional range workers may also be spawned mid-download when load drops.
+
+### `download.segmented_buffer_bytes`
+
+- Type: Natural
+- Default: `16777216` (16 MiB)
+
+Maximum in-memory buffer budget for out-of-order segment reassembly. Applies backpressure to workers that run ahead of the client.
+
 ## `proxy`
 
 Proxy behavior settings.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,22 @@ Segmented download is only used while the number of in-flight NAR downloads is l
 
 Maximum in-memory buffer budget for out-of-order segment reassembly. Applies backpressure to workers that run ahead of the client.
 
+### HTTP Range support (substituter compatibility)
+
+Segmented download requires the winning upstream substituter to advertise `Accept-Ranges: bytes` on the initial `200 OK` NAR response and to honour `Range` requests with `206 Partial Content` plus a `Content-Range` header. If a substituter does not meet these requirements, `selector4nix` transparently falls back to a single-stream download.
+
+Spot checks performed in July 2026 against a `zlib` store path (`dbz6pb9g67kpgpl95k8d85kzpxm1c32p`, `.nar.zst` object) using `HEAD` and `Range: bytes=0-1023`:
+
+| Substituter | Segmented download | Notes |
+|-------------|-------------------|-------|
+| `https://cache.nixos.org/` | Supported | `Accept-Ranges: bytes`; range probe returned `206` with `Content-Range` (Amazon S3 backend) |
+| `https://mirrors.tuna.tsinghua.edu.cn/nix-channels/store/` | Supported | `Accept-Ranges: bytes`; range probe returned `206` with `Content-Range` |
+| `https://mirrors.ustc.edu.cn/nix-channels/store/` | Supported | `Accept-Ranges: bytes`; range probe returned `206` with `Content-Range` |
+| `https://mirror.sjtu.edu.cn/nix-channels/store/` | Not supported | No `Accept-Ranges` on NAR; range probe returned `200` without `Content-Range` |
+| `https://mirrors.bfsu.edu.cn/nix-channels/store/` | Redirects to Tsinghua | Returns `302` to the Tsinghua mirror; inherits its range behaviour after redirect |
+
+These results are illustrative only. Substituter CDNs, mirror sync state, and object availability can change over time. Private caches (for example Attic) depend on the storage backend in use.
+
 ## `proxy`
 
 Proxy behavior settings.

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -38,6 +38,9 @@ periodic_probing = true
 # segmented_load_threshold = 3
 # In-memory reassembly buffer budget in bytes (default: 16777216).
 # segmented_buffer_bytes = 16777216
+# Requires upstream Accept-Ranges: bytes support; see docs/configuration.md for
+# substituter compatibility notes (cache.nixos.org, USTC, and Tsinghua support
+# range requests; SJTU does not in spot checks).
 
 # Proxy behavior settings.
 [proxy]

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -26,6 +26,19 @@ ignore_nar_info_error = false
 # Probing during retry recovery is always enabled regardless of this setting.
 periodic_probing = true
 
+# Optional segmented NAR download settings.
+# [download]
+# Enable multi-connection range downloads when load is low (default: false).
+# segmented = true
+# Minimum file size before segmented download is considered (default: 8388608).
+# segmented_min_file_bytes = 8388608
+# Maximum parallel connections per segmented download (default: 4, minimum: 2).
+# segmented_max_connections = 4
+# Only segment while in-flight NAR downloads are at or below this count (default: 3).
+# segmented_load_threshold = 3
+# In-memory reassembly buffer budget in bytes (default: 16777216).
+# segmented_buffer_bytes = 16777216
+
 # Proxy behavior settings.
 [proxy]
 # Whether to rewrite NAR URLs in NAR info responses (default: true).

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -26,7 +26,7 @@ use selector4nix::domain::substituter::{SubstituterRepository, SubstituterServic
 use selector4nix::infrastructure::config::{AppConfiguration, AppCredential};
 use selector4nix::infrastructure::provider::*;
 use selector4nix::infrastructure::repository::*;
-use selector4nix::infrastructure::util::PerHostHttpThrottler;
+use selector4nix::infrastructure::util::{DownloadLoadTracker, PerHostHttpThrottler};
 use selector4nix_actor::actor::Address;
 use selector4nix_actor::registry::{
     AsyncFactory, CapacityOption, ExpirationOption, RegistryBuilder,
@@ -145,10 +145,14 @@ pub async fn init_context(
         credentials.clone(),
     ));
 
+    let load_tracker = DownloadLoadTracker::new();
+
     let nar_stream_provider = Arc::new(ReqwestNarStreamProvider::new(
         http_client,
         throttler,
         credentials.clone(),
+        config.download.clone(),
+        load_tracker,
     ));
 
     let substituters = config

--- a/src/infrastructure/config/general_parsed.rs
+++ b/src/infrastructure/config/general_parsed.rs
@@ -8,14 +8,16 @@ use crate::domain::common::url::Url;
 use crate::domain::nar_info::model::NarUrlRewriteOption;
 use crate::domain::substituter::model::{PeriodicProbingOption, Priority};
 use crate::infrastructure::config::general_raw::{
-    AppRawConfiguration, CacheInfoRawConfiguration, CacheRawConfiguration, NetworkRawConfiguration,
-    ProxyRawConfiguration, ServerRawConfiguration, SubstituterRawConfiguration,
+    AppRawConfiguration, CacheInfoRawConfiguration, CacheRawConfiguration,
+    DownloadRawConfiguration, NetworkRawConfiguration, ProxyRawConfiguration,
+    ServerRawConfiguration, SubstituterRawConfiguration,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AppConfiguration {
     pub server: ServerConfiguration,
     pub network: NetworkConfiguration,
+    pub download: DownloadConfiguration,
     pub proxy: ProxyConfiguration,
     pub cache_info: CacheInfoConfiguration,
     pub cache: CacheConfiguration,
@@ -63,6 +65,7 @@ impl TryFrom<AppRawConfiguration> for AppConfiguration {
         Ok(Self {
             server: raw.server.try_into()?,
             network: raw.network.unwrap_or_default().try_into()?,
+            download: raw.download.unwrap_or_default().try_into()?,
             proxy: raw.proxy.unwrap_or_default().try_into()?,
             cache_info: raw.cache_info.unwrap_or_default().try_into()?,
             cache: raw.cache.unwrap_or_default().try_into()?,
@@ -127,6 +130,30 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
             } else {
                 PeriodicProbingOption::None
             },
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DownloadConfiguration {
+    pub segmented: bool,
+    pub segmented_min_file_bytes: u64,
+    pub segmented_max_connections: usize,
+    pub segmented_load_threshold: usize,
+    pub segmented_buffer_bytes: usize,
+}
+
+impl TryFrom<DownloadRawConfiguration> for DownloadConfiguration {
+    type Error = AnyhowError;
+
+    fn try_from(raw: DownloadRawConfiguration) -> Result<Self, Self::Error> {
+        let segmented_max_connections = raw.segmented_max_connections.unwrap_or(4).max(2);
+        Ok(Self {
+            segmented: raw.segmented.unwrap_or(false),
+            segmented_min_file_bytes: raw.segmented_min_file_bytes.unwrap_or(8 * 1024 * 1024),
+            segmented_max_connections,
+            segmented_load_threshold: raw.segmented_load_threshold.unwrap_or(3),
+            segmented_buffer_bytes: raw.segmented_buffer_bytes.unwrap_or(16 * 1024 * 1024),
         })
     }
 }

--- a/src/infrastructure/config/general_raw.rs
+++ b/src/infrastructure/config/general_raw.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 pub struct AppRawConfiguration {
     pub server: ServerRawConfiguration,
     pub network: Option<NetworkRawConfiguration>,
+    pub download: Option<DownloadRawConfiguration>,
     pub proxy: Option<ProxyRawConfiguration>,
     pub cache_info: Option<CacheInfoRawConfiguration>,
     pub cache: Option<CacheRawConfiguration>,
@@ -33,6 +34,15 @@ pub struct NetworkRawConfiguration {
     pub tolerance_msecs: Option<u64>,
     pub ignore_nar_info_error: Option<bool>,
     pub periodic_probing: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]
+pub struct DownloadRawConfiguration {
+    pub segmented: Option<bool>,
+    pub segmented_min_file_bytes: Option<u64>,
+    pub segmented_max_connections: Option<usize>,
+    pub segmented_load_threshold: Option<usize>,
+    pub segmented_buffer_bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -5,6 +5,6 @@ mod general_raw;
 
 pub use credential_parsed::{AppCredential, AppCredentialEntry};
 pub use general_parsed::{
-    AppConfiguration, CacheConfiguration, CacheInfoConfiguration, NetworkConfiguration,
-    ProxyConfiguration, ServerConfiguration, SubstituterConfiguration,
+    AppConfiguration, CacheConfiguration, CacheInfoConfiguration, DownloadConfiguration,
+    NetworkConfiguration, ProxyConfiguration, ServerConfiguration, SubstituterConfiguration,
 };

--- a/src/infrastructure/provider/mod.rs
+++ b/src/infrastructure/provider/mod.rs
@@ -2,6 +2,8 @@ mod nar_info_provider;
 mod nar_stream_provider;
 mod substituter_probing_provider;
 
+mod segmented;
+
 pub use nar_info_provider::ReqwestNarInfoProvider;
 pub use nar_stream_provider::ReqwestNarStreamProvider;
 pub use substituter_probing_provider::ReqwestSubstituterProbingProvider;

--- a/src/infrastructure/provider/nar_stream_provider.rs
+++ b/src/infrastructure/provider/nar_stream_provider.rs
@@ -13,13 +13,18 @@ use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::common::url::Url;
 use crate::domain::nar_file::model::NarFileLocation;
 use crate::domain::nar_file::port::{NarStreamData, NarStreamHeaders, NarStreamProvider};
-use crate::infrastructure::config::AppCredential;
-use crate::infrastructure::util::{PerHostHttpThrottler, ThrottlerPermit};
+use crate::infrastructure::config::{AppCredential, DownloadConfiguration};
+use crate::infrastructure::provider::segmented::start_segmented_download;
+use crate::infrastructure::util::{
+    DownloadLoadTracker, LoadGuard, PerHostHttpThrottler, ThrottlerPermit,
+};
 
 pub struct ReqwestNarStreamProvider {
     client: Client,
     throttler: Arc<PerHostHttpThrottler>,
     credentials: Arc<AppCredential>,
+    download_config: DownloadConfiguration,
+    load_tracker: DownloadLoadTracker,
 }
 
 impl ReqwestNarStreamProvider {
@@ -27,11 +32,15 @@ impl ReqwestNarStreamProvider {
         client: Client,
         throttler: Arc<PerHostHttpThrottler>,
         credentials: Arc<AppCredential>,
+        download_config: DownloadConfiguration,
+        load_tracker: DownloadLoadTracker,
     ) -> Self {
         Self {
             client,
             throttler,
             credentials,
+            download_config,
+            load_tracker,
         }
     }
 
@@ -39,28 +48,73 @@ impl ReqwestNarStreamProvider {
         url: Url,
         response: Response,
         permit: ThrottlerPermit,
+        load_guard: LoadGuard,
     ) -> AnyhowResult<Option<NarStreamData>> {
-        let headers = NarStreamHeaders {
-            content_length: response.content_length(),
-            content_type: response
-                .headers()
-                .get(header::CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok())
-                .map(ToString::to_string),
-            content_encoding: response
-                .headers()
-                .get(header::CONTENT_ENCODING)
-                .and_then(|v| v.to_str().ok())
-                .map(ToString::to_string),
-        };
-
+        let headers = extract_stream_headers(&response);
         let stream = ThrottledStream {
             inner: response
                 .bytes_stream()
                 .map(|chunk| chunk.with_context(|| "failed to read nar stream")),
             _permit: permit,
+            _load_guard: load_guard,
         };
         Ok(Some(NarStreamData::new(headers, Box::pin(stream), url)))
+    }
+
+    fn try_segmented_response(
+        &self,
+        url: Url,
+        response: Response,
+        permit: ThrottlerPermit,
+        headers: PassthroughHeaders,
+    ) -> AnyhowResult<Option<NarStreamData>> {
+        let stream_headers = extract_stream_headers(&response);
+        let Some(content_length) = stream_headers.content_length else {
+            return Self::wrap_ok_response(
+                url,
+                response,
+                permit,
+                self.load_tracker.enter(),
+            );
+        };
+
+        if !is_segmented_eligible(
+            &self.download_config,
+            &self.load_tracker,
+            content_length,
+            accepts_byte_ranges(&response),
+            stream_headers.content_encoding.as_deref(),
+        ) {
+            return Self::wrap_ok_response(
+                url,
+                response,
+                permit,
+                self.load_tracker.enter(),
+            );
+        }
+
+        tracing::debug!(
+            %url,
+            content_length,
+            load = self.load_tracker.current(),
+            "starting segmented nar download"
+        );
+
+        start_segmented_download(
+            self.client.clone(),
+            Arc::clone(&self.throttler),
+            Arc::clone(&self.credentials),
+            self.download_config.clone(),
+            self.load_tracker.clone(),
+            self.load_tracker.enter(),
+            permit,
+            url.clone(),
+            headers,
+            content_length,
+            stream_headers,
+            response,
+        )
+        .map(Some)
     }
 }
 
@@ -116,7 +170,12 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
             match response {
                 Ok(Ok(response)) => match response.status() {
                     StatusCode::OK => {
-                        return Self::wrap_ok_response(url.clone(), response, permit);
+                        return self.try_segmented_response(
+                            url.clone(),
+                            response,
+                            permit,
+                            headers.clone(),
+                        );
                     }
                     StatusCode::NOT_FOUND | StatusCode::FORBIDDEN => {
                         not_found_count += 1;
@@ -144,9 +203,48 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
     }
 }
 
+fn extract_stream_headers(response: &Response) -> NarStreamHeaders {
+    NarStreamHeaders {
+        content_length: response.content_length(),
+        content_type: response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(ToString::to_string),
+        content_encoding: response
+            .headers()
+            .get(header::CONTENT_ENCODING)
+            .and_then(|v| v.to_str().ok())
+            .map(ToString::to_string),
+    }
+}
+
+fn accepts_byte_ranges(response: &Response) -> bool {
+    response
+        .headers()
+        .get(header::ACCEPT_RANGES)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("bytes"))
+}
+
+fn is_segmented_eligible(
+    config: &DownloadConfiguration,
+    load_tracker: &DownloadLoadTracker,
+    content_length: u64,
+    accept_ranges: bool,
+    content_encoding: Option<&str>,
+) -> bool {
+    config.segmented
+        && load_tracker.current() <= config.segmented_load_threshold
+        && content_length >= config.segmented_min_file_bytes
+        && accept_ranges
+        && content_encoding.is_none()
+}
+
 struct ThrottledStream<S> {
     inner: S,
     _permit: ThrottlerPermit,
+    _load_guard: LoadGuard,
 }
 
 impl<S> Stream for ThrottledStream<S>
@@ -157,5 +255,51 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.get_mut().inner.poll_next_unpin(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segmented_eligibility_requires_all_conditions() {
+        let config = DownloadConfiguration {
+            segmented: true,
+            segmented_min_file_bytes: 1024,
+            segmented_max_connections: 4,
+            segmented_load_threshold: 3,
+            segmented_buffer_bytes: 4096,
+        };
+        let tracker = DownloadLoadTracker::new();
+
+        assert!(is_segmented_eligible(
+            &config,
+            &tracker,
+            2048,
+            true,
+            None
+        ));
+        assert!(!is_segmented_eligible(
+            &config,
+            &tracker,
+            512,
+            true,
+            None
+        ));
+        assert!(!is_segmented_eligible(
+            &config,
+            &tracker,
+            2048,
+            false,
+            None
+        ));
+        assert!(!is_segmented_eligible(
+            &config,
+            &tracker,
+            2048,
+            true,
+            Some("gzip")
+        ));
     }
 }

--- a/src/infrastructure/provider/nar_stream_provider.rs
+++ b/src/infrastructure/provider/nar_stream_provider.rs
@@ -301,5 +301,19 @@ mod tests {
             true,
             Some("gzip")
         ));
+
+        let _guards = [
+            tracker.enter(),
+            tracker.enter(),
+            tracker.enter(),
+            tracker.enter(),
+        ];
+        assert!(!is_segmented_eligible(
+            &config,
+            &tracker,
+            2048,
+            true,
+            None
+        ));
     }
 }

--- a/src/infrastructure/provider/segmented/coordinator.rs
+++ b/src/infrastructure/provider/segmented/coordinator.rs
@@ -1,0 +1,445 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use anyhow::{Context as _, Result as AnyhowResult};
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use http::{StatusCode, header};
+use reqwest::{Client, Response};
+use tokio::sync::mpsc;
+use tokio::time;
+
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
+use crate::domain::common::url::Url;
+use crate::domain::nar_file::port::{NarStreamData, NarStreamHeaders};
+use crate::infrastructure::config::{AppCredential, DownloadConfiguration};
+use crate::infrastructure::util::{
+    DownloadLoadTracker, LoadGuard, PerHostHttpThrottler, ThrottlerPermit,
+};
+
+use super::reorder::ReorderBuffer;
+
+struct SegmentHandle {
+    start: u64,
+    end: u64,
+    cancel: Arc<AtomicBool>,
+}
+
+struct CoordinatorContext {
+    reorder: Arc<ReorderBuffer>,
+    total_size: u64,
+    config: DownloadConfiguration,
+    load_tracker: DownloadLoadTracker,
+    active_workers: AtomicUsize,
+    segments: std::sync::Mutex<Vec<SegmentHandle>>,
+    workers_done: AtomicUsize,
+    expected_workers: AtomicUsize,
+}
+
+pub fn start_segmented_download(
+    client: Client,
+    throttler: Arc<PerHostHttpThrottler>,
+    credentials: Arc<AppCredential>,
+    config: DownloadConfiguration,
+    load_tracker: DownloadLoadTracker,
+    load_guard: LoadGuard,
+    initial_permit: ThrottlerPermit,
+    url: Url,
+    headers: PassthroughHeaders,
+    total_size: u64,
+    stream_headers: NarStreamHeaders,
+    initial_response: Response,
+) -> AnyhowResult<NarStreamData> {
+    let reorder = ReorderBuffer::new(total_size, config.segmented_buffer_bytes);
+    let ctx = Arc::new(CoordinatorContext {
+        reorder: Arc::clone(&reorder),
+        total_size,
+        config: config.clone(),
+        load_tracker,
+        active_workers: AtomicUsize::new(0),
+        segments: std::sync::Mutex::new(Vec::new()),
+        workers_done: AtomicUsize::new(0),
+        expected_workers: AtomicUsize::new(0),
+    });
+
+    let initial_end = (total_size / config.segmented_max_connections as u64).max(1);
+    spawn_initial_worker(
+        Arc::clone(&ctx),
+        initial_response,
+        0,
+        initial_end.min(total_size),
+        initial_permit,
+    );
+
+    if initial_end < total_size {
+        spawn_range_segments(
+            Arc::clone(&ctx),
+            client.clone(),
+            throttler.clone(),
+            credentials.clone(),
+            url.clone(),
+            headers.clone(),
+            initial_end,
+            total_size,
+            config.segmented_max_connections.saturating_sub(1),
+        );
+    }
+
+    spawn_supervisor(
+        Arc::clone(&ctx),
+        client,
+        throttler,
+        credentials,
+        url.clone(),
+        headers,
+    );
+
+    let stream = SegmentedStream::new(reorder, load_guard);
+    Ok(NarStreamData::new(stream_headers, Box::pin(stream), url))
+}
+
+fn spawn_initial_worker(
+    ctx: Arc<CoordinatorContext>,
+    response: Response,
+    start: u64,
+    end: u64,
+    _permit: ThrottlerPermit,
+) {
+    let cancel = Arc::new(AtomicBool::new(false));
+    ctx.segments
+        .lock()
+        .expect("segment mutex poisoned")
+        .push(SegmentHandle {
+            start,
+            end,
+            cancel: Arc::clone(&cancel),
+        });
+    ctx.expected_workers.fetch_add(1, Ordering::Relaxed);
+
+    let reorder = Arc::clone(&ctx.reorder);
+    let ctx = Arc::clone(&ctx);
+    tokio::spawn(async move {
+        ctx.active_workers.fetch_add(1, Ordering::Relaxed);
+        let result = read_response_segment(response, reorder, start, end, cancel).await;
+        ctx.active_workers.fetch_sub(1, Ordering::Relaxed);
+        on_worker_finished(&ctx, result).await;
+    });
+}
+
+fn spawn_range_segments(
+    ctx: Arc<CoordinatorContext>,
+    client: Client,
+    throttler: Arc<PerHostHttpThrottler>,
+    credentials: Arc<AppCredential>,
+    url: Url,
+    headers: PassthroughHeaders,
+    start: u64,
+    end: u64,
+    max_segments: usize,
+) {
+    if start >= end || max_segments == 0 {
+        return;
+    }
+
+    let count = max_segments.min(((end - start) as usize).max(1));
+    let chunk_size = ((end - start) + count as u64 - 1) / count as u64;
+
+    let mut offset = start;
+    while offset < end {
+        let segment_end = (offset + chunk_size).min(end);
+        spawn_range_worker(
+            Arc::clone(&ctx),
+            client.clone(),
+            throttler.clone(),
+            credentials.clone(),
+            url.clone(),
+            headers.clone(),
+            offset,
+            segment_end,
+        );
+        offset = segment_end;
+    }
+}
+
+fn spawn_range_worker(
+    ctx: Arc<CoordinatorContext>,
+    client: Client,
+    throttler: Arc<PerHostHttpThrottler>,
+    credentials: Arc<AppCredential>,
+    url: Url,
+    headers: PassthroughHeaders,
+    start: u64,
+    end: u64,
+) {
+    let cancel = Arc::new(AtomicBool::new(false));
+    ctx.segments
+        .lock()
+        .expect("segment mutex poisoned")
+        .push(SegmentHandle {
+            start,
+            end,
+            cancel: Arc::clone(&cancel),
+        });
+    ctx.expected_workers.fetch_add(1, Ordering::Relaxed);
+
+    let reorder = Arc::clone(&ctx.reorder);
+    let host = url.host().to_string();
+    let ctx = Arc::clone(&ctx);
+    tokio::spawn(async move {
+        ctx.active_workers.fetch_add(1, Ordering::Relaxed);
+        let permit = throttler.acquire(&host).await;
+        let result = read_range_segment(
+            client,
+            credentials,
+            url,
+            headers,
+            reorder,
+            start,
+            end,
+            cancel,
+        )
+        .await;
+        drop(permit);
+        ctx.active_workers.fetch_sub(1, Ordering::Relaxed);
+        on_worker_finished(&ctx, result).await;
+    });
+}
+
+fn spawn_supervisor(
+    ctx: Arc<CoordinatorContext>,
+    client: Client,
+    throttler: Arc<PerHostHttpThrottler>,
+    credentials: Arc<AppCredential>,
+    url: Url,
+    headers: PassthroughHeaders,
+) {
+    let min_tail_bytes = ctx
+        .config
+        .segmented_min_file_bytes
+        .saturating_div(ctx.config.segmented_max_connections as u64)
+        .max(1);
+
+    tokio::spawn(async move {
+        let mut interval = time::interval(Duration::from_millis(250));
+        loop {
+            interval.tick().await;
+
+            if ctx.reorder.cursor() >= ctx.total_size {
+                break;
+            }
+
+            if ctx.load_tracker.current() > ctx.config.segmented_load_threshold {
+                continue;
+            }
+
+            let delivered = ctx.reorder.cursor();
+            let tail = ctx.total_size.saturating_sub(delivered);
+            if tail <= min_tail_bytes {
+                continue;
+            }
+
+            if ctx.active_workers.load(Ordering::Relaxed) >= ctx.config.segmented_max_connections {
+                continue;
+            }
+
+            let split_plan = {
+                let segments = ctx.segments.lock().expect("segment mutex poisoned");
+                find_splittable(&segments, delivered, min_tail_bytes)
+            };
+
+            let Some((index, split_at, old_end)) = split_plan else {
+                continue;
+            };
+
+            {
+                let mut segments = ctx.segments.lock().expect("segment mutex poisoned");
+                segments[index].cancel.store(true, Ordering::Relaxed);
+                segments.remove(index);
+            }
+
+            spawn_range_segments(
+                Arc::clone(&ctx),
+                client.clone(),
+                throttler.clone(),
+                credentials.clone(),
+                url.clone(),
+                headers.clone(),
+                split_at,
+                old_end,
+                ctx.config
+                    .segmented_max_connections
+                    .saturating_sub(ctx.active_workers.load(Ordering::Relaxed)),
+            );
+
+            tracing::debug!(
+                split_at,
+                tail = ctx.total_size.saturating_sub(split_at),
+                "spawned additional segmented download workers"
+            );
+        }
+    });
+}
+
+fn find_splittable(
+    segments: &[SegmentHandle],
+    delivered: u64,
+    min_tail_bytes: u64,
+) -> Option<(usize, u64, u64)> {
+    segments
+        .iter()
+        .enumerate()
+        .filter(|(_, segment)| {
+            let progress = delivered.max(segment.start);
+            segment.end > progress && segment.end.saturating_sub(progress) > min_tail_bytes
+        })
+        .max_by_key(|(_, segment)| segment.end.saturating_sub(delivered.max(segment.start)))
+        .map(|(index, segment)| (index, delivered.max(segment.start), segment.end))
+}
+
+async fn on_worker_finished(ctx: &CoordinatorContext, result: AnyhowResult<()>) {
+    if let Err(err) = result {
+        ctx.reorder.fail(err).await;
+    }
+
+    let done = ctx.workers_done.fetch_add(1, Ordering::Relaxed) + 1;
+    let expected = ctx.expected_workers.load(Ordering::Relaxed);
+    if done >= expected && ctx.active_workers.load(Ordering::Relaxed) == 0 {
+        ctx.reorder.mark_complete();
+    }
+}
+
+async fn read_response_segment(
+    response: Response,
+    reorder: Arc<ReorderBuffer>,
+    start: u64,
+    end: u64,
+    cancel: Arc<AtomicBool>,
+) -> AnyhowResult<()> {
+    let mut offset = start;
+    let mut stream = response.bytes_stream();
+
+    while offset < end && !cancel.load(Ordering::Relaxed) {
+        let chunk = match stream.next().await {
+            Some(Ok(chunk)) => chunk,
+            Some(Err(err)) => {
+                return Err(err).context("failed to read initial segmented nar stream");
+            }
+            None => break,
+        };
+
+        let remaining = end - offset;
+        if chunk.len() as u64 > remaining {
+            reorder
+                .push(offset, chunk.slice(..remaining as usize))
+                .await?;
+            break;
+        }
+
+        let chunk_len = chunk.len() as u64;
+        reorder.push(offset, chunk).await?;
+        offset += chunk_len;
+    }
+
+    Ok(())
+}
+
+async fn read_range_segment(
+    client: Client,
+    credentials: Arc<AppCredential>,
+    url: Url,
+    headers: PassthroughHeaders,
+    reorder: Arc<ReorderBuffer>,
+    start: u64,
+    end: u64,
+    cancel: Arc<AtomicBool>,
+) -> AnyhowResult<()> {
+    let range_header = format!("bytes={start}-{}", end.saturating_sub(1));
+
+    let mut request = client
+        .get(url.value())
+        .headers(headers.to_headers())
+        .header(header::RANGE, range_header);
+
+    if let Some(credential) = credentials.lookup(&url) {
+        request = request.basic_auth(credential.login.clone(), credential.secret.clone());
+    }
+
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("failed to request nar range from {url}"))?;
+
+    if response.status() != StatusCode::PARTIAL_CONTENT {
+        return Err(anyhow::anyhow!(
+            "substituter returned {} instead of 206 Partial Content for range request",
+            response.status()
+        ));
+    }
+
+    let mut offset = start;
+    let mut stream = response.bytes_stream();
+
+    while offset < end && !cancel.load(Ordering::Relaxed) {
+        let chunk = match stream.next().await {
+            Some(Ok(chunk)) => chunk,
+            Some(Err(err)) => {
+                return Err(err).context("failed to read ranged segmented nar stream");
+            }
+            None => break,
+        };
+
+        let remaining = end - offset;
+        if chunk.len() as u64 > remaining {
+            reorder
+                .push(offset, chunk.slice(..remaining as usize))
+                .await?;
+            break;
+        }
+
+        let chunk_len = chunk.len() as u64;
+        reorder.push(offset, chunk).await?;
+        offset += chunk_len;
+    }
+
+    if offset < end && !cancel.load(Ordering::Relaxed) {
+        return Err(anyhow::anyhow!(
+            "range worker ended before segment was fully received"
+        ));
+    }
+
+    Ok(())
+}
+
+struct SegmentedStream {
+    receiver: mpsc::Receiver<anyhow::Result<Bytes>>,
+    _load_guard: LoadGuard,
+}
+
+impl SegmentedStream {
+    fn new(reorder: Arc<ReorderBuffer>, load_guard: LoadGuard) -> Self {
+        let (sender, receiver) = mpsc::channel(1);
+        tokio::spawn(async move {
+            while let Some(item) = reorder.pop_next().await {
+                if sender.send(item).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            receiver,
+            _load_guard: load_guard,
+        }
+    }
+}
+
+impl Stream for SegmentedStream {
+    type Item = AnyhowResult<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.receiver.poll_recv(cx)
+    }
+}

--- a/src/infrastructure/provider/segmented/coordinator.rs
+++ b/src/infrastructure/provider/segmented/coordinator.rs
@@ -373,10 +373,14 @@ async fn read_range_segment(
         .with_context(|| format!("failed to request nar range from {url}"))?;
 
     if response.status() != StatusCode::PARTIAL_CONTENT {
-        return Err(anyhow::anyhow!(
-            "substituter returned {} instead of 206 Partial Content for range request",
-            response.status()
-        ));
+        tracing::debug!(
+            %url,
+            status = %response.status(),
+            start,
+            end,
+            "range request not supported, skipping worker"
+        );
+        return Ok(());
     }
 
     let mut offset = start;

--- a/src/infrastructure/provider/segmented/mod.rs
+++ b/src/infrastructure/provider/segmented/mod.rs
@@ -1,0 +1,4 @@
+mod coordinator;
+mod reorder;
+
+pub use coordinator::start_segmented_download;

--- a/src/infrastructure/provider/segmented/reorder.rs
+++ b/src/infrastructure/provider/segmented/reorder.rs
@@ -121,4 +121,29 @@ mod tests {
         );
         assert!(buffer.pop_next().await.is_none());
     }
+
+    #[tokio::test]
+    async fn reports_error_when_marked_complete_with_missing_bytes() {
+        let buffer = ReorderBuffer::new(10, 1024);
+        buffer.push(0, Bytes::from_static(b"01234")).await.unwrap();
+        buffer.mark_complete();
+
+        assert_eq!(
+            buffer.pop_next().await.unwrap().unwrap(),
+            Bytes::from_static(b"01234")
+        );
+        let err = buffer.pop_next().await.unwrap().unwrap_err();
+        assert!(err.to_string().contains("ended before all bytes were received"));
+    }
+
+    #[tokio::test]
+    async fn propagates_failures() {
+        let buffer = ReorderBuffer::new(10, 1024);
+        buffer
+            .fail(anyhow::anyhow!("worker failed"))
+            .await;
+
+        let err = buffer.pop_next().await.unwrap().unwrap_err();
+        assert!(err.to_string().contains("worker failed"));
+    }
 }

--- a/src/infrastructure/provider/segmented/reorder.rs
+++ b/src/infrastructure/provider/segmented/reorder.rs
@@ -3,31 +3,37 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use bytes::Bytes;
-use tokio::sync::{Mutex, Notify, Semaphore};
+use tokio::sync::{Mutex, Notify};
 
+/// Reassembles out-of-order segment chunks into an in-order byte stream while
+/// keeping memory bounded.
+///
+/// Admission is windowed: a chunk is accepted immediately when it lies within
+/// `max_ahead` bytes of the output cursor (and always when it is at or before
+/// the cursor), otherwise the producing worker waits until the cursor advances.
+/// This guarantees the next-needed bytes can always be buffered, so the leading
+/// segment keeps streaming to the client mid-download, while trailing segments
+/// that race too far ahead are throttled to bound memory usage.
 pub struct ReorderBuffer {
     total_size: u64,
+    max_ahead: u64,
     cursor: AtomicU64,
-    pending: Mutex<BTreeMap<u64, PendingChunk>>,
-    byte_budget: Arc<Semaphore>,
-    notify: Notify,
+    pending: Mutex<BTreeMap<u64, Bytes>>,
+    data_notify: Notify,
+    window_notify: Notify,
     complete: AtomicBool,
     error: Mutex<Option<String>>,
-}
-
-struct PendingChunk {
-    bytes: Bytes,
-    permit_count: u32,
 }
 
 impl ReorderBuffer {
     pub fn new(total_size: u64, buffer_bytes: usize) -> Arc<Self> {
         Arc::new(Self {
             total_size,
+            max_ahead: (buffer_bytes.max(1)) as u64,
             cursor: AtomicU64::new(0),
             pending: Mutex::new(BTreeMap::new()),
-            byte_budget: Arc::new(Semaphore::new(buffer_bytes.max(1))),
-            notify: Notify::new(),
+            data_notify: Notify::new(),
+            window_notify: Notify::new(),
             complete: AtomicBool::new(false),
             error: Mutex::new(None),
         })
@@ -39,13 +45,23 @@ impl ReorderBuffer {
 
     pub fn mark_complete(&self) {
         self.complete.store(true, Ordering::Relaxed);
-        self.notify.notify_waiters();
+        self.data_notify.notify_waiters();
+        self.window_notify.notify_waiters();
     }
 
     pub async fn fail(&self, err: anyhow::Error) {
         *self.error.lock().await = Some(err.to_string());
         self.complete.store(true, Ordering::Relaxed);
-        self.notify.notify_waiters();
+        self.data_notify.notify_waiters();
+        self.window_notify.notify_waiters();
+    }
+
+    fn is_admitted(&self, offset: u64) -> bool {
+        if self.complete.load(Ordering::Relaxed) {
+            return true;
+        }
+        let cursor = self.cursor.load(Ordering::Relaxed);
+        offset <= cursor || offset - cursor < self.max_ahead
     }
 
     pub async fn push(&self, offset: u64, data: Bytes) -> anyhow::Result<()> {
@@ -53,26 +69,29 @@ impl ReorderBuffer {
             return Ok(());
         }
 
-        let permit_count = data.len() as u32;
-        self.byte_budget
-            .acquire_many(permit_count)
-            .await
-            .map_err(|_| anyhow::anyhow!("byte budget semaphore closed"))?
-            .forget();
+        while !self.is_admitted(offset) {
+            let notified = self.window_notify.notified();
+            tokio::pin!(notified);
+            // Register interest before re-checking so a concurrent cursor
+            // advance cannot be missed (lost-wakeup safe).
+            notified.as_mut().enable();
+            if self.is_admitted(offset) {
+                break;
+            }
+            notified.await;
+        }
 
-        self.pending.lock().await.insert(
-            offset,
-            PendingChunk {
-                bytes: data,
-                permit_count,
-            },
-        );
-        self.notify.notify_waiters();
+        self.pending.lock().await.insert(offset, data);
+        self.data_notify.notify_waiters();
         Ok(())
     }
 
     pub async fn pop_next(&self) -> Option<anyhow::Result<Bytes>> {
         loop {
+            let notified = self.data_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
             if let Some(err) = self.error.lock().await.clone() {
                 return Some(Err(anyhow::anyhow!(err)));
             }
@@ -82,11 +101,11 @@ impl ReorderBuffer {
                 return None;
             }
 
-            if let Some(chunk) = self.pending.lock().await.remove(&cursor) {
-                let next = cursor + chunk.bytes.len() as u64;
+            if let Some(bytes) = self.pending.lock().await.remove(&cursor) {
+                let next = cursor + bytes.len() as u64;
                 self.cursor.store(next, Ordering::Relaxed);
-                self.byte_budget.add_permits(chunk.permit_count as usize);
-                return Some(Ok(chunk.bytes));
+                self.window_notify.notify_waiters();
+                return Some(Ok(bytes));
             }
 
             if self.complete.load(Ordering::Relaxed) {
@@ -95,7 +114,7 @@ impl ReorderBuffer {
                 )));
             }
 
-            self.notify.notified().await;
+            notified.await;
         }
     }
 }
@@ -139,11 +158,88 @@ mod tests {
     #[tokio::test]
     async fn propagates_failures() {
         let buffer = ReorderBuffer::new(10, 1024);
-        buffer
-            .fail(anyhow::anyhow!("worker failed"))
-            .await;
+        buffer.fail(anyhow::anyhow!("worker failed")).await;
 
         let err = buffer.pop_next().await.unwrap().unwrap_err();
         assert!(err.to_string().contains("worker failed"));
+    }
+
+    #[tokio::test]
+    async fn streams_leading_bytes_before_trailing_chunk_arrives() {
+        let buffer = ReorderBuffer::new(10, 1024);
+
+        // Only the leading chunk is available; the tail has not been fetched.
+        buffer.push(0, Bytes::from_static(b"01234")).await.unwrap();
+
+        // The client receives the leading segment immediately, mid-download.
+        assert_eq!(
+            buffer.pop_next().await.unwrap().unwrap(),
+            Bytes::from_static(b"01234")
+        );
+
+        // The trailing chunk arrives later and is then emitted in order.
+        buffer.push(5, Bytes::from_static(b"56789")).await.unwrap();
+        buffer.mark_complete();
+
+        assert_eq!(
+            buffer.pop_next().await.unwrap().unwrap(),
+            Bytes::from_static(b"56789")
+        );
+        assert!(buffer.pop_next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn leading_chunk_larger_than_window_is_admitted() {
+        // Window is only 4 bytes, yet the in-order leading chunk must always be
+        // admitted so it can stream to the client without blocking.
+        let buffer = ReorderBuffer::new(10, 4);
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            buffer.push(0, Bytes::from_static(b"0123456789")),
+        )
+        .await
+        .expect("leading chunk must not block on a small window")
+        .unwrap();
+
+        assert_eq!(
+            buffer.pop_next().await.unwrap().unwrap(),
+            Bytes::from_static(b"0123456789")
+        );
+        assert!(buffer.pop_next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn far_ahead_chunk_is_admitted_after_cursor_advances() {
+        // Window of 5 bytes. The trailing chunk at offset 5 starts outside the
+        // window and must wait until the cursor advances past the leading chunk.
+        let buffer = ReorderBuffer::new(10, 5);
+        buffer.push(0, Bytes::from_static(b"01234")).await.unwrap();
+
+        let writer = {
+            let buffer = Arc::clone(&buffer);
+            tokio::spawn(async move {
+                buffer.push(5, Bytes::from_static(b"56789")).await.unwrap();
+            })
+        };
+
+        // Draining the leading chunk advances the cursor to 5, opening the
+        // window for the trailing chunk.
+        assert_eq!(
+            buffer.pop_next().await.unwrap().unwrap(),
+            Bytes::from_static(b"01234")
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), writer)
+            .await
+            .expect("trailing push should be admitted once the window opens")
+            .unwrap();
+
+        buffer.mark_complete();
+        assert_eq!(
+            buffer.pop_next().await.unwrap().unwrap(),
+            Bytes::from_static(b"56789")
+        );
+        assert!(buffer.pop_next().await.is_none());
     }
 }

--- a/src/infrastructure/provider/segmented/reorder.rs
+++ b/src/infrastructure/provider/segmented/reorder.rs
@@ -1,0 +1,124 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use bytes::Bytes;
+use tokio::sync::{Mutex, Notify, Semaphore};
+
+pub struct ReorderBuffer {
+    total_size: u64,
+    cursor: AtomicU64,
+    pending: Mutex<BTreeMap<u64, PendingChunk>>,
+    byte_budget: Arc<Semaphore>,
+    notify: Notify,
+    complete: AtomicBool,
+    error: Mutex<Option<String>>,
+}
+
+struct PendingChunk {
+    bytes: Bytes,
+    permit_count: u32,
+}
+
+impl ReorderBuffer {
+    pub fn new(total_size: u64, buffer_bytes: usize) -> Arc<Self> {
+        Arc::new(Self {
+            total_size,
+            cursor: AtomicU64::new(0),
+            pending: Mutex::new(BTreeMap::new()),
+            byte_budget: Arc::new(Semaphore::new(buffer_bytes.max(1))),
+            notify: Notify::new(),
+            complete: AtomicBool::new(false),
+            error: Mutex::new(None),
+        })
+    }
+
+    pub fn cursor(&self) -> u64 {
+        self.cursor.load(Ordering::Relaxed)
+    }
+
+    pub fn mark_complete(&self) {
+        self.complete.store(true, Ordering::Relaxed);
+        self.notify.notify_waiters();
+    }
+
+    pub async fn fail(&self, err: anyhow::Error) {
+        *self.error.lock().await = Some(err.to_string());
+        self.complete.store(true, Ordering::Relaxed);
+        self.notify.notify_waiters();
+    }
+
+    pub async fn push(&self, offset: u64, data: Bytes) -> anyhow::Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let permit_count = data.len() as u32;
+        self.byte_budget
+            .acquire_many(permit_count)
+            .await
+            .map_err(|_| anyhow::anyhow!("byte budget semaphore closed"))?
+            .forget();
+
+        self.pending.lock().await.insert(
+            offset,
+            PendingChunk {
+                bytes: data,
+                permit_count,
+            },
+        );
+        self.notify.notify_waiters();
+        Ok(())
+    }
+
+    pub async fn pop_next(&self) -> Option<anyhow::Result<Bytes>> {
+        loop {
+            if let Some(err) = self.error.lock().await.clone() {
+                return Some(Err(anyhow::anyhow!(err)));
+            }
+
+            let cursor = self.cursor.load(Ordering::Relaxed);
+            if cursor >= self.total_size {
+                return None;
+            }
+
+            if let Some(chunk) = self.pending.lock().await.remove(&cursor) {
+                let next = cursor + chunk.bytes.len() as u64;
+                self.cursor.store(next, Ordering::Relaxed);
+                self.byte_budget.add_permits(chunk.permit_count as usize);
+                return Some(Ok(chunk.bytes));
+            }
+
+            if self.complete.load(Ordering::Relaxed) {
+                return Some(Err(anyhow::anyhow!(
+                    "segmented download ended before all bytes were received"
+                )));
+            }
+
+            self.notify.notified().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn emits_chunks_in_offset_order() {
+        let buffer = ReorderBuffer::new(10, 1024);
+        buffer.push(5, Bytes::from_static(b"56789")).await.unwrap();
+        buffer.push(0, Bytes::from_static(b"01234")).await.unwrap();
+        buffer.mark_complete();
+
+        assert_eq!(
+            buffer.pop_next().await.unwrap().unwrap(),
+            Bytes::from_static(b"01234")
+        );
+        assert_eq!(
+            buffer.pop_next().await.unwrap().unwrap(),
+            Bytes::from_static(b"56789")
+        );
+        assert!(buffer.pop_next().await.is_none());
+    }
+}

--- a/src/infrastructure/util/download_load_tracker.rs
+++ b/src/infrastructure/util/download_load_tracker.rs
@@ -26,3 +26,26 @@ impl Drop for LoadGuard {
         self.0.fetch_sub(1, Ordering::Relaxed);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enter_and_drop_updates_current_load() {
+        let tracker = DownloadLoadTracker::new();
+        assert_eq!(tracker.current(), 0);
+
+        let guard = tracker.enter();
+        assert_eq!(tracker.current(), 1);
+
+        let guard2 = tracker.enter();
+        assert_eq!(tracker.current(), 2);
+
+        drop(guard);
+        assert_eq!(tracker.current(), 1);
+
+        drop(guard2);
+        assert_eq!(tracker.current(), 0);
+    }
+}

--- a/src/infrastructure/util/download_load_tracker.rs
+++ b/src/infrastructure/util/download_load_tracker.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug, Clone, Default)]
+pub struct DownloadLoadTracker(Arc<AtomicUsize>);
+
+impl DownloadLoadTracker {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicUsize::new(0)))
+    }
+
+    pub fn current(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    pub fn enter(&self) -> LoadGuard {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        LoadGuard(Arc::clone(&self.0))
+    }
+}
+
+pub struct LoadGuard(Arc<AtomicUsize>);
+
+impl Drop for LoadGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}

--- a/src/infrastructure/util/mod.rs
+++ b/src/infrastructure/util/mod.rs
@@ -1,3 +1,5 @@
+mod download_load_tracker;
 mod per_host_http_throttler;
 
+pub use download_load_tracker::{DownloadLoadTracker, LoadGuard};
 pub use per_host_http_throttler::{PerHostHttpThrottler, ThrottlerPermit};

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -110,3 +110,37 @@ priority = 0
 
     assert!(result.is_err());
 }
+
+#[test]
+fn download_config_is_parsed_from_toml() {
+    let config = AppConfiguration::deserialize(&fixture::config::make_config_string_overriden(
+        r#"
+[download]
+segmented = true
+segmented_min_file_bytes = 2048
+segmented_max_connections = 6
+segmented_load_threshold = 2
+segmented_buffer_bytes = 8192
+"#,
+    ))
+    .unwrap();
+
+    assert!(config.download.segmented);
+    assert_eq!(config.download.segmented_min_file_bytes, 2048);
+    assert_eq!(config.download.segmented_max_connections, 6);
+    assert_eq!(config.download.segmented_load_threshold, 2);
+    assert_eq!(config.download.segmented_buffer_bytes, 8192);
+}
+
+#[test]
+fn segmented_max_connections_is_clamped_to_two() {
+    let config = AppConfiguration::deserialize(&fixture::config::make_config_string_overriden(
+        r#"
+[download]
+segmented_max_connections = 1
+"#,
+    ))
+    .unwrap();
+
+    assert_eq!(config.download.segmented_max_connections, 2);
+}

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -39,6 +39,11 @@ fn defaults_are_applied_when_sections_omitted() {
     assert!(config.substituters[0].storage_url.is_none());
     assert!(config.substituters[0].nar_info_timeout.is_none());
     assert!(config.substituters[0].nar_timeout.is_none());
+    assert!(!config.download.segmented);
+    assert_eq!(config.download.segmented_min_file_bytes, 8 * 1024 * 1024);
+    assert_eq!(config.download.segmented_max_connections, 4);
+    assert_eq!(config.download.segmented_load_threshold, 3);
+    assert_eq!(config.download.segmented_buffer_bytes, 16 * 1024 * 1024);
 }
 
 #[test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -4,4 +4,5 @@ pub mod mock;
 mod config_test;
 mod credential_test;
 mod nar_info_service_test;
+mod nar_stream_test;
 mod status_test;

--- a/tests/integration/mock/mod.rs
+++ b/tests/integration/mock/mod.rs
@@ -1,1 +1,2 @@
 pub mod nar_info_provider;
+pub mod range_server;

--- a/tests/integration/mock/range_server.rs
+++ b/tests/integration/mock/range_server.rs
@@ -1,0 +1,126 @@
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use bytes::Bytes;
+use tokio::net::TcpListener;
+
+#[derive(Clone)]
+struct ServerState {
+    data: Arc<Bytes>,
+    accept_ranges: bool,
+}
+
+pub struct RangeNarServer {
+    pub base_url: String,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl RangeNarServer {
+    pub async fn start(data: Bytes) -> Self {
+        Self::start_with_options(data, true).await
+    }
+
+    pub async fn start_without_ranges(data: Bytes) -> Self {
+        Self::start_with_options(data, false).await
+    }
+
+    async fn start_with_options(data: Bytes, accept_ranges: bool) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind range nar server");
+        let addr = listener.local_addr().expect("failed to read local addr");
+        let state = ServerState {
+            data: Arc::new(data),
+            accept_ranges,
+        };
+        let app = Router::new()
+            .route("/nar/test.nar.xz", get(serve_nar))
+            .with_state(state);
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("range nar server failed");
+        });
+
+        Self {
+            base_url: format!("http://{addr}"),
+            handle,
+        }
+    }
+}
+
+impl Drop for RangeNarServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+async fn serve_nar(
+    headers: HeaderMap,
+    State(state): State<ServerState>,
+) -> impl IntoResponse {
+    let total = state.data.len();
+
+    if state.accept_ranges {
+        if let Some(range) = headers.get(header::RANGE).and_then(|value| value.to_str().ok()) {
+            if let Some((start, end)) = parse_range_header(range, total) {
+                let slice = state.data.slice(start..=end);
+                let headers = [
+                    (header::CONTENT_TYPE, "application/x-nix-nar".to_string()),
+                    (header::ACCEPT_RANGES, "bytes".to_string()),
+                    (
+                        header::CONTENT_RANGE,
+                        format!("bytes {start}-{end}/{total}"),
+                    ),
+                    (header::CONTENT_LENGTH, slice.len().to_string()),
+                ];
+                return (StatusCode::PARTIAL_CONTENT, headers, slice).into_response();
+            }
+        }
+    }
+
+    if state.accept_ranges {
+        let headers = [
+            (header::CONTENT_TYPE, "application/x-nix-nar".to_string()),
+            (header::CONTENT_LENGTH, total.to_string()),
+            (header::ACCEPT_RANGES, "bytes".to_string()),
+        ];
+        return (
+            StatusCode::OK,
+            headers,
+            (*state.data).clone(),
+        )
+            .into_response();
+    }
+
+    let headers = [
+        (header::CONTENT_TYPE, "application/x-nix-nar".to_string()),
+        (header::CONTENT_LENGTH, total.to_string()),
+    ];
+    (
+        StatusCode::OK,
+        headers,
+        (*state.data).clone(),
+    )
+        .into_response()
+}
+
+fn parse_range_header(range: &str, total: usize) -> Option<(usize, usize)> {
+    let range = range.strip_prefix("bytes=")?;
+    let (start, end) = range.split_once('-')?;
+    let start = start.parse::<usize>().ok()?;
+    let end = if end.is_empty() {
+        total.saturating_sub(1)
+    } else {
+        end.parse::<usize>().ok()?
+    };
+    if start > end || end >= total {
+        return None;
+    }
+    Some((start, end))
+}

--- a/tests/integration/mock/range_server.rs
+++ b/tests/integration/mock/range_server.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use axum::Router;
 use axum::extract::State;
@@ -12,14 +13,26 @@ use tokio::net::TcpListener;
 struct ServerState {
     data: Arc<Bytes>,
     accept_ranges: bool,
+    full_requests: Arc<AtomicUsize>,
+    range_requests: Arc<AtomicUsize>,
 }
 
 pub struct RangeNarServer {
     pub base_url: String,
+    full_requests: Arc<AtomicUsize>,
+    range_requests: Arc<AtomicUsize>,
     handle: tokio::task::JoinHandle<()>,
 }
 
 impl RangeNarServer {
+    pub fn full_request_count(&self) -> usize {
+        self.full_requests.load(Ordering::Relaxed)
+    }
+
+    pub fn range_request_count(&self) -> usize {
+        self.range_requests.load(Ordering::Relaxed)
+    }
+
     pub async fn start(data: Bytes) -> Self {
         Self::start_with_options(data, true).await
     }
@@ -33,9 +46,13 @@ impl RangeNarServer {
             .await
             .expect("failed to bind range nar server");
         let addr = listener.local_addr().expect("failed to read local addr");
+        let full_requests = Arc::new(AtomicUsize::new(0));
+        let range_requests = Arc::new(AtomicUsize::new(0));
         let state = ServerState {
             data: Arc::new(data),
             accept_ranges,
+            full_requests: Arc::clone(&full_requests),
+            range_requests: Arc::clone(&range_requests),
         };
         let app = Router::new()
             .route("/nar/test.nar.xz", get(serve_nar))
@@ -49,6 +66,8 @@ impl RangeNarServer {
 
         Self {
             base_url: format!("http://{addr}"),
+            full_requests,
+            range_requests,
             handle,
         }
     }
@@ -69,6 +88,9 @@ async fn serve_nar(
     if state.accept_ranges {
         if let Some(range) = headers.get(header::RANGE).and_then(|value| value.to_str().ok()) {
             if let Some((start, end)) = parse_range_header(range, total) {
+                state
+                    .range_requests
+                    .fetch_add(1, Ordering::Relaxed);
                 let slice = state.data.slice(start..=end);
                 let headers = [
                     (header::CONTENT_TYPE, "application/x-nix-nar".to_string()),
@@ -85,6 +107,7 @@ async fn serve_nar(
     }
 
     if state.accept_ranges {
+        state.full_requests.fetch_add(1, Ordering::Relaxed);
         let headers = [
             (header::CONTENT_TYPE, "application/x-nix-nar".to_string()),
             (header::CONTENT_LENGTH, total.to_string()),
@@ -102,6 +125,7 @@ async fn serve_nar(
         (header::CONTENT_TYPE, "application/x-nix-nar".to_string()),
         (header::CONTENT_LENGTH, total.to_string()),
     ];
+    state.full_requests.fetch_add(1, Ordering::Relaxed);
     (
         StatusCode::OK,
         headers,

--- a/tests/integration/nar_stream_test.rs
+++ b/tests/integration/nar_stream_test.rs
@@ -1,0 +1,96 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use selector4nix::domain::common::passthrough_headers::PassthroughHeaders;
+use selector4nix::domain::common::url::Url;
+use selector4nix::domain::nar_file::model::NarFileLocation;
+use selector4nix::domain::nar_file::port::NarStreamProvider;
+use selector4nix::infrastructure::config::{AppCredential, DownloadConfiguration};
+use selector4nix::infrastructure::provider::ReqwestNarStreamProvider;
+use selector4nix::infrastructure::util::{DownloadLoadTracker, PerHostHttpThrottler};
+
+use super::mock::range_server::RangeNarServer;
+
+fn segmented_download_config() -> DownloadConfiguration {
+    DownloadConfiguration {
+        segmented: true,
+        segmented_min_file_bytes: 1024,
+        segmented_max_connections: 4,
+        segmented_load_threshold: 3,
+        segmented_buffer_bytes: 64 * 1024,
+    }
+}
+
+fn make_provider(config: DownloadConfiguration) -> ReqwestNarStreamProvider {
+    ReqwestNarStreamProvider::new(
+        reqwest::Client::new(),
+        Arc::new(PerHostHttpThrottler::new(8)),
+        Arc::new(AppCredential::empty()),
+        config,
+        DownloadLoadTracker::new(),
+    )
+}
+
+async fn collect_stream(provider: &ReqwestNarStreamProvider, url: &Url) -> Vec<u8> {
+    let location = NarFileLocation::new(url.clone(), None);
+    let data = provider
+        .stream_nar(&[location], &PassthroughHeaders::empty())
+        .await
+        .unwrap()
+        .expect("nar stream should be available");
+
+    let mut body = Vec::new();
+    let mut stream = data.inner;
+    while let Some(chunk) = stream.next().await {
+        body.extend_from_slice(&chunk.unwrap());
+    }
+    body
+}
+
+#[tokio::test]
+async fn segmented_download_returns_full_object() {
+    let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
+    let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
+    let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
+    let provider = make_provider(segmented_download_config());
+
+    let body = collect_stream(&provider, &url).await;
+    assert_eq!(body, payload);
+}
+
+#[tokio::test]
+async fn segmented_download_falls_back_when_feature_disabled() {
+    let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
+    let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
+    let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
+    let provider = make_provider(DownloadConfiguration {
+        segmented: false,
+        ..segmented_download_config()
+    });
+
+    let body = collect_stream(&provider, &url).await;
+    assert_eq!(body, payload);
+}
+
+#[tokio::test]
+async fn segmented_download_falls_back_for_small_files() {
+    let payload = vec![1u8, 2, 3, 4, 5];
+    let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
+    let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
+    let provider = make_provider(segmented_download_config());
+
+    let body = collect_stream(&provider, &url).await;
+    assert_eq!(body, payload);
+}
+
+#[tokio::test]
+async fn segmented_download_falls_back_without_accept_ranges() {
+    let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
+    let server = RangeNarServer::start_without_ranges(Bytes::from(payload.clone())).await;
+    let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
+    let provider = make_provider(segmented_download_config());
+
+    let body = collect_stream(&provider, &url).await;
+    assert_eq!(body, payload);
+}

--- a/tests/integration/nar_stream_test.rs
+++ b/tests/integration/nar_stream_test.rs
@@ -63,6 +63,32 @@ async fn segmented_download_returns_full_object() {
 }
 
 #[tokio::test]
+async fn segmented_download_handles_file_larger_than_buffer() {
+    // The object is much larger than the reassembly buffer. Trailing segments
+    // cannot be fully buffered ahead of the cursor, so the download only
+    // completes if the leading segment keeps streaming to the client while the
+    // rest is still being fetched.
+    let payload: Vec<u8> = (0..256 * 1024).map(|i| (i % 251) as u8).collect();
+    let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
+    let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
+    let provider = make_provider(
+        DownloadConfiguration {
+            segmented_buffer_bytes: 16 * 1024,
+            ..segmented_download_config()
+        },
+        DownloadLoadTracker::new(),
+    );
+
+    let body = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        collect_stream(&provider, &url),
+    )
+    .await
+    .expect("segmented download must not deadlock on files larger than the buffer");
+    assert_eq!(body, payload);
+}
+
+#[tokio::test]
 async fn segmented_download_uses_multiple_range_requests() {
     let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
     let server = RangeNarServer::start(Bytes::from(payload.clone())).await;

--- a/tests/integration/nar_stream_test.rs
+++ b/tests/integration/nar_stream_test.rs
@@ -22,13 +22,16 @@ fn segmented_download_config() -> DownloadConfiguration {
     }
 }
 
-fn make_provider(config: DownloadConfiguration) -> ReqwestNarStreamProvider {
+fn make_provider(
+    config: DownloadConfiguration,
+    load_tracker: DownloadLoadTracker,
+) -> ReqwestNarStreamProvider {
     ReqwestNarStreamProvider::new(
         reqwest::Client::new(),
         Arc::new(PerHostHttpThrottler::new(8)),
         Arc::new(AppCredential::empty()),
         config,
-        DownloadLoadTracker::new(),
+        load_tracker,
     )
 }
 
@@ -53,10 +56,23 @@ async fn segmented_download_returns_full_object() {
     let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
     let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
     let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
-    let provider = make_provider(segmented_download_config());
+    let provider = make_provider(segmented_download_config(), DownloadLoadTracker::new());
 
     let body = collect_stream(&provider, &url).await;
     assert_eq!(body, payload);
+}
+
+#[tokio::test]
+async fn segmented_download_uses_multiple_range_requests() {
+    let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
+    let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
+    let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
+    let provider = make_provider(segmented_download_config(), DownloadLoadTracker::new());
+
+    let body = collect_stream(&provider, &url).await;
+    assert_eq!(body, payload);
+    assert_eq!(server.full_request_count(), 1);
+    assert!(server.range_request_count() >= 2);
 }
 
 #[tokio::test]
@@ -64,13 +80,18 @@ async fn segmented_download_falls_back_when_feature_disabled() {
     let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
     let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
     let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
-    let provider = make_provider(DownloadConfiguration {
-        segmented: false,
-        ..segmented_download_config()
-    });
+    let provider = make_provider(
+        DownloadConfiguration {
+            segmented: false,
+            ..segmented_download_config()
+        },
+        DownloadLoadTracker::new(),
+    );
 
     let body = collect_stream(&provider, &url).await;
     assert_eq!(body, payload);
+    assert_eq!(server.full_request_count(), 1);
+    assert_eq!(server.range_request_count(), 0);
 }
 
 #[tokio::test]
@@ -78,10 +99,12 @@ async fn segmented_download_falls_back_for_small_files() {
     let payload = vec![1u8, 2, 3, 4, 5];
     let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
     let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
-    let provider = make_provider(segmented_download_config());
+    let provider = make_provider(segmented_download_config(), DownloadLoadTracker::new());
 
     let body = collect_stream(&provider, &url).await;
     assert_eq!(body, payload);
+    assert_eq!(server.full_request_count(), 1);
+    assert_eq!(server.range_request_count(), 0);
 }
 
 #[tokio::test]
@@ -89,8 +112,49 @@ async fn segmented_download_falls_back_without_accept_ranges() {
     let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
     let server = RangeNarServer::start_without_ranges(Bytes::from(payload.clone())).await;
     let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
-    let provider = make_provider(segmented_download_config());
+    let provider = make_provider(segmented_download_config(), DownloadLoadTracker::new());
 
     let body = collect_stream(&provider, &url).await;
     assert_eq!(body, payload);
+    assert_eq!(server.full_request_count(), 1);
+    assert_eq!(server.range_request_count(), 0);
+}
+
+#[tokio::test]
+async fn segmented_download_falls_back_when_load_is_high() {
+    let payload: Vec<u8> = (0..16 * 1024).map(|i| (i % 251) as u8).collect();
+    let server = RangeNarServer::start(Bytes::from(payload.clone())).await;
+    let url = Url::new(&format!("{}/nar/test.nar.xz", server.base_url)).unwrap();
+
+    let tracker = DownloadLoadTracker::new();
+    let _in_flight = [
+        tracker.enter(),
+        tracker.enter(),
+        tracker.enter(),
+        tracker.enter(),
+    ];
+
+    let provider = make_provider(
+        DownloadConfiguration {
+            segmented_load_threshold: 3,
+            ..segmented_download_config()
+        },
+        tracker,
+    );
+
+    let body = collect_stream(&provider, &url).await;
+    assert_eq!(body, payload);
+    assert_eq!(server.full_request_count(), 1);
+    assert_eq!(server.range_request_count(), 0);
+}
+
+#[tokio::test]
+async fn load_guard_tracks_in_flight_downloads() {
+    let tracker = DownloadLoadTracker::new();
+    assert_eq!(tracker.current(), 0);
+
+    let guard = tracker.enter();
+    assert_eq!(tracker.current(), 1);
+    drop(guard);
+    assert_eq!(tracker.current(), 0);
 }


### PR DESCRIPTION

please throw code away and update the prompt if needed

please review the prompt instead of code

prompt:

```

add optional feature of multi threaded fetching when connections number low. so fetch single file multithread when possible when just fetching like 3 files. need to research: what rust crates needed what
  way to impl etc.

  Question 1: How should the proxy decide when to activate multi-connection (segmented) fetching for a single file?

   choice: both — segment when load is low AND file exceeds a min size; also need to change to segment mid download when load become low mid download

  Question 2: Segmented download needs out-of-order segments reassembled in order before sending to the Nix client. The project markets a low memory footprint. Which reassembly strategy do you want?

   choice: bounded_mem — Bounded in-memory reorder with per-segment backpressure (memory capped at ~segments x buffer size; no disk)


recheck your commit diff rethink make sure everything good and enough test

do check: check if nixos official cache support segment ? how about china nix substituter mirror? do they support segment? maybe mention result in doc

please try to stream the first segment to client mid segement downloads before reassembly can be completed
```