### PR TITLE
Add configuration items for chunked NAR streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Nix substituter proxy with parallel cache queries and latency-aware selection.
 - Automatically detects and skips unavailable substituters, retrying them with exponential backoff
 - Continuously probes substituters to detect failures early and verify recovery
 - Proxy private cache substituters with additional credentials
+- Pre-fetch multiple NAR file chunks concurrently to improve network utilization, based on sliding window
 
 Note that `selector4nix` only intends to work as a proxy rather than a full-featured cache substituter. NAR files are streamed directly from the best substituter without being cached locally. However, it does cache `.narinfo` files for better responsiveness.
 

--- a/components/selector4nix-streaming/src/client.rs
+++ b/components/selector4nix-streaming/src/client.rs
@@ -16,12 +16,11 @@ use crate::stream::{
 };
 use crate::throttler::{PerHostHttpThrottler, ThrottlerAdapter, ThrottlerPermit};
 
-const CHUNK_MAX_LEN: NonZeroUsize = NonZeroUsize::new(4 * 1024 * 1024).unwrap();
-const WINDOW_MAX_LEN: NonZeroUsize = NonZeroUsize::new(8).unwrap();
-
 struct StreamingClientContext {
     client: Client,
     throttler: Arc<PerHostHttpThrottler>,
+    chunk_max_len: NonZeroUsize,
+    window_max_len: NonZeroUsize,
 }
 
 pub struct StreamingClient {
@@ -29,7 +28,12 @@ pub struct StreamingClient {
 }
 
 impl StreamingClient {
-    pub fn new(client: ClientBuilder, max_concurrent_requests: usize) -> Self {
+    pub fn new(
+        client: ClientBuilder,
+        max_concurrent_requests: usize,
+        chunk_max_len: NonZeroUsize,
+        window_max_len: NonZeroUsize,
+    ) -> Self {
         Self {
             context: Arc::new(StreamingClientContext {
                 client: client
@@ -37,6 +41,8 @@ impl StreamingClient {
                     .build()
                     .expect("invalid reqwest client configuration"),
                 throttler: Arc::new(PerHostHttpThrottler::new(max_concurrent_requests)),
+                chunk_max_len,
+                window_max_len,
             }),
         }
     }
@@ -90,7 +96,7 @@ impl StreamingRequest {
         let request = (self.configure.as_deref().unwrap_or(&|x| x))(self.request);
         let request = request.header(
             header::RANGE,
-            format!("bytes=0-{}", usize::from(CHUNK_MAX_LEN) - 1),
+            format!("bytes=0-{}", usize::from(self.context.chunk_max_len) - 1),
         );
         let response = request.send().await.context(TransportSnafu)?;
 
@@ -205,9 +211,9 @@ impl StreamingResponse {
                 context,
                 permit,
             } => Box::pin(ChunkedStream::new(ChunkedStreamArgs {
-                chunk_max_len: CHUNK_MAX_LEN,
+                chunk_max_len: context.chunk_max_len,
                 bytes_total,
-                window_max_len: WINDOW_MAX_LEN,
+                window_max_len: context.window_max_len,
                 connector: Box::new(HttpChunkConnector::new(
                     context.client.clone(),
                     url,

--- a/components/selector4nix-streaming/src/client.rs
+++ b/components/selector4nix-streaming/src/client.rs
@@ -19,19 +19,25 @@ use crate::throttler::{PerHostHttpThrottler, ThrottlerAdapter, ThrottlerPermit};
 const CHUNK_MAX_LEN: NonZeroUsize = NonZeroUsize::new(4 * 1024 * 1024).unwrap();
 const WINDOW_MAX_LEN: NonZeroUsize = NonZeroUsize::new(8).unwrap();
 
-pub struct StreamingClient {
+struct StreamingClientContext {
     client: Client,
     throttler: Arc<PerHostHttpThrottler>,
+}
+
+pub struct StreamingClient {
+    context: Arc<StreamingClientContext>,
 }
 
 impl StreamingClient {
     pub fn new(client: ClientBuilder, max_concurrent_requests: usize) -> Self {
         Self {
-            client: client
-                .http1_only()
-                .build()
-                .expect("invalid reqwest client configuration"),
-            throttler: Arc::new(PerHostHttpThrottler::new(max_concurrent_requests)),
+            context: Arc::new(StreamingClientContext {
+                client: client
+                    .http1_only()
+                    .build()
+                    .expect("invalid reqwest client configuration"),
+                throttler: Arc::new(PerHostHttpThrottler::new(max_concurrent_requests)),
+            }),
         }
     }
 
@@ -45,13 +51,12 @@ impl StreamingClient {
             .expect("`url` should have a host")
             .to_string();
 
-        let request = self.client.get(url);
+        let request = self.context.client.get(url);
         StreamingRequest {
             request,
             host,
-            client: self.client.clone(),
+            context: Arc::clone(&self.context),
             configure: None,
-            throttler: Arc::clone(&self.throttler),
         }
     }
 }
@@ -59,9 +64,8 @@ impl StreamingClient {
 pub struct StreamingRequest {
     request: RequestBuilder,
     host: String,
-    client: Client,
     configure: Option<Box<dyn Fn(RequestBuilder) -> RequestBuilder + Send + Sync + 'static>>,
-    throttler: Arc<PerHostHttpThrottler>,
+    context: Arc<StreamingClientContext>,
 }
 
 impl StreamingRequest {
@@ -78,7 +82,7 @@ impl StreamingRequest {
     }
 
     pub async fn send(self) -> Result<StreamingResponse, StreamHttpBodyError> {
-        let permit = self.throttler.acquire(&self.host).await;
+        let permit = self.context.throttler.acquire(&self.host).await;
 
         // The first request always asks for the leading chunk so that servers supporting range
         // requests can be served via a chunked response, while servers that ignore `Range` fall
@@ -90,22 +94,17 @@ impl StreamingRequest {
         );
         let response = request.send().await.context(TransportSnafu)?;
 
-        StreamingResponse::from_response(
-            response,
-            self.client,
-            self.configure,
-            self.throttler,
-            self.host,
-            permit,
-        )
+        StreamingResponse::from_response(response, self.configure, self.host, self.context, permit)
     }
 }
 
-pub enum StreamingResponse {
+pub struct StreamingResponse(StreamingResponseInner);
+
+enum StreamingResponseInner {
     Full {
         response: Response,
         content_length: Option<u64>,
-        _permit: ThrottlerPermit,
+        permit: ThrottlerPermit,
     },
     Chunked {
         response: Response,
@@ -113,30 +112,28 @@ pub enum StreamingResponse {
         initial_chunk_len: usize,
         url: Url,
         host: String,
-        client: Client,
         configure: Option<Box<dyn Fn(RequestBuilder) -> RequestBuilder + Send + Sync + 'static>>,
-        throttler: Arc<PerHostHttpThrottler>,
-        _permit: ThrottlerPermit,
+        context: Arc<StreamingClientContext>,
+        permit: ThrottlerPermit,
     },
 }
 
 impl StreamingResponse {
     fn from_response(
         response: Response,
-        client: Client,
         configure: Option<Box<dyn Fn(RequestBuilder) -> RequestBuilder + Send + Sync + 'static>>,
-        throttler: Arc<PerHostHttpThrottler>,
         host: String,
+        context: Arc<StreamingClientContext>,
         permit: ThrottlerPermit,
     ) -> Result<StreamingResponse, StreamHttpBodyError> {
         match response.status() {
             StatusCode::OK => {
                 tracing::debug!(url = %response.url(), "select full (unchunked) stream");
-                Ok(StreamingResponse::Full {
+                Ok(StreamingResponse(StreamingResponseInner::Full {
                     content_length: response.content_length(),
                     response,
-                    _permit: permit,
-                })
+                    permit,
+                }))
             }
             StatusCode::PARTIAL_CONTENT => {
                 let bytes_total = response
@@ -158,17 +155,16 @@ impl StreamingResponse {
 
                 let url = response.url().clone();
                 tracing::debug!(%url, ?bytes_total, ?initial_chunk_len, "select chunked stream");
-                Ok(StreamingResponse::Chunked {
+                Ok(StreamingResponse(StreamingResponseInner::Chunked {
                     response,
                     bytes_total,
                     initial_chunk_len,
                     url,
                     host,
-                    client,
                     configure,
-                    throttler,
-                    _permit: permit,
-                })
+                    context,
+                    permit,
+                }))
             }
             StatusCode::NOT_FOUND | StatusCode::FORBIDDEN => Err(StreamHttpBodyError::NotFound),
             status => Err(StreamHttpBodyError::InvalidStatus { status }),
@@ -176,46 +172,49 @@ impl StreamingResponse {
     }
 
     pub fn content_length(&self) -> Option<u64> {
-        match self {
-            StreamingResponse::Full { content_length, .. } => *content_length,
-            StreamingResponse::Chunked { bytes_total, .. } => Some(*bytes_total as u64),
+        match &self.0 {
+            StreamingResponseInner::Full { content_length, .. } => *content_length,
+            StreamingResponseInner::Chunked { bytes_total, .. } => Some(*bytes_total as u64),
         }
     }
 
     pub fn raw_headers(&self) -> &HeaderMap {
-        match self {
-            StreamingResponse::Full { response, .. } => response.headers(),
-            StreamingResponse::Chunked { response, .. } => response.headers(),
+        match &self.0 {
+            StreamingResponseInner::Full { response, .. } => response.headers(),
+            StreamingResponseInner::Chunked { response, .. } => response.headers(),
         }
     }
 
     pub fn into_stream(self) -> SBoxStream<AnyhowResult<Bytes>> {
-        match self {
-            StreamingResponse::Full {
-                response, _permit, ..
+        match self.0 {
+            StreamingResponseInner::Full {
+                response, permit, ..
             } => Box::pin(FullStream::new(
                 response.bytes_stream().map(|chunk| {
                     anyhow::Context::with_context(chunk, || "failed to read byte stream")
                 }),
-                _permit,
+                permit,
             )),
-            StreamingResponse::Chunked {
+            StreamingResponseInner::Chunked {
                 response,
                 bytes_total,
                 initial_chunk_len,
-                client,
                 url,
                 configure,
-                throttler,
                 host,
-                _permit,
+                context,
+                permit,
             } => Box::pin(ChunkedStream::new(ChunkedStreamArgs {
                 chunk_max_len: CHUNK_MAX_LEN,
                 bytes_total,
                 window_max_len: WINDOW_MAX_LEN,
-                connector: Box::new(HttpChunkConnector::new(client, url, configure)),
-                throttler: Box::new(ThrottlerAdapter::new(throttler, host)),
-                initial_permit: _permit,
+                connector: Box::new(HttpChunkConnector::new(
+                    context.client.clone(),
+                    url,
+                    configure,
+                )),
+                throttler: Box::new(ThrottlerAdapter::new(Arc::clone(&context.throttler), host)),
+                initial_permit: permit,
                 initial_chunk_stream: Box::pin(BoundedHttpStream::new(
                     Box::pin(response.bytes_stream()),
                     initial_chunk_len,

--- a/components/selector4nix-streaming/src/client.rs
+++ b/components/selector4nix-streaming/src/client.rs
@@ -19,6 +19,7 @@ use crate::throttler::{PerHostHttpThrottler, ThrottlerAdapter, ThrottlerPermit};
 struct StreamingClientContext {
     client: Client,
     throttler: Arc<PerHostHttpThrottler>,
+    enable_chunked_streaming: bool,
     chunk_max_len: NonZeroUsize,
     window_max_len: NonZeroUsize,
 }
@@ -31,6 +32,7 @@ impl StreamingClient {
     pub fn new(
         client: ClientBuilder,
         max_concurrent_requests: usize,
+        enable_chunked_streaming: bool,
         chunk_max_len: NonZeroUsize,
         window_max_len: NonZeroUsize,
     ) -> Self {
@@ -41,6 +43,7 @@ impl StreamingClient {
                     .build()
                     .expect("invalid reqwest client configuration"),
                 throttler: Arc::new(PerHostHttpThrottler::new(max_concurrent_requests)),
+                enable_chunked_streaming,
                 chunk_max_len,
                 window_max_len,
             }),
@@ -90,16 +93,21 @@ impl StreamingRequest {
     pub async fn send(self) -> Result<StreamingResponse, StreamHttpBodyError> {
         let permit = self.context.throttler.acquire(&self.host).await;
 
-        // The first request always asks for the leading chunk so that servers supporting range
-        // requests can be served via a chunked response, while servers that ignore `Range` fall
-        // back to a full stream.
         let request = (self.configure.as_deref().unwrap_or(&|x| x))(self.request);
-        let request = request.header(
-            header::RANGE,
-            format!("bytes=0-{}", usize::from(self.context.chunk_max_len) - 1),
-        );
-        let response = request.send().await.context(TransportSnafu)?;
 
+        let request = if self.context.enable_chunked_streaming {
+            // The first request always asks for the leading chunk so that servers supporting range
+            // requests can be served via a chunked response, while servers that ignore `Range` fall
+            // back to a full stream.
+            request.header(
+                header::RANGE,
+                format!("bytes=0-{}", usize::from(self.context.chunk_max_len) - 1),
+            )
+        } else {
+            request
+        };
+
+        let response = request.send().await.context(TransportSnafu)?;
         StreamingResponse::from_response(response, self.configure, self.host, self.context, permit)
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,13 @@ Timeout in seconds for NAR file downloads, also used as connect timeout.
 
 Maximum number of concurrent outgoing NAR file streaming requests, applied per distinct substituter host. The overall ceiling across the proxy is `max_concurrent_requests` multiplied by the number of distinct substituter hosts.
 
+### `network.chunked_streaming`
+
+- Type: Boolean
+- Default: `true`
+
+When enabled, NAR files are downloaded using concurrent multi-connection chunked transfer if the upstream substituter supports Range requests. When multiple NAR files are downloaded concurrently, available connections are shared fairly across files so that no single file monopolizes the bandwidth.
+
 ### `network.streaming_chunk_max_len`
 
 - Type: Positive Integer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,20 @@ Timeout in seconds for NAR file downloads, also used as connect timeout.
 
 Maximum number of concurrent outgoing NAR file streaming requests, applied per distinct substituter host. The overall ceiling across the proxy is `max_concurrent_requests` multiplied by the number of distinct substituter hosts.
 
+### `network.streaming_chunk_max_len`
+
+- Type: Positive Integer
+- Default: `4194304`
+
+Maximum size in bytes of each chunk when downloading NAR files. The default value is 4 MiB.
+
+### `network.streaming_window_max_len`
+
+- Type: Positive Integer
+- Default: `8`
+
+Maximum number of chunks that may be in flight simultaneously for a single NAR file. The effective concurrency is also bounded by `max_concurrent_requests`. When the per-host concurrency limit is saturated, new chunks defer in favor of streaming other NAR files.
+
 ### `network.tolerance_msecs`
 
 - Type: Natural

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -25,6 +25,8 @@ ignore_nar_info_error = false
 # Whether to continuously probe substituters for health every 30 seconds (default: true).
 # Probing during retry recovery is always enabled regardless of this setting.
 periodic_probing = true
+# Whether to enable chunked NAR transfer via concurrent Range requests (default: true).
+chunked_streaming = true
 # Maximum chunk size in bytes for chunked NAR transfer (default: 4194304).
 streaming_chunk_max_len = 4194304
 # Maximum number of in-flight chunks per NAR file, also bounded by max_concurrent_requests (default: 8).

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -25,6 +25,10 @@ ignore_nar_info_error = false
 # Whether to continuously probe substituters for health every 30 seconds (default: true).
 # Probing during retry recovery is always enabled regardless of this setting.
 periodic_probing = true
+# Maximum chunk size in bytes for chunked NAR transfer (default: 4194304).
+streaming_chunk_max_len = 4194304
+# Maximum number of in-flight chunks per NAR file, also bounded by max_concurrent_requests (default: 8).
+streaming_window_max_len = 8
 
 # Proxy behavior settings.
 [proxy]

--- a/src/api/handlers/index.html
+++ b/src/api/handlers/index.html
@@ -540,6 +540,9 @@
         ['NAR Timeout', `${network.nar_timeout_secs}s`],
         ['Max Concurrent', String(network.max_concurrent_requests)],
         ['Ignore NAR Error', network.ignore_nar_info_error ? 'enabled' : 'disabled'],
+        ['Chunked Streaming', network.chunked_streaming ? 'enabled' : 'disabled'],
+        ['Streaming Chunk Size', `${(network.streaming_chunk_max_len / 1048576).toFixed(0)} MiB`],
+        ['Streaming Window Size', String(network.streaming_window_max_len)],
       ];
 
       document.getElementById('config-info').innerHTML = items

--- a/src/api/handlers/status.rs
+++ b/src/api/handlers/status.rs
@@ -26,6 +26,9 @@ struct NetworkStatus {
     nar_timeout_secs: u64,
     max_concurrent_requests: usize,
     ignore_nar_info_error: bool,
+    chunked_streaming: bool,
+    streaming_chunk_max_len: usize,
+    streaming_window_max_len: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -103,6 +106,9 @@ fn to_response(snapshot: StatusSnapshot) -> StatusResponse {
             nar_timeout_secs: config.network.nar_timeout.as_secs(),
             max_concurrent_requests: config.network.max_concurrent_requests,
             ignore_nar_info_error: config.network.ignore_nar_info_error,
+            chunked_streaming: config.network.chunked_streaming,
+            streaming_chunk_max_len: usize::from(config.network.streaming_chunk_max_len),
+            streaming_window_max_len: usize::from(config.network.streaming_window_max_len),
         },
         proxy: proxy_status(config.proxy.rewrite_nar_url),
         substituters: SubstitutersStatus {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -130,6 +130,8 @@ pub async fn init_context(
     let streaming_http_client = Arc::new(StreamingClient::new(
         http_client_builder_factory(config),
         config.network.max_concurrent_requests,
+        config.network.streaming_chunk_max_len,
+        config.network.streaming_window_max_len,
     ));
 
     let substituter_probing_provider = Arc::new(ReqwestSubstituterProbingProvider::new(

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -130,6 +130,7 @@ pub async fn init_context(
     let streaming_http_client = Arc::new(StreamingClient::new(
         http_client_builder_factory(config),
         config.network.max_concurrent_requests,
+        config.network.chunked_streaming,
         config.network.streaming_chunk_max_len,
         config.network.streaming_window_max_len,
     ));

--- a/src/infrastructure/config/general_parsed.rs
+++ b/src/infrastructure/config/general_parsed.rs
@@ -107,6 +107,7 @@ pub struct NetworkConfiguration {
     pub tolerance: u64,
     pub ignore_nar_info_error: bool,
     pub periodic_probing: PeriodicProbingOption,
+    pub chunked_streaming: bool,
     pub streaming_chunk_max_len: NonZeroUsize,
     pub streaming_window_max_len: NonZeroUsize,
 }
@@ -130,6 +131,7 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
             } else {
                 PeriodicProbingOption::None
             },
+            chunked_streaming: raw.chunked_streaming.unwrap_or(true),
             streaming_chunk_max_len: raw
                 .streaming_chunk_max_len
                 .unwrap_or(NonZeroUsize::new(4 * 1024 * 1024).unwrap()),

--- a/src/infrastructure/config/general_parsed.rs
+++ b/src/infrastructure/config/general_parsed.rs
@@ -1,4 +1,5 @@
 use std::net::{IpAddr, SocketAddr};
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -106,6 +107,8 @@ pub struct NetworkConfiguration {
     pub tolerance: u64,
     pub ignore_nar_info_error: bool,
     pub periodic_probing: PeriodicProbingOption,
+    pub streaming_chunk_max_len: NonZeroUsize,
+    pub streaming_window_max_len: NonZeroUsize,
 }
 
 impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
@@ -127,6 +130,12 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
             } else {
                 PeriodicProbingOption::None
             },
+            streaming_chunk_max_len: raw
+                .streaming_chunk_max_len
+                .unwrap_or(NonZeroUsize::new(4 * 1024 * 1024).unwrap()),
+            streaming_window_max_len: raw
+                .streaming_window_max_len
+                .unwrap_or(NonZeroUsize::new(8).unwrap()),
         })
     }
 }

--- a/src/infrastructure/config/general_raw.rs
+++ b/src/infrastructure/config/general_raw.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::{net::IpAddr, num::NonZeroUsize};
 
 use anyhow::{Context, Result as AnyhowResult};
 use serde::Deserialize;
@@ -33,6 +33,8 @@ pub struct NetworkRawConfiguration {
     pub tolerance_msecs: Option<u64>,
     pub ignore_nar_info_error: Option<bool>,
     pub periodic_probing: Option<bool>,
+    pub streaming_chunk_max_len: Option<NonZeroUsize>,
+    pub streaming_window_max_len: Option<NonZeroUsize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]

--- a/src/infrastructure/config/general_raw.rs
+++ b/src/infrastructure/config/general_raw.rs
@@ -33,6 +33,7 @@ pub struct NetworkRawConfiguration {
     pub tolerance_msecs: Option<u64>,
     pub ignore_nar_info_error: Option<bool>,
     pub periodic_probing: Option<bool>,
+    pub chunked_streaming: Option<bool>,
     pub streaming_chunk_max_len: Option<NonZeroUsize>,
     pub streaming_window_max_len: Option<NonZeroUsize>,
 }

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -28,6 +28,7 @@ fn defaults_are_applied_when_sections_omitted() {
         config.network.periodic_probing,
         PeriodicProbingOption::Enabled,
     );
+    assert_eq!(config.network.chunked_streaming, true);
     assert_eq!(
         config.network.streaming_chunk_max_len,
         NonZeroUsize::new(4 * 1024 * 1024).unwrap(),

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use selector4nix::domain::nar_info::model::NarUrlRewriteOption;
@@ -25,7 +26,15 @@ fn defaults_are_applied_when_sections_omitted() {
     assert!(!config.network.ignore_nar_info_error);
     assert_eq!(
         config.network.periodic_probing,
-        PeriodicProbingOption::Enabled
+        PeriodicProbingOption::Enabled,
+    );
+    assert_eq!(
+        config.network.streaming_chunk_max_len,
+        NonZeroUsize::new(4 * 1024 * 1024).unwrap(),
+    );
+    assert_eq!(
+        config.network.streaming_window_max_len,
+        NonZeroUsize::new(8).unwrap(),
     );
     assert_eq!(config.proxy.rewrite_nar_url, NarUrlRewriteOption::ToSelf);
     assert_eq!(config.cache_info.store_dir, "/nix/store");


### PR DESCRIPTION
Add `network.chunked_streaming`, `network.streaming_chunk_max_len` and `network.streaming_window_max_len` and show these configuration items in the dashboard.