### PR TITLE
Fix `unused_variables` warning

### DIFF
--- a/crates/selector4nix-web/src/dashboard/mod.rs
+++ b/crates/selector4nix-web/src/dashboard/mod.rs
@@ -15,7 +15,7 @@ use rust_embed::Embed;
 struct TemplateAssets;
 
 static VIEW_ENVIRONMENT: LazyLock<AutoReloader> = LazyLock::new(|| {
-    AutoReloader::new(|notifier| {
+    AutoReloader::new(|#[allow(unused_variables)] notifier| {
         // In debug builds, always trigger a reload from the filesystem.
         #[cfg(debug_assertions)]
         notifier.set_callback(|| true);


### PR DESCRIPTION
The warning is caused by the conditional compilation of the template engine's reloading logic in development environment and only appears in release builds. So it is considered a false positive.