### PR TITLE
Deprecate build support by garnix

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,7 +1,0 @@
-builds:
-  exclude: []
-  include:
-    - devShell.x86_64-linux
-    - devShell.aarch64-darwin
-    - packages.x86_64-linux.selector4nix
-    - packages.aarch64-darwin.selector4nix


### PR DESCRIPTION
Remove all garnix related configurations and suspend the CI service. Garnix will be shut down in the near future, and we already an alternative CI pipeline backed by GitHub Actions.