### PR TITLE
Fallback earlier when streaming NAR file if selected substituter is already unavailable

### DIFF
--- a/src/application/nar_info/usecase/resolution.rs
+++ b/src/application/nar_info/usecase/resolution.rs
@@ -85,7 +85,11 @@ impl NarInfoResolutionUseCase {
                 source_url,
             } => {
                 let nar_file_key = NarFileKey::from_file_name(&nar_file);
-                let location = NarFileLocation::new(source_url, substituter.nar_timeout());
+                let location = NarFileLocation::new(
+                    source_url,
+                    substituter.clone(),
+                    substituter.nar_timeout(),
+                );
                 let sender = self.nar_file_registry.get(&nar_file_key).await;
                 let _ = sender.tell(NarFileRequest::SetLocation(location)).await;
             }

--- a/src/domain/nar_file/model/nar_file.rs
+++ b/src/domain/nar_file/model/nar_file.rs
@@ -57,14 +57,22 @@ mod tests {
 
     use crate::domain::common::url::Url;
     use crate::domain::nar_info::model::NarFileName;
+    use crate::domain::substituter::model::{Priority, SubstituterMeta};
 
     use super::*;
 
     fn make_nar_file(expire_at: SystemTime) -> NarFile {
         let nar_file_name = NarFileName::new("abc123.nar.xz".into()).unwrap();
         let key = NarFileKey::from_file_name(&nar_file_name);
-        let location =
-            NarFileLocation::new(Url::new("https://example.com/abc123.nar.xz").unwrap(), None);
+
+        let location = NarFileLocation::new(
+            Url::new("https://example.com/abc123.nar.xz").unwrap(),
+            SubstituterMeta::new(
+                Url::new("https://example.com/").unwrap(),
+                Priority::new(40).unwrap(),
+            ),
+            None,
+        );
         NarFile::new(key).on_located(location, ExpireAt::new(expire_at))
     }
 

--- a/src/domain/nar_file/model/nar_file_location.rs
+++ b/src/domain/nar_file/model/nar_file_location.rs
@@ -4,19 +4,23 @@ use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
 use crate::domain::common::url::Url;
+use crate::domain::substituter::model::SubstituterMeta;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Getters, CopyGetters, Serialize, Deserialize)]
 pub struct NarFileLocation {
     #[getset(get = "pub")]
     source_url: Url,
+    #[getset(get = "pub")]
+    substituter: SubstituterMeta,
     #[getset(get_copy = "pub")]
     timeout: Option<Duration>,
 }
 
 impl NarFileLocation {
-    pub fn new(source_url: Url, timeout: Option<Duration>) -> Self {
+    pub fn new(source_url: Url, substituter: SubstituterMeta, timeout: Option<Duration>) -> Self {
         Self {
             source_url,
+            substituter,
             timeout,
         }
     }

--- a/src/domain/nar_file/service.rs
+++ b/src/domain/nar_file/service.rs
@@ -38,16 +38,27 @@ impl NarFileService {
         let nar_file_name = nar_file.key().to_file_name();
 
         if let Some(location) = nar_file.location() {
-            tracing::trace!(nar_file = %nar_file_name.value(), source_url = %location.source_url(), "use cached nar file location");
+            // Don't send requests to selected substituter that is unavailable and do fallback
+            // early. Always avoid short-circuit if `{url}/nar != storage_url`, because we only
+            // probe the health information of host of `url` and can't determine `storage_url`'s
+            // status.
+            if location.substituter().has_custom_storage_url()
+                || self
+                    .substituter_repository
+                    .exists_available(location.substituter().url())
+                    .await
+            {
+                tracing::trace!(nar_file = %nar_file_name.value(), source_url = %location.source_url(), "use cached nar file location");
 
-            let locations = [location.clone()];
-            let outcome = self
-                .nar_stream_provider
-                .stream_nar(&locations, &headers)
-                .await;
+                let locations = [location.clone()];
+                let outcome = self
+                    .nar_stream_provider
+                    .stream_nar(&locations, &headers)
+                    .await;
 
-            if let Ok(Some(data)) = outcome {
-                return (nar_file, Ok(Some(data)));
+                if let Ok(Some(data)) = outcome {
+                    return (nar_file, Ok(Some(data)));
+                }
             }
 
             tracing::trace!(nar_file = %nar_file_name.value(), "fallback to query all substituters for nar file location");

--- a/src/domain/nar_file/service.rs
+++ b/src/domain/nar_file/service.rs
@@ -100,7 +100,7 @@ impl NarFileService {
             .map(|sub| {
                 let source_url = nar_file_name.with_storage_prefix(sub.meta().storage_url());
                 let timeout = sub.meta().nar_timeout();
-                NarFileLocation::new(source_url, timeout)
+                NarFileLocation::new(source_url, sub.meta().clone(), timeout)
             })
             .collect()
     }

--- a/src/domain/substituter/model/substituter_meta.rs
+++ b/src/domain/substituter/model/substituter_meta.rs
@@ -10,6 +10,7 @@ use crate::domain::substituter::model::Priority;
 struct SubstituterMetaInner {
     url: Url,
     storage_url: Url,
+    has_custom_storage_url: bool,
     priority: Priority,
     nar_info_timeout: Option<Duration>,
     nar_timeout: Option<Duration>,
@@ -24,6 +25,7 @@ impl SubstituterMeta {
         Self(Arc::new(SubstituterMetaInner {
             url,
             storage_url,
+            has_custom_storage_url: false,
             priority,
             nar_info_timeout: None,
             nar_timeout: None,
@@ -36,6 +38,10 @@ impl SubstituterMeta {
 
     pub fn storage_url(&self) -> &Url {
         &self.0.storage_url
+    }
+
+    pub fn has_custom_storage_url(&self) -> bool {
+        self.0.has_custom_storage_url
     }
 
     pub fn priority(&self) -> Priority {
@@ -51,8 +57,13 @@ impl SubstituterMeta {
     }
 
     pub fn with_storage_url(&self, storage_url: Url) -> Self {
+        let has_custom_storage_url = match self.0.url.as_dir().join("nar") {
+            Ok(default) => storage_url != default,
+            Err(_) => true,
+        };
         Self(Arc::new(SubstituterMetaInner {
             storage_url,
+            has_custom_storage_url,
             ..(*self.0).clone()
         }))
     }
@@ -95,5 +106,35 @@ impl<'de> Deserialize<'de> for SubstituterMeta {
         Ok(Self(Arc::new(SubstituterMetaInner::deserialize(
             deserializer,
         )?)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_meta(url: &str) -> SubstituterMeta {
+        SubstituterMeta::new(Url::new(url).unwrap(), Priority::new(40).unwrap())
+    }
+
+    #[test]
+    fn default_storage_url_is_not_custom() {
+        let meta = make_meta("https://cache.nixos.org");
+        assert!(!meta.has_custom_storage_url());
+    }
+
+    #[test]
+    fn storage_url_equal_to_default_is_not_custom() {
+        let meta = make_meta("https://example.com");
+        let default_storage = meta.url().as_dir().join("nar").unwrap();
+        let meta = meta.with_storage_url(default_storage);
+        assert!(!meta.has_custom_storage_url());
+    }
+
+    #[test]
+    fn storage_url_differing_from_default_is_custom() {
+        let meta = make_meta("https://example.com");
+        let meta = meta.with_storage_url(Url::new("https://cdn.example.com/nar").unwrap());
+        assert!(meta.has_custom_storage_url());
     }
 }

--- a/src/domain/substituter/repository.rs
+++ b/src/domain/substituter/repository.rs
@@ -49,5 +49,7 @@ pub trait SubstituterRepository: Send + Sync {
 
     async fn query_all_available(&self) -> Arc<Vec<SubstituterCandidate>>;
 
+    async fn exists_available(&self, url: &Url) -> bool;
+
     async fn save(&self, substituter: Substituter);
 }

--- a/src/infrastructure/repository/substituter.rs
+++ b/src/infrastructure/repository/substituter.rs
@@ -42,6 +42,12 @@ impl SubstituterRepository for InMemorySubstituterRepository {
         self.available_substituters.load_full()
     }
 
+    async fn exists_available(&self, url: &Url) -> bool {
+        self.substituters
+            .get(url)
+            .is_some_and(|s| !s.is_unavailable())
+    }
+
     async fn save(&self, substituter: Substituter) {
         let _permit = self.write_permit.acquire().await;
 
@@ -76,16 +82,16 @@ impl SubstituterRepository for InMemorySubstituterRepository {
 
 #[cfg(test)]
 mod tests {
+    use tokio::time::Instant;
+
     use crate::domain::substituter::SubstituterRepository;
-    use crate::domain::substituter::model::{
-        Availability, Priority, Substituter as Sub, SubstituterMeta,
-    };
+    use crate::domain::substituter::model::{Availability, Priority, Substituter, SubstituterMeta};
 
     use super::*;
 
-    fn make_sub(url: &str, availability: Availability) -> Sub {
+    fn make_sub(url: &str, availability: Availability) -> Substituter {
         let meta = SubstituterMeta::new(Url::new(url).unwrap(), Priority::new(40).unwrap());
-        Sub::new(meta, availability)
+        Substituter::new(meta, availability)
     }
 
     #[tokio::test]
@@ -96,7 +102,7 @@ mod tests {
         repo.save(make_sub(
             "https://b.example.com",
             Availability::Offline {
-                detected_at: tokio::time::Instant::now(),
+                detected_at: Instant::now(),
             },
         ))
         .await;
@@ -110,6 +116,45 @@ mod tests {
         let repo = InMemorySubstituterRepository::new();
         let result = repo.query_all_available().await;
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn exists_available_returns_true() {
+        let repo = InMemorySubstituterRepository::new();
+        repo.save(make_sub("https://a.example.com", Availability::Normal))
+            .await;
+
+        let res = repo
+            .exists_available(&Url::new("https://a.example.com").unwrap())
+            .await;
+        assert!(res);
+    }
+
+    #[tokio::test]
+    async fn exists_available_returns_false_if_unavailable() {
+        let repo = InMemorySubstituterRepository::new();
+        repo.save(make_sub(
+            "https://a.example.com",
+            Availability::Offline {
+                detected_at: Instant::now(),
+            },
+        ))
+        .await;
+
+        let res = repo
+            .exists_available(&Url::new("https://a.example.com").unwrap())
+            .await;
+        assert!(!res);
+    }
+
+    #[tokio::test]
+    async fn exists_available_returns_false_if_does_not_exist() {
+        let repo = InMemorySubstituterRepository::new();
+
+        let res = repo
+            .exists_available(&Url::new("https://a.example.com").unwrap())
+            .await;
+        assert!(!res);
     }
 
     #[tokio::test]
@@ -133,7 +178,7 @@ mod tests {
         repo.save(make_sub(
             "https://a.example.com",
             Availability::Offline {
-                detected_at: tokio::time::Instant::now(),
+                detected_at: Instant::now(),
             },
         ))
         .await;

--- a/tests/integration/fixture/nar_file.rs
+++ b/tests/integration/fixture/nar_file.rs
@@ -15,5 +15,9 @@ pub fn make_nar_file_key() -> NarFileKey {
 }
 
 pub fn make_nar_file_location(substituter_url: &Url, priority: u32) -> NarFileLocation {
-    NarFileLocation::new(make_source_url(substituter_url, priority), None)
+    NarFileLocation::new(
+        make_source_url(substituter_url, priority),
+        substituter::make_substituter_meta(substituter_url, 1),
+        None,
+    )
 }

--- a/tests/integration/fixture/nar_file.rs
+++ b/tests/integration/fixture/nar_file.rs
@@ -1,17 +1,33 @@
+use std::time::{Duration, SystemTime};
+
+use selector4nix::domain::common::expire_at::ExpireAt;
 use selector4nix::domain::common::url::Url;
-use selector4nix::domain::nar_file::model::{NarFileKey, NarFileLocation};
+use selector4nix::domain::nar_file::model::{NarFile, NarFileKey, NarFileLocation};
+use selector4nix::domain::substituter::model::SubstituterMeta;
 
 use super::{nar_info, substituter};
 
 pub const NAR_FILE: &str = "1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz";
 
+pub fn make_source_url_with_substituter_meta(meta: &SubstituterMeta) -> Url {
+    nar_info::make_nar_file_name().with_storage_prefix(meta.storage_url())
+}
+
 pub fn make_source_url(substituter_url: &Url, priority: u32) -> Url {
     let meta = substituter::make_substituter_meta(substituter_url, priority);
-    nar_info::make_nar_file_name().with_storage_prefix(meta.storage_url())
+    make_source_url_with_substituter_meta(&meta)
 }
 
 pub fn make_nar_file_key() -> NarFileKey {
     NarFileKey::from_file_name(&nar_info::make_nar_file_name())
+}
+
+pub fn make_nar_file_location_with_substituter_meta(meta: &SubstituterMeta) -> NarFileLocation {
+    NarFileLocation::new(
+        make_source_url_with_substituter_meta(meta),
+        meta.clone(),
+        None,
+    )
 }
 
 pub fn make_nar_file_location(substituter_url: &Url, priority: u32) -> NarFileLocation {
@@ -20,4 +36,9 @@ pub fn make_nar_file_location(substituter_url: &Url, priority: u32) -> NarFileLo
         substituter::make_substituter_meta(substituter_url, 1),
         None,
     )
+}
+
+pub fn make_nar_file_with_location(location: NarFileLocation) -> NarFile {
+    let expire_at = ExpireAt::since(SystemTime::now(), Duration::from_secs(3600));
+    NarFile::new(make_nar_file_key()).on_located(location, expire_at)
 }

--- a/tests/integration/fixture/substituter.rs
+++ b/tests/integration/fixture/substituter.rs
@@ -4,13 +4,31 @@ use selector4nix::domain::common::url::Url;
 use selector4nix::domain::substituter::model::{
     Availability, Priority, Substituter, SubstituterMeta,
 };
+use tokio::time::Instant;
 
 pub fn make_substituter_meta(url: &Url, priority: u32) -> SubstituterMeta {
     SubstituterMeta::new(url.clone(), Priority::new(priority).unwrap())
 }
 
+pub fn make_substituter_meta_with_storage_url(
+    url: &Url,
+    storage_url: Url,
+    priority: u32,
+) -> SubstituterMeta {
+    make_substituter_meta(url, priority).with_storage_url(storage_url)
+}
+
 pub fn make_substituter_normal(url: &Url, priority: u32) -> Substituter {
     Substituter::new(make_substituter_meta(url, priority), Availability::Normal)
+}
+
+pub fn make_substituter_offline(url: &Url, priority: u32) -> Substituter {
+    Substituter::new(
+        make_substituter_meta(url, priority),
+        Availability::Offline {
+            detected_at: Instant::now(),
+        },
+    )
 }
 
 pub fn make_substituter_normal_with_nar_info_timeout(

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -3,5 +3,6 @@ pub mod mock;
 
 mod config_test;
 mod credential_test;
+mod nar_file_service_test;
 mod nar_info_service_test;
 mod status_query_usecase_test;

--- a/tests/integration/mock/mod.rs
+++ b/tests/integration/mock/mod.rs
@@ -1,1 +1,2 @@
 pub mod nar_info_provider;
+pub mod nar_stream_provider;

--- a/tests/integration/mock/nar_stream_provider.rs
+++ b/tests/integration/mock/nar_stream_provider.rs
@@ -1,0 +1,62 @@
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use anyhow::Result as AnyhowResult;
+use async_trait::async_trait;
+use selector4nix::domain::common::passthrough_headers::PassthroughHeaders;
+use selector4nix::domain::common::url::Url;
+use selector4nix::domain::nar_file::model::NarFileLocation;
+use selector4nix::domain::nar_file::port::{NarStreamData, NarStreamHeaders, NarStreamProvider};
+
+pub struct MockNarStreamProvider {
+    success_urls: HashSet<Url>,
+    contacted: Mutex<HashSet<Url>>,
+}
+
+impl MockNarStreamProvider {
+    pub fn new<I>(success_urls: I) -> Self
+    where
+        I: IntoIterator<Item = Url>,
+    {
+        Self {
+            success_urls: success_urls.into_iter().collect(),
+            contacted: Mutex::new(HashSet::new()),
+        }
+    }
+
+    pub fn has_contacted_url(&self, url: &Url) -> bool {
+        self.contacted.lock().unwrap().contains(url)
+    }
+}
+
+#[async_trait]
+impl NarStreamProvider for MockNarStreamProvider {
+    async fn stream_nar(
+        &self,
+        locations: &[NarFileLocation],
+        _headers: &PassthroughHeaders,
+    ) -> AnyhowResult<Option<NarStreamData>> {
+        {
+            let mut contacted = self.contacted.lock().unwrap();
+            for loc in locations {
+                contacted.insert(loc.source_url().clone());
+            }
+        }
+
+        for loc in locations {
+            if self.success_urls.contains(loc.source_url()) {
+                let data = NarStreamData::new(
+                    NarStreamHeaders {
+                        content_length: None,
+                        content_type: None,
+                        content_encoding: None,
+                    },
+                    Box::pin(futures::stream::empty()),
+                    loc.source_url().clone(),
+                );
+                return Ok(Some(data));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/tests/integration/nar_file_service_test.rs
+++ b/tests/integration/nar_file_service_test.rs
@@ -1,0 +1,174 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use selector4nix::domain::common::passthrough_headers::PassthroughHeaders;
+use selector4nix::domain::common::url::Url;
+use selector4nix::domain::nar_file::model::NarFile;
+use selector4nix::domain::nar_file::{NarFileService, StreamNarFileError};
+use selector4nix::domain::substituter::SubstituterRepository;
+use selector4nix::domain::substituter::model::Substituter;
+use selector4nix::infrastructure::repository::InMemorySubstituterRepository;
+
+use crate::fixture::{nar_file, substituter};
+use crate::mock::nar_stream_provider::MockNarStreamProvider;
+
+#[derive(Debug)]
+struct TestCaseEnvironment {
+    substituters: Vec<Substituter>,
+    success_urls: HashSet<Url>,
+}
+
+#[derive(Debug)]
+struct TestCaseInput {
+    nar_file: NarFile,
+}
+
+#[derive(Debug)]
+struct TestCaseExpectation {
+    result_source_url: Result<Option<Url>, StreamNarFileError>,
+    used_substituter_url: Option<Url>,
+    not_contacted_source_urls: Vec<Url>,
+}
+
+async fn run_test(
+    env: TestCaseEnvironment,
+    input: TestCaseInput,
+    expectation: TestCaseExpectation,
+) {
+    let repo = Arc::new(InMemorySubstituterRepository::new());
+    for sub in env.substituters {
+        repo.save(sub).await;
+    }
+
+    let provider = Arc::new(MockNarStreamProvider::new(env.success_urls));
+    let service = NarFileService::new(provider.clone(), repo, Duration::from_secs(14400));
+
+    let (nar_file, result) = service
+        .stream(
+            input.nar_file,
+            PassthroughHeaders::empty(),
+            SystemTime::now(),
+        )
+        .await;
+
+    assert_eq!(
+        result.map(|opt| opt.map(|data| data.source_url)),
+        expectation.result_source_url,
+    );
+
+    assert_eq!(
+        nar_file
+            .location()
+            .map(|location| location.substituter().url().clone()),
+        expectation.used_substituter_url,
+    );
+
+    for forbidden in &expectation.not_contacted_source_urls {
+        assert!(!provider.has_contacted_url(forbidden));
+    }
+}
+
+#[tokio::test]
+async fn cached_substituter_unavailable_falls_back_early() {
+    let a_url = Url::new("https://cache-a.example.com").unwrap();
+    let b_url = Url::new("https://cache-b.example.com").unwrap();
+    let a_src = nar_file::make_source_url(&a_url, 40);
+    let b_src = nar_file::make_source_url(&b_url, 10);
+
+    let nar_file =
+        nar_file::make_nar_file_with_location(nar_file::make_nar_file_location(&a_url, 40));
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![
+                substituter::make_substituter_offline(&a_url, 40),
+                substituter::make_substituter_normal(&b_url, 10),
+            ],
+            success_urls: HashSet::from([b_src.clone()]),
+        },
+        TestCaseInput { nar_file },
+        TestCaseExpectation {
+            result_source_url: Ok(Some(b_src)),
+            used_substituter_url: Some(b_url),
+            not_contacted_source_urls: vec![a_src],
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn cached_substituter_available_serves_from_cache() {
+    let a_url = Url::new("https://cache-a.example.com").unwrap();
+    let a_src = nar_file::make_source_url(&a_url, 40);
+
+    let nar_file =
+        nar_file::make_nar_file_with_location(nar_file::make_nar_file_location(&a_url, 40));
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![substituter::make_substituter_normal(&a_url, 40)],
+            success_urls: HashSet::from([a_src.clone()]),
+        },
+        TestCaseInput { nar_file },
+        TestCaseExpectation {
+            result_source_url: Ok(Some(a_src)),
+            used_substituter_url: Some(a_url),
+            not_contacted_source_urls: vec![],
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn offline_substituter_with_separate_storage_still_served_from_cache() {
+    let a_url = Url::new("https://cache-a.example.com").unwrap();
+    let a_storage = Url::new("https://storage-a.example.com/nar").unwrap();
+    let meta = substituter::make_substituter_meta_with_storage_url(&a_url, a_storage, 40);
+    let a_src = nar_file::make_source_url_with_substituter_meta(&meta);
+
+    let nar_file = nar_file::make_nar_file_with_location(
+        nar_file::make_nar_file_location_with_substituter_meta(&meta),
+    );
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![substituter::make_substituter_offline(&a_url, 40)],
+            success_urls: HashSet::from([a_src.clone()]),
+        },
+        TestCaseInput { nar_file },
+        TestCaseExpectation {
+            result_source_url: Ok(Some(a_src)),
+            used_substituter_url: Some(a_url),
+            not_contacted_source_urls: vec![],
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn cached_attempt_fails_falls_back() {
+    let a_url = Url::new("https://cache-a.example.com").unwrap();
+    let b_url = Url::new("https://cache-b.example.com").unwrap();
+    let b_src = nar_file::make_source_url(&b_url, 10);
+
+    let nar_file =
+        nar_file::make_nar_file_with_location(nar_file::make_nar_file_location(&a_url, 40));
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![
+                substituter::make_substituter_normal(&a_url, 40),
+                substituter::make_substituter_normal(&b_url, 10),
+            ],
+            success_urls: HashSet::from([b_src.clone()]),
+        },
+        TestCaseInput { nar_file },
+        TestCaseExpectation {
+            result_source_url: Ok(Some(b_src)),
+            used_substituter_url: Some(b_url),
+            not_contacted_source_urls: vec![],
+        },
+    )
+    .await;
+}


### PR DESCRIPTION
Add early fallback strategy for NAR file streaming in case that the selected substituter is unavailable when requesting the NAR file. This avoids wasted timeout for unhealthy substituters and make the system reacts more quickly to such situation.

Add a new integration test `nar_file_service_test`.