### PR TITLE
Fix CI cache miss by adding extra dependent substituters

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -30,6 +30,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: selector4nix
+          extraPullNames: nix-community
           skipPush: true
 
       - name: Discover System Tests
@@ -61,6 +62,13 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: selector4nix
+          extraPullNames: nix-community
+          skipPush: true
 
       - name: Build selector4nix
         run: |

--- a/.github/workflows/upload-cache.yml
+++ b/.github/workflows/upload-cache.yml
@@ -38,6 +38,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: selector4nix
+          extraPullNames: nix-community
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build selector4nix


### PR DESCRIPTION
Our `selector4nix.cachix.org` depends on `nix-community.cachix.org`, which remove duplication of store paths that already exist in the `nix-community.cachix.org` substituter. `nix-community.cachix.org` wasn't in the CI's substituter list, so Nix didn't know how to build some missing store path. Hence Nix didn't know how to build the needed `selector4nix-deps` that depends on those missing store paths. Eventually a large amount of wasteful builds were triggered.