### PR TITLE
Enable all testcases from all crates in the workspace

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -16,6 +16,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     lockFile = ../Cargo.lock;
   };
 
+  cargoTestFlags = [ "--workspace" ];
+
   passthru.tests = {
     system-test-cache-persistence = callPackage ../tests/system/cache-persistence/package.nix {
       inherit rustPlatform;


### PR DESCRIPTION
Add `--workspace` to `cargoTestFlags` to enable all testcases, otherwise, only testcases from the crate to be built are executed.