### PR TITLE
Refactor by extracting common test fixtures helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
  "postcard",
  "redb",
  "reqwest",
+ "selector4nix",
  "selector4nix-actor",
  "selector4nix-db",
  "selector4nix-streaming",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,4 @@ url = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+selector4nix = { path = ".", features = ["test-support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,13 @@ authors = ["Justin Chen"]
 keywords = ["nix", "substituter", "proxy", "cache"]
 categories = ["network-programming", "caching"]
 
+[features]
+test-support = []
+
+[[test]]
+name = "integration"
+required-features = ["test-support"]
+
 [dependencies]
 selector4nix-actor = { path = "components/selector4nix-actor" }
 selector4nix-db = { path = "components/selector4nix-db" }

--- a/src/domain/nar_file/model/nar_file.rs
+++ b/src/domain/nar_file/model/nar_file.rs
@@ -57,7 +57,7 @@ mod tests {
 
     use crate::domain::common::url::Url;
     use crate::domain::nar_info::model::NarFileName;
-    use crate::domain::substituter::model::{Priority, SubstituterMeta};
+    use crate::domain::substituter::model::test_support::make_substituter_meta_with_url;
 
     use super::*;
 
@@ -67,10 +67,7 @@ mod tests {
 
         let location = NarFileLocation::new(
             Url::new("https://example.com/abc123.nar.xz").unwrap(),
-            SubstituterMeta::new(
-                Url::new("https://example.com/").unwrap(),
-                Priority::new(40).unwrap(),
-            ),
+            make_substituter_meta_with_url(&Url::new("https://example.com/").unwrap()),
             None,
         );
         NarFile::new(key).on_located(location, ExpireAt::new(expire_at))

--- a/src/domain/nar_file/model/nar_file_key.rs
+++ b/src/domain/nar_file/model/nar_file_key.rs
@@ -52,30 +52,29 @@ impl NarFileKey {
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::nar_info::model::test_support::{
+        NAR_FILE_SAMPLE_UNCOMPRESSED, make_nar_file_name,
+    };
+
     use super::*;
 
     #[test]
     fn new_succeeds_given_compression() {
-        let name =
-            NarFileName::new("1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz".into())
-                .unwrap();
-        let key = NarFileKey::from_file_name(&name);
+        let key = NarFileKey::from_file_name(&make_nar_file_name());
         assert_eq!(
             key.file_hash(),
-            "1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3",
+            "1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3"
         );
         assert_eq!(key.compression(), Some("xz"));
     }
 
     #[test]
     fn new_succeeds_given_no_compression() {
-        let name =
-            NarFileName::new("0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd.nar".into())
-                .unwrap();
+        let name = NarFileName::new(NAR_FILE_SAMPLE_UNCOMPRESSED.to_string()).unwrap();
         let key = NarFileKey::from_file_name(&name);
         assert_eq!(
             key.file_hash(),
-            "0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd",
+            "0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd"
         );
     }
 }

--- a/src/domain/nar_info/model/mod.rs
+++ b/src/domain/nar_info/model/mod.rs
@@ -11,3 +11,30 @@ pub use nar_info_resolution::{NarInfoResolution, NarUrlRewriteOption};
 pub use proxy_nar_info_data::ProxyNarInfoData;
 pub use store_path_hash::{StorePathHash, TryNewStorePathHashError};
 pub use upstream_nar_info_data::{TryUpstreamNewNarInfoData, UpstreamNarInfoData};
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    use crate::domain::nar_info::model::{NarFileName, StorePathHash, UpstreamNarInfoData};
+
+    pub const STORE_PATH_HASH_RUBY: &str = "p4pclmv1gyja5kzc26npqpia1qqxrf0l";
+    pub const NAR_FILE_RUBY_XZ: &str =
+        "1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz";
+    pub const NAR_FILE_SAMPLE_UNCOMPRESSED: &str =
+        "0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd.nar";
+
+    pub fn make_store_path_hash() -> StorePathHash {
+        StorePathHash::new(STORE_PATH_HASH_RUBY.to_string()).unwrap()
+    }
+
+    pub fn make_nar_file_name() -> NarFileName {
+        NarFileName::new(NAR_FILE_RUBY_XZ.to_string()).unwrap()
+    }
+
+    pub fn make_upstream_nar_info_data_with_url(url_field: &str) -> UpstreamNarInfoData {
+        let content = format!(
+            "StorePath: /nix/store/{STORE_PATH_HASH_RUBY}-ruby-2.7.3\n\
+             URL: {url_field}\n"
+        );
+        UpstreamNarInfoData::new(content).unwrap()
+    }
+}

--- a/src/domain/nar_info/model/nar_file_name.rs
+++ b/src/domain/nar_info/model/nar_file_name.rs
@@ -42,25 +42,20 @@ impl From<TryNewNarFileNameError> for AppError {
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::common::url::Url;
+    use crate::domain::nar_info::model::test_support::{
+        NAR_FILE_RUBY_XZ, NAR_FILE_SAMPLE_UNCOMPRESSED,
+    };
+
     use super::*;
 
     #[test]
     fn new_succeeds() {
-        let name =
-            NarFileName::new("1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz".into())
-                .unwrap();
-        assert_eq!(
-            name.value(),
-            "1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
-        );
+        let name = NarFileName::new(NAR_FILE_RUBY_XZ.to_string()).unwrap();
+        assert_eq!(name.value(), NAR_FILE_RUBY_XZ);
 
-        let name =
-            NarFileName::new("0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd.nar".into())
-                .unwrap();
-        assert_eq!(
-            name.value(),
-            "0mcjpwqknlcvkb42x5kyn7pmxa6ibpmrxqrcgzjm6fhwl99v19kd.nar"
-        );
+        let name = NarFileName::new(NAR_FILE_SAMPLE_UNCOMPRESSED.to_string()).unwrap();
+        assert_eq!(name.value(), NAR_FILE_SAMPLE_UNCOMPRESSED);
     }
 
     #[test]

--- a/src/domain/nar_info/model/nar_info.rs
+++ b/src/domain/nar_info/model/nar_info.rs
@@ -63,24 +63,17 @@ impl NarInfo {
 mod tests {
     use std::time::Duration;
 
+    use crate::domain::nar_info::model::test_support::make_store_path_hash;
+
     use super::*;
-
-    fn make_hash() -> StorePathHash {
-        StorePathHash::new("p4pclmv1gyja5kzc26npqpia1qqxrf0l".into()).unwrap()
-    }
-
-    fn make_nar_info(expire_at: SystemTime) -> NarInfo {
-        let hash = make_hash();
-        let nar = NarInfo::new(hash.clone());
-        nar.on_resolved(NarInfoResolution::NotFound, ExpireAt::new(expire_at))
-    }
 
     #[test]
     fn check_expiry_and_update_changed_to_unknown_given_expired() {
         let now = SystemTime::now();
         let expire_at = now - Duration::from_secs(1);
 
-        let nar_info = make_nar_info(expire_at);
+        let nar_info = NarInfo::new(make_store_path_hash())
+            .on_resolved(NarInfoResolution::NotFound, ExpireAt::new(expire_at));
         let nar_info = nar_info.check_expiry_and_update(now);
 
         assert!(nar_info.resolution().is_none());
@@ -91,7 +84,8 @@ mod tests {
         let now = SystemTime::now();
         let expire_at = now + Duration::from_secs(1);
 
-        let nar_info = make_nar_info(expire_at);
+        let nar_info = NarInfo::new(make_store_path_hash())
+            .on_resolved(NarInfoResolution::NotFound, ExpireAt::new(expire_at));
         let nar_info = nar_info.check_expiry_and_update(now);
 
         assert!(nar_info.resolution().is_some());

--- a/src/domain/nar_info/model/nar_info_resolution.rs
+++ b/src/domain/nar_info/model/nar_info_resolution.rs
@@ -66,45 +66,24 @@ pub enum NarUrlRewriteOption {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::substituter::model::Priority;
+    use crate::domain::nar_info::model::test_support::{
+        NAR_FILE_RUBY_XZ, make_upstream_nar_info_data_with_url,
+    };
+    use crate::domain::substituter::model::test_support::{DEFAULT_URL, make_substituter_meta};
 
     use super::*;
-
-    fn make_upstream_nar_info_data() -> UpstreamNarInfoData {
-        UpstreamNarInfoData::new(
-            "StorePath: /nix/store/p4pclmv1gyja5kzc26npqpia1qqxrf0l-ruby-2.7.3\n\
-             URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
-                .into(),
-        )
-        .unwrap()
-    }
-
-    fn make_upstream_nar_info_data_with_external_url() -> UpstreamNarInfoData {
-        UpstreamNarInfoData::new(
-            "StorePath: /nix/store/p4pclmv1gyja5kzc26npqpia1qqxrf0l-ruby-2.7.3\n\
-             URL: https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
-                .into(),
-        )
-        .unwrap()
-    }
-
-    fn make_substituter_meta() -> SubstituterMeta {
-        SubstituterMeta::new(
-            Url::new("https://cache.nixos.org").unwrap(),
-            Priority::new(40).unwrap(),
-        )
-    }
 
     #[test]
     fn from_completed_query_returns_not_found_given_none() {
         let resolution = NarInfoResolution::from_completed_query(None, NarUrlRewriteOption::ToSelf);
-        assert!(matches!(resolution, NarInfoResolution::NotFound));
+        assert_eq!(resolution, NarInfoResolution::NotFound);
     }
 
     #[test]
     fn from_completed_query_resolves_given_relative_url() {
+        let upstream = make_upstream_nar_info_data_with_url(&format!("nar/{NAR_FILE_RUBY_XZ}"));
         let resolution = NarInfoResolution::from_completed_query(
-            Some((make_upstream_nar_info_data(), make_substituter_meta())),
+            Some((upstream, make_substituter_meta())),
             NarUrlRewriteOption::ToSelf,
         );
 
@@ -114,12 +93,14 @@ mod tests {
                 source_url,
                 ..
             } => {
-                assert!(nar_info.content().contains(
-                    "URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
-                ));
+                assert!(
+                    nar_info
+                        .content()
+                        .contains(&format!("URL: nar/{NAR_FILE_RUBY_XZ}\n"))
+                );
                 assert_eq!(
                     source_url.value(),
-                    "https://cache.nixos.org/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
+                    &format!("{DEFAULT_URL}/nar/{NAR_FILE_RUBY_XZ}")
                 );
             }
             _ => panic!("expected Resolved"),
@@ -128,11 +109,11 @@ mod tests {
 
     #[test]
     fn from_completed_query_resolves_given_external_url_and_rewrite_true() {
+        let upstream = make_upstream_nar_info_data_with_url(&format!(
+            "https://storage.example.com/nar/{NAR_FILE_RUBY_XZ}"
+        ));
         let resolution = NarInfoResolution::from_completed_query(
-            Some((
-                make_upstream_nar_info_data_with_external_url(),
-                make_substituter_meta(),
-            )),
+            Some((upstream, make_substituter_meta())),
             NarUrlRewriteOption::ToSelf,
         );
 
@@ -142,13 +123,15 @@ mod tests {
                 source_url,
                 ..
             } => {
-                assert!(nar_info.content().contains(
-                    "URL: nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz\n"
-                ));
+                assert!(
+                    nar_info
+                        .content()
+                        .contains(&format!("URL: nar/{NAR_FILE_RUBY_XZ}\n"))
+                );
                 assert!(!nar_info.content().contains("https://storage.example.com"));
                 assert_eq!(
                     source_url.value(),
-                    "https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
+                    &format!("https://storage.example.com/nar/{NAR_FILE_RUBY_XZ}")
                 );
             }
             _ => panic!("expected Resolved"),
@@ -157,11 +140,11 @@ mod tests {
 
     #[test]
     fn from_completed_query_preserves_external_url_given_rewrite_false() {
+        let upstream = make_upstream_nar_info_data_with_url(&format!(
+            "https://storage.example.com/nar/{NAR_FILE_RUBY_XZ}"
+        ));
         let resolution = NarInfoResolution::from_completed_query(
-            Some((
-                make_upstream_nar_info_data_with_external_url(),
-                make_substituter_meta(),
-            )),
+            Some((upstream, make_substituter_meta())),
             NarUrlRewriteOption::Keep,
         );
 
@@ -171,12 +154,10 @@ mod tests {
                 source_url,
                 ..
             } => {
-                assert!(nar_info.content().contains("https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"));
+                let expected_url = format!("https://storage.example.com/nar/{NAR_FILE_RUBY_XZ}");
+                assert!(nar_info.content().contains(&expected_url));
                 assert!(!nar_info.content().contains("URL: nar/"));
-                assert_eq!(
-                    source_url.value(),
-                    "https://storage.example.com/nar/1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz"
-                );
+                assert_eq!(source_url.value(), &expected_url);
             }
             _ => panic!("expected Resolved"),
         }

--- a/src/domain/nar_info/model/proxy_nar_info_data.rs
+++ b/src/domain/nar_info/model/proxy_nar_info_data.rs
@@ -76,52 +76,46 @@ impl ProxyNarInfoData {
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::substituter::model::test_support::{DEFAULT_URL, make_substituter_meta};
+
     use super::*;
-    use crate::domain::substituter::model::Priority;
 
     fn make_upstream_relative() -> UpstreamNarInfoData {
-        UpstreamNarInfoData::new(
-            "StorePath: /nix/store/abc-hello\n\
+        let content = "StorePath: /nix/store/abc-hello\n\
              URL: nar/abc.nar.xz?query=abc\n\
              Compression: xz\n"
-                .into(),
-        )
-        .unwrap()
+            .to_string();
+        UpstreamNarInfoData::new(content).unwrap()
     }
 
     fn make_upstream_absolute() -> UpstreamNarInfoData {
-        UpstreamNarInfoData::new(
-            "StorePath: /nix/store/abc-hello\n\
+        let content = "StorePath: /nix/store/abc-hello\n\
              URL: https://other.com/custom/abc.nar.xz\n\
              Compression: xz\n"
-                .into(),
-        )
-        .unwrap()
-    }
-
-    fn make_meta() -> SubstituterMeta {
-        SubstituterMeta::new(
-            Url::new("https://cache.example.com").unwrap(),
-            Priority::new(40).unwrap(),
-        )
+            .to_string();
+        UpstreamNarInfoData::new(content).unwrap()
     }
 
     #[test]
     fn keep_preserves_relative_url() {
-        let (proxy, nar_source_url) =
-            ProxyNarInfoData::proxy_by_keep_url(&make_upstream_relative(), &make_meta());
+        let (proxy, nar_source_url) = ProxyNarInfoData::proxy_by_keep_url(
+            &make_upstream_relative(),
+            &make_substituter_meta(),
+        );
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
         assert!(proxy.content().contains("URL: nar/abc.nar.xz?query=abc\n"));
         assert_eq!(
             nar_source_url.value(),
-            "https://cache.example.com/nar/abc.nar.xz?query=abc"
+            &format!("{DEFAULT_URL}/nar/abc.nar.xz?query=abc")
         );
     }
 
     #[test]
     fn keep_preserves_absolute_url() {
-        let (proxy, nar_source_url) =
-            ProxyNarInfoData::proxy_by_keep_url(&make_upstream_absolute(), &make_meta());
+        let (proxy, nar_source_url) = ProxyNarInfoData::proxy_by_keep_url(
+            &make_upstream_absolute(),
+            &make_substituter_meta(),
+        );
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
         assert!(
             proxy
@@ -136,20 +130,24 @@ mod tests {
 
     #[test]
     fn to_self_strips_query_param_given_relative_url() {
-        let (proxy, nar_source_url) =
-            ProxyNarInfoData::proxy_by_rewrite_url_to_self(&make_upstream_relative(), &make_meta());
+        let (proxy, nar_source_url) = ProxyNarInfoData::proxy_by_rewrite_url_to_self(
+            &make_upstream_relative(),
+            &make_substituter_meta(),
+        );
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
         assert!(proxy.content().contains("URL: nar/abc.nar.xz\n"));
         assert_eq!(
             nar_source_url.value(),
-            "https://cache.example.com/nar/abc.nar.xz?query=abc"
+            &format!("{DEFAULT_URL}/nar/abc.nar.xz?query=abc")
         );
     }
 
     #[test]
     fn to_self_rewrites_absolute_url_to_relative() {
-        let (proxy, nar_source_url) =
-            ProxyNarInfoData::proxy_by_rewrite_url_to_self(&make_upstream_absolute(), &make_meta());
+        let (proxy, nar_source_url) = ProxyNarInfoData::proxy_by_rewrite_url_to_self(
+            &make_upstream_absolute(),
+            &make_substituter_meta(),
+        );
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
         assert!(proxy.content().contains("URL: nar/abc.nar.xz\n"));
         assert!(!proxy.content().contains("https://other.com"));
@@ -163,25 +161,19 @@ mod tests {
     fn to_upstream_rewrites_relative_url_to_absolute() {
         let (proxy, nar_source_url) = ProxyNarInfoData::proxy_by_rewrite_url_to_upstream(
             &make_upstream_relative(),
-            &make_meta(),
+            &make_substituter_meta(),
         );
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
-        assert!(
-            proxy
-                .content()
-                .contains("URL: https://cache.example.com/nar/abc.nar.xz?query=abc\n")
-        );
-        assert_eq!(
-            nar_source_url.value(),
-            "https://cache.example.com/nar/abc.nar.xz?query=abc"
-        );
+        let expected_url = format!("{DEFAULT_URL}/nar/abc.nar.xz?query=abc");
+        assert!(proxy.content().contains(&format!("URL: {expected_url}\n")));
+        assert_eq!(nar_source_url.value(), &expected_url);
     }
 
     #[test]
     fn to_upstream_preserves_absolute_url() {
         let (proxy, nar_source_url) = ProxyNarInfoData::proxy_by_rewrite_url_to_upstream(
             &make_upstream_absolute(),
-            &make_meta(),
+            &make_substituter_meta(),
         );
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
         assert!(

--- a/src/domain/nar_info/model/store_path_hash.rs
+++ b/src/domain/nar_info/model/store_path_hash.rs
@@ -47,14 +47,20 @@ impl From<TryNewStorePathHashError> for AppError {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::substituter::model::Priority;
+    use crate::domain::common::url::Url;
+    use crate::domain::nar_info::model::test_support::{
+        STORE_PATH_HASH_RUBY, make_store_path_hash,
+    };
+    use crate::domain::substituter::model::test_support::{
+        DEFAULT_URL, make_substituter_meta, make_substituter_meta_with_url,
+    };
 
     use super::*;
 
     #[test]
     fn new_succeeds() {
-        let hash = StorePathHash::new("p4pclmv1gyja5kzc26npqpia1qqxrf0l".to_string()).unwrap();
-        assert_eq!(hash.value(), "p4pclmv1gyja5kzc26npqpia1qqxrf0l");
+        let hash = make_store_path_hash();
+        assert_eq!(hash.value(), STORE_PATH_HASH_RUBY);
     }
 
     #[test]
@@ -87,27 +93,25 @@ mod tests {
 
     #[test]
     fn build_nar_info_url_succeeds() {
-        let hash = StorePathHash::new("p4pclmv1gyja5kzc26npqpia1qqxrf0l".into()).unwrap();
-        let meta = SubstituterMeta::new(
-            Url::new("https://cache.nixos.org").unwrap(),
-            Priority::new(40).unwrap(),
-        );
+        let hash = make_store_path_hash();
+        let substituter = make_substituter_meta();
         assert_eq!(
-            hash.on_substituter(&meta).value(),
-            "https://cache.nixos.org/p4pclmv1gyja5kzc26npqpia1qqxrf0l.narinfo",
+            hash.on_substituter(&substituter).value(),
+            &format!("{DEFAULT_URL}/{STORE_PATH_HASH_RUBY}.narinfo"),
         );
     }
 
     #[test]
     fn build_nar_info_url_succeeds_given_base_path() {
-        let hash = StorePathHash::new("p4pclmv1gyja5kzc26npqpia1qqxrf0l".into()).unwrap();
-        let meta = SubstituterMeta::new(
-            Url::new("https://mirrors.ustc.edu.cn/nix-channels/store").unwrap(),
-            Priority::new(40).unwrap(),
+        let hash = make_store_path_hash();
+        let substituter = make_substituter_meta_with_url(
+            &Url::new("https://mirrors.ustc.edu.cn/nix-channels/store").unwrap(),
         );
         assert_eq!(
-            hash.on_substituter(&meta).value(),
-            "https://mirrors.ustc.edu.cn/nix-channels/store/p4pclmv1gyja5kzc26npqpia1qqxrf0l.narinfo",
+            hash.on_substituter(&substituter).value(),
+            &format!(
+                "https://mirrors.ustc.edu.cn/nix-channels/store/{STORE_PATH_HASH_RUBY}.narinfo"
+            ),
         );
     }
 }

--- a/src/domain/nar_info/model/upstream_nar_info_data.rs
+++ b/src/domain/nar_info/model/upstream_nar_info_data.rs
@@ -81,16 +81,11 @@ impl From<TryUpstreamNewNarInfoData> for AppError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::domain::nar_info::model::test_support::make_upstream_nar_info_data_with_url;
 
     #[test]
     fn source_url_is_some_given_absolute_url() {
-        let data = UpstreamNarInfoData::new(
-            "StorePath: /nix/store/abc-hello\n\
-             URL: https://other.com/custom/abc.nar.xz\n"
-                .into(),
-        )
-        .unwrap();
+        let data = make_upstream_nar_info_data_with_url("https://other.com/custom/abc.nar.xz");
         assert!(data.nar_source_url().is_some());
         assert_eq!(
             data.nar_source_url().as_ref().unwrap().value(),
@@ -100,23 +95,13 @@ mod tests {
 
     #[test]
     fn source_url_is_none_given_relative_path() {
-        let data = UpstreamNarInfoData::new(
-            "StorePath: /nix/store/abc-hello\n\
-             URL: nar/abc.nar.xz\n"
-                .into(),
-        )
-        .unwrap();
+        let data = make_upstream_nar_info_data_with_url("nar/abc.nar.xz");
         assert!(data.nar_source_url().is_none());
     }
 
     #[test]
     fn nar_file_splits_query_params() {
-        let data = UpstreamNarInfoData::new(
-            "StorePath: /nix/store/abc-hello\n\
-             URL: nar/abc.nar.xz?X-Amz-Signature=abc123\n"
-                .into(),
-        )
-        .unwrap();
+        let data = make_upstream_nar_info_data_with_url("nar/abc.nar.xz?X-Amz-Signature=abc123");
         assert_eq!(data.nar_file().value(), "abc.nar.xz");
         assert!(data.nar_source_url().is_none());
         assert_eq!(data.query_params(), Some("X-Amz-Signature=abc123"));
@@ -124,11 +109,9 @@ mod tests {
 
     #[test]
     fn source_url_preserves_query_params_given_absolute_url() {
-        let data = UpstreamNarInfoData::new(
-            "StorePath: /nix/store/abc-hello\n\
-             URL: https://storage.com/nar/abc.nar.xz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=f776\n".into(),
-        )
-        .unwrap();
+        let data = make_upstream_nar_info_data_with_url(
+            "https://storage.com/nar/abc.nar.xz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=f776",
+        );
         let source_url = data.nar_source_url().unwrap();
         assert!(
             source_url

--- a/src/domain/substituter/model/mod.rs
+++ b/src/domain/substituter/model/mod.rs
@@ -7,3 +7,46 @@ pub use availability::Availability;
 pub use priority::{Priority, TryNewPriorityError};
 pub use substituter::{PeriodicProbingOption, ProbedState, Substituter, UpdateSubstituterEvent};
 pub use substituter_meta::SubstituterMeta;
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    use tokio::time::Instant;
+
+    use crate::domain::common::url::Url;
+
+    use super::{Availability, Priority, Substituter, SubstituterMeta};
+
+    pub const DEFAULT_PRIORITY: u32 = 40;
+    pub const DEFAULT_URL: &str = "https://cache.nixos.org";
+
+    pub fn make_substituter_meta() -> SubstituterMeta {
+        SubstituterMeta::new(
+            Url::new(DEFAULT_URL).unwrap(),
+            Priority::new(DEFAULT_PRIORITY).unwrap(),
+        )
+    }
+
+    pub fn make_substituter_meta_with_url(url: &Url) -> SubstituterMeta {
+        SubstituterMeta::new(url.clone(), Priority::new(DEFAULT_PRIORITY).unwrap())
+    }
+
+    pub fn make_substituter_normal_with_url(url: &Url) -> Substituter {
+        Substituter::new(make_substituter_meta_with_url(url), Availability::Normal)
+    }
+
+    pub fn make_substituter_offline_with_url(url: &Url) -> Substituter {
+        Substituter::new(
+            make_substituter_meta_with_url(url),
+            Availability::Offline {
+                detected_at: Instant::now(),
+            },
+        )
+    }
+
+    pub fn make_substituter_maybe_ready_with_url(url: &Url) -> Substituter {
+        Substituter::new(
+            make_substituter_meta_with_url(url),
+            Availability::MaybeReady { prev_failures: 0 },
+        )
+    }
+}

--- a/src/domain/substituter/model/mod.rs
+++ b/src/domain/substituter/model/mod.rs
@@ -20,23 +20,35 @@ pub mod test_support {
     pub const DEFAULT_URL: &str = "https://cache.nixos.org";
 
     pub fn make_substituter_meta() -> SubstituterMeta {
-        SubstituterMeta::new(
-            Url::new(DEFAULT_URL).unwrap(),
-            Priority::new(DEFAULT_PRIORITY).unwrap(),
-        )
+        make_substituter_meta_with_url_pri(&Url::new(DEFAULT_URL).unwrap(), DEFAULT_PRIORITY)
     }
 
     pub fn make_substituter_meta_with_url(url: &Url) -> SubstituterMeta {
-        SubstituterMeta::new(url.clone(), Priority::new(DEFAULT_PRIORITY).unwrap())
+        make_substituter_meta_with_url_pri(url, DEFAULT_PRIORITY)
+    }
+
+    pub fn make_substituter_meta_with_url_pri(url: &Url, priority: u32) -> SubstituterMeta {
+        SubstituterMeta::new(url.clone(), Priority::new(priority).unwrap())
     }
 
     pub fn make_substituter_normal_with_url(url: &Url) -> Substituter {
-        Substituter::new(make_substituter_meta_with_url(url), Availability::Normal)
+        make_substituter_normal_with_url_pri(url, DEFAULT_PRIORITY)
+    }
+
+    pub fn make_substituter_normal_with_url_pri(url: &Url, priority: u32) -> Substituter {
+        Substituter::new(
+            make_substituter_meta_with_url_pri(url, priority),
+            Availability::Normal,
+        )
     }
 
     pub fn make_substituter_offline_with_url(url: &Url) -> Substituter {
+        make_substituter_offline_with_url_pri(url, DEFAULT_PRIORITY)
+    }
+
+    pub fn make_substituter_offline_with_url_pri(url: &Url, priority: u32) -> Substituter {
         Substituter::new(
-            make_substituter_meta_with_url(url),
+            make_substituter_meta_with_url_pri(url, priority),
             Availability::Offline {
                 detected_at: Instant::now(),
             },
@@ -44,8 +56,12 @@ pub mod test_support {
     }
 
     pub fn make_substituter_maybe_ready_with_url(url: &Url) -> Substituter {
+        make_substituter_maybe_ready_with_url_pri(url, DEFAULT_PRIORITY)
+    }
+
+    pub fn make_substituter_maybe_ready_with_url_pri(url: &Url, priority: u32) -> Substituter {
         Substituter::new(
-            make_substituter_meta_with_url(url),
+            make_substituter_meta_with_url_pri(url, priority),
             Availability::MaybeReady { prev_failures: 0 },
         )
     }

--- a/src/domain/substituter/model/substituter.rs
+++ b/src/domain/substituter/model/substituter.rs
@@ -154,15 +154,12 @@ mod tests {
     use std::collections::HashSet;
     use std::time::Duration;
 
-    use crate::domain::substituter::model::{Availability, Priority, SubstituterMeta};
+    use crate::domain::substituter::model::test_support::make_substituter_meta;
 
     use super::*;
 
     fn make_substituter(availability: Availability) -> Substituter {
-        let url = Url::new("https://cache.nixos.org").unwrap();
-        let priority = Priority::new(40).unwrap();
-        let meta = SubstituterMeta::new(url, priority);
-        Substituter::new(meta, availability)
+        Substituter::new(make_substituter_meta(), availability)
     }
 
     fn assert_events_eq(

--- a/src/domain/substituter/model/substituter_meta.rs
+++ b/src/domain/substituter/model/substituter_meta.rs
@@ -111,21 +111,20 @@ impl<'de> Deserialize<'de> for SubstituterMeta {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    fn make_meta(url: &str) -> SubstituterMeta {
-        SubstituterMeta::new(Url::new(url).unwrap(), Priority::new(40).unwrap())
-    }
+    use crate::domain::common::url::Url;
+    use crate::domain::substituter::model::test_support::{
+        make_substituter_meta, make_substituter_meta_with_url,
+    };
 
     #[test]
     fn default_storage_url_is_not_custom() {
-        let meta = make_meta("https://cache.nixos.org");
+        let meta = make_substituter_meta();
         assert!(!meta.has_custom_storage_url());
     }
 
     #[test]
     fn storage_url_equal_to_default_is_not_custom() {
-        let meta = make_meta("https://example.com");
+        let meta = make_substituter_meta_with_url(&Url::new("https://example.com").unwrap());
         let default_storage = meta.url().as_dir().join("nar").unwrap();
         let meta = meta.with_storage_url(default_storage);
         assert!(!meta.has_custom_storage_url());
@@ -133,7 +132,7 @@ mod tests {
 
     #[test]
     fn storage_url_differing_from_default_is_custom() {
-        let meta = make_meta("https://example.com");
+        let meta = make_substituter_meta_with_url(&Url::new("https://example.com").unwrap());
         let meta = meta.with_storage_url(Url::new("https://cdn.example.com/nar").unwrap());
         assert!(meta.has_custom_storage_url());
     }

--- a/src/infrastructure/repository/substituter.rs
+++ b/src/infrastructure/repository/substituter.rs
@@ -82,28 +82,24 @@ impl SubstituterRepository for InMemorySubstituterRepository {
 
 #[cfg(test)]
 mod tests {
-    use tokio::time::Instant;
-
+    use crate::domain::common::url::Url;
     use crate::domain::substituter::SubstituterRepository;
-    use crate::domain::substituter::model::{Availability, Priority, Substituter, SubstituterMeta};
+    use crate::domain::substituter::model::test_support::{
+        make_substituter_maybe_ready_with_url, make_substituter_normal_with_url,
+        make_substituter_offline_with_url,
+    };
 
     use super::*;
-
-    fn make_sub(url: &str, availability: Availability) -> Substituter {
-        let meta = SubstituterMeta::new(Url::new(url).unwrap(), Priority::new(40).unwrap());
-        Substituter::new(meta, availability)
-    }
 
     #[tokio::test]
     async fn query_all_returns_saved_substituters() {
         let repo = InMemorySubstituterRepository::new();
-        repo.save(make_sub("https://a.example.com", Availability::Normal))
-            .await;
-        repo.save(make_sub(
-            "https://b.example.com",
-            Availability::Offline {
-                detected_at: Instant::now(),
-            },
+        repo.save(make_substituter_normal_with_url(
+            &Url::new("https://a.example.com").unwrap(),
+        ))
+        .await;
+        repo.save(make_substituter_offline_with_url(
+            &Url::new("https://b.example.com").unwrap(),
         ))
         .await;
 
@@ -121,8 +117,10 @@ mod tests {
     #[tokio::test]
     async fn exists_available_returns_true() {
         let repo = InMemorySubstituterRepository::new();
-        repo.save(make_sub("https://a.example.com", Availability::Normal))
-            .await;
+        repo.save(make_substituter_normal_with_url(
+            &Url::new("https://a.example.com").unwrap(),
+        ))
+        .await;
 
         let res = repo
             .exists_available(&Url::new("https://a.example.com").unwrap())
@@ -133,11 +131,8 @@ mod tests {
     #[tokio::test]
     async fn exists_available_returns_false_if_unavailable() {
         let repo = InMemorySubstituterRepository::new();
-        repo.save(make_sub(
-            "https://a.example.com",
-            Availability::Offline {
-                detected_at: Instant::now(),
-            },
+        repo.save(make_substituter_offline_with_url(
+            &Url::new("https://a.example.com").unwrap(),
         ))
         .await;
 
@@ -160,8 +155,10 @@ mod tests {
     #[tokio::test]
     async fn save_available_inserts_into_snapshot() {
         let repo = InMemorySubstituterRepository::new();
-        repo.save(make_sub("https://a.example.com", Availability::Normal))
-            .await;
+        repo.save(make_substituter_normal_with_url(
+            &Url::new("https://a.example.com").unwrap(),
+        ))
+        .await;
 
         let avail = repo.query_all_available().await;
         assert_eq!(avail.len(), 1);
@@ -173,15 +170,8 @@ mod tests {
     async fn save_unavailable_removes_from_snapshot() {
         let repo = InMemorySubstituterRepository::new();
         let url = Url::new("https://a.example.com").unwrap();
-        repo.save(make_sub("https://a.example.com", Availability::Normal))
-            .await;
-        repo.save(make_sub(
-            "https://a.example.com",
-            Availability::Offline {
-                detected_at: Instant::now(),
-            },
-        ))
-        .await;
+        repo.save(make_substituter_normal_with_url(&url)).await;
+        repo.save(make_substituter_offline_with_url(&url)).await;
 
         let avail = repo.query_all_available().await;
         assert!(avail.is_empty());
@@ -191,13 +181,9 @@ mod tests {
     #[tokio::test]
     async fn save_available_updates_is_maybe_ready() {
         let repo = InMemorySubstituterRepository::new();
-        repo.save(make_sub(
-            "https://a.example.com",
-            Availability::MaybeReady { prev_failures: 0 },
-        ))
-        .await;
-        repo.save(make_sub("https://a.example.com", Availability::Normal))
-            .await;
+        let url = Url::new("https://a.example.com").unwrap();
+        repo.save(make_substituter_maybe_ready_with_url(&url)).await;
+        repo.save(make_substituter_normal_with_url(&url)).await;
 
         let avail = repo.query_all_available().await;
         assert_eq!(avail.len(), 1);
@@ -207,11 +193,12 @@ mod tests {
     #[tokio::test]
     async fn save_multiple_available() {
         let repo = InMemorySubstituterRepository::new();
-        repo.save(make_sub("https://a.example.com", Availability::Normal))
-            .await;
-        repo.save(make_sub(
-            "https://b.example.com",
-            Availability::MaybeReady { prev_failures: 1 },
+        repo.save(make_substituter_normal_with_url(
+            &Url::new("https://a.example.com").unwrap(),
+        ))
+        .await;
+        repo.save(make_substituter_maybe_ready_with_url(
+            &Url::new("https://b.example.com").unwrap(),
         ))
         .await;
 

--- a/tests/integration/config_test.rs
+++ b/tests/integration/config_test.rs
@@ -5,7 +5,7 @@ use selector4nix::domain::nar_info::model::NarUrlRewriteOption;
 use selector4nix::domain::substituter::model::PeriodicProbingOption;
 use selector4nix::infrastructure::config::AppConfiguration;
 
-use super::fixture;
+use super::fixture::config::{make_config_string_minimal, make_config_string_overriden};
 
 #[test]
 fn example_config_file_is_valid() {
@@ -15,8 +15,7 @@ fn example_config_file_is_valid() {
 
 #[test]
 fn defaults_are_applied_when_sections_omitted() {
-    let config =
-        AppConfiguration::deserialize(&fixture::config::make_config_string_minimal()).unwrap();
+    let config = AppConfiguration::deserialize(&make_config_string_minimal()).unwrap();
 
     assert_eq!(config.server.port, 5496);
     assert_eq!(config.network.nar_info_timeout, Duration::from_secs(30));
@@ -53,7 +52,7 @@ fn defaults_are_applied_when_sections_omitted() {
 
 #[test]
 fn zero_timeout_is_clamped_to_one() {
-    let config = AppConfiguration::deserialize(&fixture::config::make_config_string_overriden(
+    let config = AppConfiguration::deserialize(&make_config_string_overriden(
         r#"
 [network]
 nar_info_timeout_secs = 0
@@ -68,7 +67,7 @@ nar_timeout_secs = 0
 
 #[test]
 fn zero_tolerance_is_clamped_to_one() {
-    let config = AppConfiguration::deserialize(&fixture::config::make_config_string_overriden(
+    let config = AppConfiguration::deserialize(&make_config_string_overriden(
         r#"
 [network]
 tolerance_msecs = 0
@@ -81,7 +80,7 @@ tolerance_msecs = 0
 
 #[test]
 fn invalid_rewrite_to_target_is_rejected() {
-    let result = AppConfiguration::deserialize(&fixture::config::make_config_string_overriden(
+    let result = AppConfiguration::deserialize(&make_config_string_overriden(
         r#"
 [proxy]
 rewrite_to_target = "invalid"
@@ -93,7 +92,7 @@ rewrite_to_target = "invalid"
 
 #[test]
 fn non_absolute_store_dir_is_rejected() {
-    let result = AppConfiguration::deserialize(&fixture::config::make_config_string_overriden(
+    let result = AppConfiguration::deserialize(&make_config_string_overriden(
         r#"
 [cache_info]
 store_dir = "relative/path"
@@ -105,7 +104,7 @@ store_dir = "relative/path"
 
 #[test]
 fn zero_priority_is_rejected() {
-    let result = AppConfiguration::deserialize(&fixture::config::make_config_string_overriden(
+    let result = AppConfiguration::deserialize(&make_config_string_overriden(
         r#"
 [[substituters]]
 url = "https://cache.nixos.org/"

--- a/tests/integration/fixture/nar_file.rs
+++ b/tests/integration/fixture/nar_file.rs
@@ -3,23 +3,21 @@ use std::time::{Duration, SystemTime};
 use selector4nix::domain::common::expire_at::ExpireAt;
 use selector4nix::domain::common::url::Url;
 use selector4nix::domain::nar_file::model::{NarFile, NarFileKey, NarFileLocation};
+use selector4nix::domain::nar_info::model::test_support::make_nar_file_name;
 use selector4nix::domain::substituter::model::SubstituterMeta;
-
-use super::{nar_info, substituter};
-
-pub const NAR_FILE: &str = "1w1fff338fvdw53sqgamddn1b2xgds473pv6y13gizdbqjv4i5p3.nar.xz";
+use selector4nix::domain::substituter::model::test_support::make_substituter_meta_with_url_pri;
 
 pub fn make_source_url_with_substituter_meta(meta: &SubstituterMeta) -> Url {
-    nar_info::make_nar_file_name().with_storage_prefix(meta.storage_url())
+    make_nar_file_name().with_storage_prefix(meta.storage_url())
 }
 
 pub fn make_source_url(substituter_url: &Url, priority: u32) -> Url {
-    let meta = substituter::make_substituter_meta(substituter_url, priority);
+    let meta = make_substituter_meta_with_url_pri(substituter_url, priority);
     make_source_url_with_substituter_meta(&meta)
 }
 
 pub fn make_nar_file_key() -> NarFileKey {
-    NarFileKey::from_file_name(&nar_info::make_nar_file_name())
+    NarFileKey::from_file_name(&make_nar_file_name())
 }
 
 pub fn make_nar_file_location_with_substituter_meta(meta: &SubstituterMeta) -> NarFileLocation {
@@ -31,11 +29,8 @@ pub fn make_nar_file_location_with_substituter_meta(meta: &SubstituterMeta) -> N
 }
 
 pub fn make_nar_file_location(substituter_url: &Url, priority: u32) -> NarFileLocation {
-    NarFileLocation::new(
-        make_source_url(substituter_url, priority),
-        substituter::make_substituter_meta(substituter_url, 1),
-        None,
-    )
+    let meta = make_substituter_meta_with_url_pri(substituter_url, priority);
+    make_nar_file_location_with_substituter_meta(&meta)
 }
 
 pub fn make_nar_file_with_location(location: NarFileLocation) -> NarFile {

--- a/tests/integration/fixture/nar_info.rs
+++ b/tests/integration/fixture/nar_info.rs
@@ -1,33 +1,19 @@
 use std::time::Duration;
 
 use selector4nix::domain::common::url::Url;
-use selector4nix::domain::nar_info::model::{NarFileName, StorePathHash, UpstreamNarInfoData};
+use selector4nix::domain::nar_info::model::test_support::{
+    NAR_FILE_RUBY_XZ, make_upstream_nar_info_data_with_url,
+};
+use selector4nix::domain::nar_info::model::{StorePathHash, UpstreamNarInfoData};
 use selector4nix::domain::nar_info::port::NarInfoQueryData;
-
-use super::substituter;
-
-const STORE_PATH_HASH: &str = "p4pclmv1gyja5kzc26npqpia1qqxrf0l";
-const NAR_FILE: &str = super::nar_file::NAR_FILE;
-
-pub fn make_store_path_hash() -> StorePathHash {
-    StorePathHash::new(STORE_PATH_HASH.to_string()).unwrap()
-}
-
-pub fn make_nar_file_name() -> NarFileName {
-    NarFileName::new(NAR_FILE.to_string()).unwrap()
-}
+use selector4nix::domain::substituter::model::test_support::make_substituter_meta_with_url;
 
 pub fn make_upstream_nar_info_data() -> UpstreamNarInfoData {
-    UpstreamNarInfoData::new(format!(
-        "StorePath: /nix/store/{STORE_PATH_HASH}-ruby-2.7.3\n\
-         URL: nar/{NAR_FILE}\n\
-         Compression: xz\n"
-    ))
-    .unwrap()
+    make_upstream_nar_info_data_with_url(&format!("nar/{NAR_FILE_RUBY_XZ}"))
 }
 
 pub fn make_nar_info_url(substituter_url: &Url, hash: &StorePathHash) -> Url {
-    let meta = substituter::make_substituter_meta(substituter_url, 1);
+    let meta = make_substituter_meta_with_url(substituter_url);
     hash.on_substituter(&meta)
 }
 

--- a/tests/integration/fixture/substituter.rs
+++ b/tests/integration/fixture/substituter.rs
@@ -1,34 +1,15 @@
 use std::time::Duration;
 
 use selector4nix::domain::common::url::Url;
-use selector4nix::domain::substituter::model::{
-    Availability, Priority, Substituter, SubstituterMeta,
-};
-use tokio::time::Instant;
-
-pub fn make_substituter_meta(url: &Url, priority: u32) -> SubstituterMeta {
-    SubstituterMeta::new(url.clone(), Priority::new(priority).unwrap())
-}
+use selector4nix::domain::substituter::model::test_support::make_substituter_meta_with_url_pri;
+use selector4nix::domain::substituter::model::{Availability, Substituter, SubstituterMeta};
 
 pub fn make_substituter_meta_with_storage_url(
     url: &Url,
     storage_url: Url,
     priority: u32,
 ) -> SubstituterMeta {
-    make_substituter_meta(url, priority).with_storage_url(storage_url)
-}
-
-pub fn make_substituter_normal(url: &Url, priority: u32) -> Substituter {
-    Substituter::new(make_substituter_meta(url, priority), Availability::Normal)
-}
-
-pub fn make_substituter_offline(url: &Url, priority: u32) -> Substituter {
-    Substituter::new(
-        make_substituter_meta(url, priority),
-        Availability::Offline {
-            detected_at: Instant::now(),
-        },
-    )
+    make_substituter_meta_with_url_pri(url, priority).with_storage_url(storage_url)
 }
 
 pub fn make_substituter_normal_with_nar_info_timeout(
@@ -37,14 +18,7 @@ pub fn make_substituter_normal_with_nar_info_timeout(
     timeout: Duration,
 ) -> Substituter {
     Substituter::new(
-        make_substituter_meta(url, priority).with_nar_info_timeout(timeout),
+        make_substituter_meta_with_url_pri(url, priority).with_nar_info_timeout(timeout),
         Availability::Normal,
-    )
-}
-
-pub fn make_substituter_maybe_ready(url: &Url, priority: u32) -> Substituter {
-    Substituter::new(
-        make_substituter_meta(url, priority),
-        Availability::MaybeReady { prev_failures: 0 },
     )
 }

--- a/tests/integration/nar_file_service_test.rs
+++ b/tests/integration/nar_file_service_test.rs
@@ -8,9 +8,16 @@ use selector4nix::domain::nar_file::NarFileService;
 use selector4nix::domain::nar_file::model::NarFile;
 use selector4nix::domain::substituter::SubstituterRepository;
 use selector4nix::domain::substituter::model::Substituter;
+use selector4nix::domain::substituter::model::test_support::{
+    make_substituter_normal_with_url_pri, make_substituter_offline_with_url_pri,
+};
 use selector4nix::infrastructure::repository::InMemorySubstituterRepository;
 
-use crate::fixture::{nar_file, substituter};
+use crate::fixture::nar_file::{
+    make_nar_file_location, make_nar_file_location_with_substituter_meta,
+    make_nar_file_with_location, make_source_url, make_source_url_with_substituter_meta,
+};
+use crate::fixture::substituter::make_substituter_meta_with_storage_url;
 use crate::mock::nar_stream_provider::MockNarStreamProvider;
 
 #[derive(Debug)]
@@ -73,17 +80,16 @@ async fn run_test(
 async fn cached_substituter_unavailable_falls_back_early() {
     let a_url = Url::new("https://cache-a.example.com").unwrap();
     let b_url = Url::new("https://cache-b.example.com").unwrap();
-    let a_src = nar_file::make_source_url(&a_url, 40);
-    let b_src = nar_file::make_source_url(&b_url, 10);
+    let a_src = make_source_url(&a_url, 40);
+    let b_src = make_source_url(&b_url, 10);
 
-    let nar_file =
-        nar_file::make_nar_file_with_location(nar_file::make_nar_file_location(&a_url, 40));
+    let nar_file = make_nar_file_with_location(make_nar_file_location(&a_url, 40));
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![
-                substituter::make_substituter_offline(&a_url, 40),
-                substituter::make_substituter_normal(&b_url, 10),
+                make_substituter_offline_with_url_pri(&a_url, 40),
+                make_substituter_normal_with_url_pri(&b_url, 10),
             ],
             success_urls: HashSet::from([b_src.clone()]),
         },
@@ -100,14 +106,13 @@ async fn cached_substituter_unavailable_falls_back_early() {
 #[tokio::test]
 async fn cached_substituter_available_serves_from_cache() {
     let a_url = Url::new("https://cache-a.example.com").unwrap();
-    let a_src = nar_file::make_source_url(&a_url, 40);
+    let a_src = make_source_url(&a_url, 40);
 
-    let nar_file =
-        nar_file::make_nar_file_with_location(nar_file::make_nar_file_location(&a_url, 40));
+    let nar_file = make_nar_file_with_location(make_nar_file_location(&a_url, 40));
 
     run_test(
         TestCaseEnvironment {
-            substituters: vec![substituter::make_substituter_normal(&a_url, 40)],
+            substituters: vec![make_substituter_normal_with_url_pri(&a_url, 40)],
             success_urls: HashSet::from([a_src.clone()]),
         },
         TestCaseInput { nar_file },
@@ -124,16 +129,14 @@ async fn cached_substituter_available_serves_from_cache() {
 async fn offline_substituter_with_separate_storage_still_served_from_cache() {
     let a_url = Url::new("https://cache-a.example.com").unwrap();
     let a_storage = Url::new("https://storage-a.example.com/nar").unwrap();
-    let meta = substituter::make_substituter_meta_with_storage_url(&a_url, a_storage, 40);
-    let a_src = nar_file::make_source_url_with_substituter_meta(&meta);
+    let meta = make_substituter_meta_with_storage_url(&a_url, a_storage, 40);
+    let a_src = make_source_url_with_substituter_meta(&meta);
 
-    let nar_file = nar_file::make_nar_file_with_location(
-        nar_file::make_nar_file_location_with_substituter_meta(&meta),
-    );
+    let nar_file = make_nar_file_with_location(make_nar_file_location_with_substituter_meta(&meta));
 
     run_test(
         TestCaseEnvironment {
-            substituters: vec![substituter::make_substituter_offline(&a_url, 40)],
+            substituters: vec![make_substituter_offline_with_url_pri(&a_url, 40)],
             success_urls: HashSet::from([a_src.clone()]),
         },
         TestCaseInput { nar_file },
@@ -150,16 +153,15 @@ async fn offline_substituter_with_separate_storage_still_served_from_cache() {
 async fn cached_attempt_fails_falls_back() {
     let a_url = Url::new("https://cache-a.example.com").unwrap();
     let b_url = Url::new("https://cache-b.example.com").unwrap();
-    let b_src = nar_file::make_source_url(&b_url, 10);
+    let b_src = make_source_url(&b_url, 10);
 
-    let nar_file =
-        nar_file::make_nar_file_with_location(nar_file::make_nar_file_location(&a_url, 40));
+    let nar_file = make_nar_file_with_location(make_nar_file_location(&a_url, 40));
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![
-                substituter::make_substituter_normal(&a_url, 40),
-                substituter::make_substituter_normal(&b_url, 10),
+                make_substituter_normal_with_url_pri(&a_url, 40),
+                make_substituter_normal_with_url_pri(&b_url, 10),
             ],
             success_urls: HashSet::from([b_src.clone()]),
         },

--- a/tests/integration/nar_info_service_test.rs
+++ b/tests/integration/nar_info_service_test.rs
@@ -4,14 +4,23 @@ use std::time::Duration;
 
 use selector4nix::domain::common::passthrough_headers::PassthroughHeaders;
 use selector4nix::domain::common::url::Url;
+use selector4nix::domain::nar_info::model::test_support::{
+    make_nar_file_name, make_store_path_hash,
+};
 use selector4nix::domain::nar_info::model::{NarUrlRewriteOption, StorePathHash};
 use selector4nix::domain::nar_info::port::NarInfoQueryData;
 use selector4nix::domain::nar_info::{NarInfoService, ResolveNarInfoEvent};
 use selector4nix::domain::substituter::SubstituterRepository;
 use selector4nix::domain::substituter::model::Substituter;
+use selector4nix::domain::substituter::model::test_support::{
+    make_substituter_maybe_ready_with_url_pri, make_substituter_meta_with_url_pri,
+    make_substituter_normal_with_url_pri,
+};
 use selector4nix::infrastructure::repository::InMemorySubstituterRepository;
 
-use crate::fixture::{nar_file, nar_info, substituter};
+use crate::fixture::nar_file::make_source_url;
+use crate::fixture::nar_info::{make_nar_info_query_data, make_nar_info_url};
+use crate::fixture::substituter::make_substituter_normal_with_nar_info_timeout;
 use crate::mock::nar_info_provider::MockNarInfoProvider;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -79,27 +88,27 @@ async fn run_test(
 #[tokio::test(start_paused = true)]
 async fn single_normal_substituter_resolves() {
     let sub_url = Url::new("https://cache.nixos.org").unwrap();
-    let sub = substituter::make_substituter_normal(&sub_url, 40);
-    let hash = nar_info::make_store_path_hash();
-    let nar_info_url = nar_info::make_nar_info_url(&sub_url, &hash);
+    let sub = make_substituter_normal_with_url_pri(&sub_url, 40);
+    let hash = make_store_path_hash();
+    let nar_info_url = make_nar_info_url(&sub_url, &hash);
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![sub],
             nar_info_entries: vec![(
                 nar_info_url,
-                Ok(nar_info::make_nar_info_query_data(Duration::from_millis(0))),
+                Ok(make_nar_info_query_data(Duration::from_millis(0))),
             )],
             tolerance: 50,
             ignore_query_error: false,
         },
         TestCaseInput { hash: hash.clone() },
         TestCaseExpectation {
-            source_url: Ok(Some(nar_file::make_source_url(&sub_url, 40))),
+            source_url: Ok(Some(make_source_url(&sub_url, 40))),
             events: vec![ResolveNarInfoEvent::NarFileLocated {
-                nar_file: nar_info::make_nar_file_name(),
-                substituter: substituter::make_substituter_meta(&sub_url, 40),
-                source_url: nar_file::make_source_url(&sub_url, 40),
+                nar_file: make_nar_file_name(),
+                substituter: make_substituter_meta_with_url_pri(&sub_url, 40),
+                source_url: make_source_url(&sub_url, 40),
             }],
         },
     )
@@ -110,20 +119,20 @@ async fn single_normal_substituter_resolves() {
 async fn all_substituters_fail() {
     let sub_a_url = Url::new("https://cache-a.example.com").unwrap();
     let sub_b_url = Url::new("https://cache-b.example.com").unwrap();
-    let sub_a = substituter::make_substituter_normal(&sub_a_url, 40);
-    let sub_b = substituter::make_substituter_normal(&sub_b_url, 10);
-    let hash = nar_info::make_store_path_hash();
+    let sub_a = make_substituter_normal_with_url_pri(&sub_a_url, 40);
+    let sub_b = make_substituter_normal_with_url_pri(&sub_b_url, 10);
+    let hash = make_store_path_hash();
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![sub_a, sub_b],
             nar_info_entries: vec![
                 (
-                    nar_info::make_nar_info_url(&sub_a_url, &hash),
+                    make_nar_info_url(&sub_a_url, &hash),
                     Err("stub error".into()),
                 ),
                 (
-                    nar_info::make_nar_info_url(&sub_b_url, &hash),
+                    make_nar_info_url(&sub_b_url, &hash),
                     Err("stub error".into()),
                 ),
             ],
@@ -145,28 +154,28 @@ async fn all_substituters_fail() {
 #[tokio::test(start_paused = true)]
 async fn non_normal_substituter_emits_succeeded_event() {
     let sub_url = Url::new("https://cache-a.example.com").unwrap();
-    let sub = substituter::make_substituter_maybe_ready(&sub_url, 40);
-    let hash = nar_info::make_store_path_hash();
+    let sub = make_substituter_maybe_ready_with_url_pri(&sub_url, 40);
+    let hash = make_store_path_hash();
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![sub],
             nar_info_entries: vec![(
-                nar_info::make_nar_info_url(&sub_url, &hash),
-                Ok(nar_info::make_nar_info_query_data(Duration::from_millis(0))),
+                make_nar_info_url(&sub_url, &hash),
+                Ok(make_nar_info_query_data(Duration::from_millis(0))),
             )],
             tolerance: 50,
             ignore_query_error: false,
         },
         TestCaseInput { hash },
         TestCaseExpectation {
-            source_url: Ok(Some(nar_file::make_source_url(&sub_url, 40))),
+            source_url: Ok(Some(make_source_url(&sub_url, 40))),
             events: vec![
                 ResolveNarInfoEvent::SubstituterSucceeded(sub_url.clone()),
                 ResolveNarInfoEvent::NarFileLocated {
-                    nar_file: nar_info::make_nar_file_name(),
-                    substituter: substituter::make_substituter_meta(&sub_url, 40),
-                    source_url: nar_file::make_source_url(&sub_url, 40),
+                    nar_file: make_nar_file_name(),
+                    substituter: make_substituter_meta_with_url_pri(&sub_url, 40),
+                    source_url: make_source_url(&sub_url, 40),
                 },
             ],
         },
@@ -178,21 +187,21 @@ async fn non_normal_substituter_emits_succeeded_event() {
 async fn lower_priority_value_preferred_at_equal_latency() {
     let sub_a_url = Url::new("https://cache-a.example.com").unwrap();
     let sub_b_url = Url::new("https://cache-b.example.com").unwrap();
-    let sub_a = substituter::make_substituter_normal(&sub_a_url, 40);
-    let sub_b = substituter::make_substituter_normal(&sub_b_url, 10);
-    let hash = nar_info::make_store_path_hash();
+    let sub_a = make_substituter_normal_with_url_pri(&sub_a_url, 40);
+    let sub_b = make_substituter_normal_with_url_pri(&sub_b_url, 10);
+    let hash = make_store_path_hash();
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![sub_a, sub_b],
             nar_info_entries: vec![
                 (
-                    nar_info::make_nar_info_url(&sub_a_url, &hash),
-                    Ok(nar_info::make_nar_info_query_data(Duration::from_millis(0))),
+                    make_nar_info_url(&sub_a_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(0))),
                 ),
                 (
-                    nar_info::make_nar_info_url(&sub_b_url, &hash),
-                    Ok(nar_info::make_nar_info_query_data(Duration::from_millis(0))),
+                    make_nar_info_url(&sub_b_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(0))),
                 ),
             ],
             tolerance: 50,
@@ -200,11 +209,11 @@ async fn lower_priority_value_preferred_at_equal_latency() {
         },
         TestCaseInput { hash },
         TestCaseExpectation {
-            source_url: Ok(Some(nar_file::make_source_url(&sub_b_url, 10))),
+            source_url: Ok(Some(make_source_url(&sub_b_url, 10))),
             events: vec![ResolveNarInfoEvent::NarFileLocated {
-                nar_file: nar_info::make_nar_file_name(),
-                substituter: substituter::make_substituter_meta(&sub_b_url, 10),
-                source_url: nar_file::make_source_url(&sub_b_url, 10),
+                nar_file: make_nar_file_name(),
+                substituter: make_substituter_meta_with_url_pri(&sub_b_url, 10),
+                source_url: make_source_url(&sub_b_url, 10),
             }],
         },
     )
@@ -215,23 +224,21 @@ async fn lower_priority_value_preferred_at_equal_latency() {
 async fn faster_high_priority_value_beats_slow_low() {
     let sub_a_url = Url::new("https://cache-a.example.com").unwrap();
     let sub_b_url = Url::new("https://cache-b.example.com").unwrap();
-    let sub_a = substituter::make_substituter_normal(&sub_a_url, 40);
-    let sub_b = substituter::make_substituter_normal(&sub_b_url, 10);
-    let hash = nar_info::make_store_path_hash();
+    let sub_a = make_substituter_normal_with_url_pri(&sub_a_url, 40);
+    let sub_b = make_substituter_normal_with_url_pri(&sub_b_url, 10);
+    let hash = make_store_path_hash();
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![sub_a, sub_b],
             nar_info_entries: vec![
                 (
-                    nar_info::make_nar_info_url(&sub_a_url, &hash),
-                    Ok(nar_info::make_nar_info_query_data(Duration::from_millis(0))),
+                    make_nar_info_url(&sub_a_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(0))),
                 ),
                 (
-                    nar_info::make_nar_info_url(&sub_b_url, &hash),
-                    Ok(nar_info::make_nar_info_query_data(Duration::from_millis(
-                        1600,
-                    ))),
+                    make_nar_info_url(&sub_b_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(1600))),
                 ),
             ],
             tolerance: 50,
@@ -239,11 +246,11 @@ async fn faster_high_priority_value_beats_slow_low() {
         },
         TestCaseInput { hash },
         TestCaseExpectation {
-            source_url: Ok(Some(nar_file::make_source_url(&sub_a_url, 40))),
+            source_url: Ok(Some(make_source_url(&sub_a_url, 40))),
             events: vec![ResolveNarInfoEvent::NarFileLocated {
-                nar_file: nar_info::make_nar_file_name(),
-                substituter: substituter::make_substituter_meta(&sub_a_url, 40),
-                source_url: nar_file::make_source_url(&sub_a_url, 40),
+                nar_file: make_nar_file_name(),
+                substituter: make_substituter_meta_with_url_pri(&sub_a_url, 40),
+                source_url: make_source_url(&sub_a_url, 40),
             }],
         },
     )
@@ -254,21 +261,21 @@ async fn faster_high_priority_value_beats_slow_low() {
 async fn partial_error_with_success() {
     let error_substituter_url = Url::new("https://cache-a.example.com").unwrap();
     let success_substituter_url = Url::new("https://cache-b.example.com").unwrap();
-    let error_sub = substituter::make_substituter_normal(&error_substituter_url, 40);
-    let success_sub = substituter::make_substituter_normal(&success_substituter_url, 10);
-    let hash = nar_info::make_store_path_hash();
+    let error_sub = make_substituter_normal_with_url_pri(&error_substituter_url, 40);
+    let success_sub = make_substituter_normal_with_url_pri(&success_substituter_url, 10);
+    let hash = make_store_path_hash();
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![error_sub, success_sub],
             nar_info_entries: vec![
                 (
-                    nar_info::make_nar_info_url(&error_substituter_url, &hash),
+                    make_nar_info_url(&error_substituter_url, &hash),
                     Err("stub error".into()),
                 ),
                 (
-                    nar_info::make_nar_info_url(&success_substituter_url, &hash),
-                    Ok(nar_info::make_nar_info_query_data(Duration::from_millis(0))),
+                    make_nar_info_url(&success_substituter_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(0))),
                 ),
             ],
             tolerance: 50,
@@ -276,16 +283,13 @@ async fn partial_error_with_success() {
         },
         TestCaseInput { hash },
         TestCaseExpectation {
-            source_url: Ok(Some(nar_file::make_source_url(
-                &success_substituter_url,
-                10,
-            ))),
+            source_url: Ok(Some(make_source_url(&success_substituter_url, 10))),
             events: vec![
                 ResolveNarInfoEvent::SubstituterError(error_substituter_url),
                 ResolveNarInfoEvent::NarFileLocated {
-                    nar_file: nar_info::make_nar_file_name(),
-                    substituter: substituter::make_substituter_meta(&success_substituter_url, 10),
-                    source_url: nar_file::make_source_url(&success_substituter_url, 10),
+                    nar_file: make_nar_file_name(),
+                    substituter: make_substituter_meta_with_url_pri(&success_substituter_url, 10),
+                    source_url: make_source_url(&success_substituter_url, 10),
                 },
             ],
         },
@@ -297,20 +301,20 @@ async fn partial_error_with_success() {
 async fn all_substituters_service_fail_with_ignore_error() {
     let sub_a_url = Url::new("https://cache-a.example.com").unwrap();
     let sub_b_url = Url::new("https://cache-b.example.com").unwrap();
-    let sub_a = substituter::make_substituter_normal(&sub_a_url, 40);
-    let sub_b = substituter::make_substituter_normal(&sub_b_url, 10);
-    let hash = nar_info::make_store_path_hash();
+    let sub_a = make_substituter_normal_with_url_pri(&sub_a_url, 40);
+    let sub_b = make_substituter_normal_with_url_pri(&sub_b_url, 10);
+    let hash = make_store_path_hash();
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![sub_a, sub_b],
             nar_info_entries: vec![
                 (
-                    nar_info::make_nar_info_url(&sub_a_url, &hash),
+                    make_nar_info_url(&sub_a_url, &hash),
                     Err("stub error".into()),
                 ),
                 (
-                    nar_info::make_nar_info_url(&sub_b_url, &hash),
+                    make_nar_info_url(&sub_b_url, &hash),
                     Err("stub error".into()),
                 ),
             ],
@@ -333,33 +337,23 @@ async fn all_substituters_service_fail_with_ignore_error() {
 async fn all_substituters_offline_treated_as_not_found() {
     let sub_a_url = Url::new("https://cache-a.example.com").unwrap();
     let sub_b_url = Url::new("https://cache-b.example.com").unwrap();
-    let sub_a = substituter::make_substituter_normal_with_nar_info_timeout(
-        &sub_a_url,
-        40,
-        Duration::from_millis(10),
-    );
-    let sub_b = substituter::make_substituter_normal_with_nar_info_timeout(
-        &sub_b_url,
-        10,
-        Duration::from_millis(20),
-    );
-    let hash = nar_info::make_store_path_hash();
+    let sub_a =
+        make_substituter_normal_with_nar_info_timeout(&sub_a_url, 40, Duration::from_millis(10));
+    let sub_b =
+        make_substituter_normal_with_nar_info_timeout(&sub_b_url, 10, Duration::from_millis(20));
+    let hash = make_store_path_hash();
 
     run_test(
         TestCaseEnvironment {
             substituters: vec![sub_a, sub_b],
             nar_info_entries: vec![
                 (
-                    nar_info::make_nar_info_url(&sub_a_url, &hash),
-                    Ok(nar_info::make_nar_info_query_data(Duration::from_millis(
-                        100,
-                    ))),
+                    make_nar_info_url(&sub_a_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(100))),
                 ),
                 (
-                    nar_info::make_nar_info_url(&sub_b_url, &hash),
-                    Ok(nar_info::make_nar_info_query_data(Duration::from_millis(
-                        200,
-                    ))),
+                    make_nar_info_url(&sub_b_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(200))),
                 ),
             ],
             tolerance: 50,

--- a/tests/integration/status_query_usecase_test.rs
+++ b/tests/integration/status_query_usecase_test.rs
@@ -26,7 +26,9 @@ use selector4nix_actor::registry::{AsyncFactory, RegistryBuilder};
 use selector4nix_db::cache_kv::CacheKv;
 
 use crate::fixture::config::make_config_string_minimal;
-use crate::fixture::substituter::{make_substituter_maybe_ready, make_substituter_normal};
+use selector4nix::domain::substituter::model::test_support::{
+    make_substituter_maybe_ready_with_url_pri, make_substituter_normal_with_url_pri,
+};
 
 fn nar_info_registry() -> Arc<NarInfoActorRegistry> {
     Arc::new(
@@ -79,10 +81,10 @@ async fn status_endpoint_returns_runtime_config_and_substituters() {
     let cache_url = Url::new("https://cache.nixos.org/").unwrap();
     let private_url = Url::new("https://private.example.com/cache/").unwrap();
     substituter_repository
-        .save(make_substituter_normal(&cache_url, 40))
+        .save(make_substituter_normal_with_url_pri(&cache_url, 40))
         .await;
     substituter_repository
-        .save(make_substituter_maybe_ready(&private_url, 10))
+        .save(make_substituter_maybe_ready_with_url_pri(&private_url, 10))
         .await;
 
     let nar_info_registry = nar_info_registry();


### PR DESCRIPTION
Closes #102

Dedup test fixtures defined in multiple test modules in the main crate, and use these new fixtures helpers in integration tests.