### PR TITLE
Change configuration schema and apply stricter configuration validation 

### DIFF
--- a/crates/selector4nix-actor/src/registry/builder.rs
+++ b/crates/selector4nix-actor/src/registry/builder.rs
@@ -1,5 +1,6 @@
 use std::hash::Hash;
 use std::marker::PhantomData;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -12,7 +13,7 @@ use crate::registry::{NoFactory, PendingTermination, Registry};
 pub enum CapacityOption {
     #[default]
     Unlimited,
-    Lru(usize),
+    Lru(NonZeroUsize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -57,7 +58,7 @@ impl<K, A, F> RegistryBuilder<K, A, F> {
     {
         let max_capacity = match self.capacity {
             CapacityOption::Unlimited => u64::MAX,
-            CapacityOption::Lru(max_capacity) => max_capacity as u64,
+            CapacityOption::Lru(max_capacity) => max_capacity.get() as u64,
         };
         let builder = Cache::builder().max_capacity(max_capacity);
 

--- a/crates/selector4nix-core/src/application/usecase/dashboard/get_cache_stats.rs
+++ b/crates/selector4nix-core/src/application/usecase/dashboard/get_cache_stats.rs
@@ -82,22 +82,22 @@ impl GetDashboardCacheStatsUseCase {
             cache: CacheStatsCacheData {
                 nar_info: CacheTypeStats {
                     size: self.nar_info_registry.entry_count().await,
-                    capacity: self.cache_config.nar_info_lookup_capacity,
+                    capacity: self.cache_config.nar_info_cache_capacity,
                 },
                 nar_file: CacheTypeStats {
                     size: self.nar_file_registry.entry_count().await,
-                    capacity: self.cache_config.nar_location_capacity,
+                    capacity: self.cache_config.nar_file_cache_capacity,
                 },
             },
             store: CacheStatsStoreData {
                 nar_info: StoreTypeStats {
                     size: self.nar_info_repository.entry_count().await.ok(),
-                    ttl_secs: self.cache_config.nar_info_lookup_ttl.as_secs(),
+                    ttl_secs: self.cache_config.nar_info_ttl.as_secs(),
                     cache_mode: self.cache_mode,
                 },
                 nar_file: StoreTypeStats {
                     size: self.nar_file_repository.entry_count().await.ok(),
-                    ttl_secs: self.cache_config.nar_location_ttl.as_secs(),
+                    ttl_secs: self.cache_config.nar_file_ttl.as_secs(),
                     cache_mode: self.cache_mode,
                 },
             },

--- a/crates/selector4nix-core/src/application/usecase/dashboard/get_cache_stats.rs
+++ b/crates/selector4nix-core/src/application/usecase/dashboard/get_cache_stats.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -29,7 +30,7 @@ pub struct CacheStatsStoreData {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct CacheTypeStats {
     pub size: usize,
-    pub capacity: usize,
+    pub capacity: NonZeroUsize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]

--- a/crates/selector4nix-core/src/application/usecase/dashboard/get_overview.rs
+++ b/crates/selector4nix-core/src/application/usecase/dashboard/get_overview.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -21,7 +22,7 @@ pub struct OverviewSummaryData {
     total_substituters: usize,
     transferring_nar_files: usize,
     nar_info_cache_size: usize,
-    nar_info_cache_capacity: usize,
+    nar_info_cache_capacity: NonZeroUsize,
     cache_mode: CacheMode,
 }
 
@@ -53,7 +54,7 @@ pub struct GetDashboardOverviewUseCase {
     nar_info_registry: Arc<NarInfoActorRegistry>,
     nar_transfer_metric: Arc<NarTransferMetric>,
     credentials: Arc<AppCredential>,
-    nar_info_cache_capacity: usize,
+    nar_info_cache_capacity: NonZeroUsize,
     cache_mode: CacheMode,
 }
 
@@ -63,7 +64,7 @@ impl GetDashboardOverviewUseCase {
         nar_info_registry: Arc<NarInfoActorRegistry>,
         nar_transfer_metric: Arc<NarTransferMetric>,
         credentials: Arc<AppCredential>,
-        nar_info_cache_capacity: usize,
+        nar_info_cache_capacity: NonZeroUsize,
         has_persistent_cache: bool,
     ) -> Self {
         Self {

--- a/crates/selector4nix-core/src/infrastructure/config/credential_raw.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/credential_raw.rs
@@ -4,6 +4,7 @@ use anyhow::Result as AnyhowResult;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AppRawCredential {
     pub credentials: Vec<AppRawCredentialEntry>,
 }
@@ -16,6 +17,7 @@ impl AppRawCredential {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AppRawCredentialEntry {
     pub url: String,
     pub login: String,

--- a/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
@@ -198,10 +198,10 @@ impl TryFrom<CacheInfoRawConfiguration> for CacheInfoConfiguration {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheConfiguration {
-    pub nar_info_lookup_capacity: usize,
-    pub nar_info_lookup_ttl: Duration,
-    pub nar_location_capacity: usize,
-    pub nar_location_ttl: Duration,
+    pub nar_info_cache_capacity: usize,
+    pub nar_info_ttl: Duration,
+    pub nar_file_cache_capacity: usize,
+    pub nar_file_ttl: Duration,
 }
 
 impl TryFrom<CacheRawConfiguration> for CacheConfiguration {
@@ -209,13 +209,13 @@ impl TryFrom<CacheRawConfiguration> for CacheConfiguration {
 
     fn try_from(raw: CacheRawConfiguration) -> Result<Self, Self::Error> {
         Ok(Self {
-            nar_info_lookup_capacity: raw.nar_info_lookup_capacity.unwrap_or(4096),
-            nar_info_lookup_ttl: raw
-                .nar_info_lookup_ttl_secs
+            nar_info_cache_capacity: raw.nar_info_cache_capacity.unwrap_or(4096),
+            nar_info_ttl: raw
+                .nar_info_ttl_secs
                 .map_or(Duration::from_hours(4), to_clamped_duration),
-            nar_location_capacity: raw.nar_location_capacity.unwrap_or(4096),
-            nar_location_ttl: raw
-                .nar_location_ttl_secs
+            nar_file_cache_capacity: raw.nar_file_cache_capacity.unwrap_or(4096),
+            nar_file_ttl: raw
+                .nar_file_ttl_secs
                 .map_or(Duration::from_hours(4), to_clamped_duration),
         })
     }

--- a/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
@@ -61,6 +61,11 @@ impl TryFrom<AppRawConfiguration> for AppConfiguration {
     type Error = AnyhowError;
 
     fn try_from(raw: AppRawConfiguration) -> Result<Self, Self::Error> {
+        if raw.substituters.is_empty() {
+            return Err(anyhow::anyhow!(
+                "at least one substituter must be configured"
+            ));
+        }
         Ok(Self {
             server: raw.server.try_into()?,
             network: raw.network.unwrap_or_default().try_into()?,

--- a/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
@@ -103,7 +103,7 @@ impl TryFrom<ServerRawConfiguration> for ServerConfiguration {
 pub struct NetworkConfiguration {
     pub nar_info_timeout: Duration,
     pub nar_timeout: Duration,
-    pub max_concurrent_requests: usize,
+    pub max_concurrent_requests: NonZeroUsize,
     pub tolerance: u64,
     pub ignore_nar_info_error: bool,
     pub periodic_probing: PeriodicProbingOption,
@@ -119,12 +119,14 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
         Ok(Self {
             nar_info_timeout: raw
                 .nar_info_timeout_secs
-                .map_or(Duration::from_secs(30), to_clamped_duration),
+                .map_or(Duration::from_secs(30), |s| Duration::from_secs(s.get())),
             nar_timeout: raw
                 .nar_timeout_secs
-                .map_or(Duration::from_secs(30), to_clamped_duration),
-            max_concurrent_requests: raw.max_concurrent_requests.unwrap_or(12),
-            tolerance: raw.tolerance_msecs.unwrap_or(50).max(1),
+                .map_or(Duration::from_secs(30), |s| Duration::from_secs(s.get())),
+            max_concurrent_requests: raw
+                .max_concurrent_requests
+                .unwrap_or(NonZeroUsize::new(12).unwrap()),
+            tolerance: raw.tolerance_msecs.unwrap_or(50),
             ignore_nar_info_error: raw.ignore_nar_info_error.unwrap_or(false),
             periodic_probing: if raw.periodic_probing.unwrap_or(true) {
                 PeriodicProbingOption::Enabled
@@ -198,9 +200,9 @@ impl TryFrom<CacheInfoRawConfiguration> for CacheInfoConfiguration {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheConfiguration {
-    pub nar_info_cache_capacity: usize,
+    pub nar_info_cache_capacity: NonZeroUsize,
     pub nar_info_ttl: Duration,
-    pub nar_file_cache_capacity: usize,
+    pub nar_file_cache_capacity: NonZeroUsize,
     pub nar_file_ttl: Duration,
 }
 
@@ -209,14 +211,18 @@ impl TryFrom<CacheRawConfiguration> for CacheConfiguration {
 
     fn try_from(raw: CacheRawConfiguration) -> Result<Self, Self::Error> {
         Ok(Self {
-            nar_info_cache_capacity: raw.nar_info_cache_capacity.unwrap_or(4096),
+            nar_info_cache_capacity: raw
+                .nar_info_cache_capacity
+                .unwrap_or(NonZeroUsize::new(4096).unwrap()),
             nar_info_ttl: raw
                 .nar_info_ttl_secs
-                .map_or(Duration::from_hours(4), to_clamped_duration),
-            nar_file_cache_capacity: raw.nar_file_cache_capacity.unwrap_or(4096),
+                .map_or(Duration::from_hours(4), |s| Duration::from_secs(s.get())),
+            nar_file_cache_capacity: raw
+                .nar_file_cache_capacity
+                .unwrap_or(NonZeroUsize::new(4096).unwrap()),
             nar_file_ttl: raw
                 .nar_file_ttl_secs
-                .map_or(Duration::from_hours(4), to_clamped_duration),
+                .map_or(Duration::from_hours(4), |s| Duration::from_secs(s.get())),
         })
     }
 }
@@ -238,12 +244,10 @@ impl TryFrom<SubstituterRawConfiguration> for SubstituterConfiguration {
             url: Url::new(&raw.url)?,
             storage_url: raw.storage_url.map(|s| Url::new(&s)).transpose()?,
             priority: raw.priority.map_or(Priority::new(40), Priority::new)?,
-            nar_info_timeout: raw.nar_info_timeout_secs.map(to_clamped_duration),
-            nar_timeout: raw.nar_timeout_secs.map(to_clamped_duration),
+            nar_info_timeout: raw
+                .nar_info_timeout_secs
+                .map(|s| Duration::from_secs(s.get())),
+            nar_timeout: raw.nar_timeout_secs.map(|s| Duration::from_secs(s.get())),
         })
     }
-}
-
-fn to_clamped_duration(secs: u64) -> Duration {
-    Duration::from_secs(secs.max(1))
 }

--- a/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result as AnyhowResult};
 use serde::Deserialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AppRawConfiguration {
     pub server: ServerRawConfiguration,
     pub network: Option<NetworkRawConfiguration>,
@@ -21,12 +22,14 @@ impl AppRawConfiguration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ServerRawConfiguration {
     pub ip: IpAddr,
     pub port: Option<u16>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct NetworkRawConfiguration {
     pub nar_info_timeout_secs: Option<u64>,
     pub nar_timeout_secs: Option<u64>,
@@ -40,12 +43,14 @@ pub struct NetworkRawConfiguration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ProxyRawConfiguration {
     pub rewrite_nar_url: Option<bool>,
     pub rewrite_to_target: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct CacheInfoRawConfiguration {
     pub store_dir: Option<String>,
     pub want_mass_query: Option<bool>,
@@ -53,6 +58,7 @@ pub struct CacheInfoRawConfiguration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct CacheRawConfiguration {
     pub nar_info_cache_capacity: Option<usize>,
     pub nar_info_ttl_secs: Option<u64>,
@@ -61,6 +67,7 @@ pub struct CacheRawConfiguration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubstituterRawConfiguration {
     pub url: String,
     pub storage_url: Option<String>,

--- a/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
@@ -1,4 +1,5 @@
-use std::{net::IpAddr, num::NonZeroUsize};
+use std::net::IpAddr;
+use std::num::NonZeroUsize;
 
 use anyhow::{Context, Result as AnyhowResult};
 use serde::Deserialize;
@@ -53,10 +54,10 @@ pub struct CacheInfoRawConfiguration {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]
 pub struct CacheRawConfiguration {
-    pub nar_info_lookup_capacity: Option<usize>,
-    pub nar_info_lookup_ttl_secs: Option<u64>,
-    pub nar_location_capacity: Option<usize>,
-    pub nar_location_ttl_secs: Option<u64>,
+    pub nar_info_cache_capacity: Option<usize>,
+    pub nar_info_ttl_secs: Option<u64>,
+    pub nar_file_cache_capacity: Option<usize>,
+    pub nar_file_ttl_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]

--- a/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
@@ -1,5 +1,5 @@
 use std::net::IpAddr;
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU64, NonZeroUsize};
 
 use anyhow::{Context, Result as AnyhowResult};
 use serde::Deserialize;
@@ -31,9 +31,9 @@ pub struct ServerRawConfiguration {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct NetworkRawConfiguration {
-    pub nar_info_timeout_secs: Option<u64>,
-    pub nar_timeout_secs: Option<u64>,
-    pub max_concurrent_requests: Option<usize>,
+    pub nar_info_timeout_secs: Option<NonZeroU64>,
+    pub nar_timeout_secs: Option<NonZeroU64>,
+    pub max_concurrent_requests: Option<NonZeroUsize>,
     pub tolerance_msecs: Option<u64>,
     pub ignore_nar_info_error: Option<bool>,
     pub periodic_probing: Option<bool>,
@@ -60,10 +60,10 @@ pub struct CacheInfoRawConfiguration {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CacheRawConfiguration {
-    pub nar_info_cache_capacity: Option<usize>,
-    pub nar_info_ttl_secs: Option<u64>,
-    pub nar_file_cache_capacity: Option<usize>,
-    pub nar_file_ttl_secs: Option<u64>,
+    pub nar_info_cache_capacity: Option<NonZeroUsize>,
+    pub nar_info_ttl_secs: Option<NonZeroU64>,
+    pub nar_file_cache_capacity: Option<NonZeroUsize>,
+    pub nar_file_ttl_secs: Option<NonZeroU64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
@@ -72,6 +72,6 @@ pub struct SubstituterRawConfiguration {
     pub url: String,
     pub storage_url: Option<String>,
     pub priority: Option<u32>,
-    pub nar_info_timeout_secs: Option<u64>,
-    pub nar_timeout_secs: Option<u64>,
+    pub nar_info_timeout_secs: Option<NonZeroU64>,
+    pub nar_timeout_secs: Option<NonZeroU64>,
 }

--- a/crates/selector4nix-core/tests/integration/config_test.rs
+++ b/crates/selector4nix-core/tests/integration/config_test.rs
@@ -95,3 +95,15 @@ priority = 0
 
     assert!(result.is_err());
 }
+
+#[test]
+fn empty_substituters_is_rejected() {
+    let result = AppConfiguration::deserialize(
+        r#"
+[server]
+ip = "127.0.0.1"
+"#,
+    );
+
+    assert!(result.is_err());
+}

--- a/crates/selector4nix-core/tests/integration/config_test.rs
+++ b/crates/selector4nix-core/tests/integration/config_test.rs
@@ -20,7 +20,10 @@ fn defaults_are_applied_when_sections_omitted() {
     assert_eq!(config.server.port, 5496);
     assert_eq!(config.network.nar_info_timeout, Duration::from_secs(30));
     assert_eq!(config.network.nar_timeout, Duration::from_secs(30));
-    assert_eq!(config.network.max_concurrent_requests, 12);
+    assert_eq!(
+        config.network.max_concurrent_requests,
+        NonZeroUsize::new(12).unwrap(),
+    );
     assert_eq!(config.network.tolerance, 50);
     assert!(!config.network.ignore_nar_info_error);
     assert_eq!(
@@ -40,42 +43,20 @@ fn defaults_are_applied_when_sections_omitted() {
     assert_eq!(config.cache_info.store_dir, "/nix/store");
     assert!(config.cache_info.want_mass_query);
     assert_eq!(config.cache_info.priority.value(), 40);
-    assert_eq!(config.cache.nar_info_cache_capacity, 4096);
+    assert_eq!(
+        config.cache.nar_info_cache_capacity,
+        NonZeroUsize::new(4096).unwrap(),
+    );
     assert_eq!(config.cache.nar_info_ttl, Duration::from_secs(14400));
-    assert_eq!(config.cache.nar_file_cache_capacity, 4096);
+    assert_eq!(
+        config.cache.nar_file_cache_capacity,
+        NonZeroUsize::new(4096).unwrap(),
+    );
     assert_eq!(config.cache.nar_file_ttl, Duration::from_secs(14400));
     assert_eq!(config.substituters.len(), 1);
     assert!(config.substituters[0].storage_url.is_none());
     assert!(config.substituters[0].nar_info_timeout.is_none());
     assert!(config.substituters[0].nar_timeout.is_none());
-}
-
-#[test]
-fn zero_timeout_is_clamped_to_one() {
-    let config = AppConfiguration::deserialize(&make_config_string_overriden(
-        r#"
-[network]
-nar_info_timeout_secs = 0
-nar_timeout_secs = 0
-"#,
-    ))
-    .unwrap();
-
-    assert_eq!(config.network.nar_info_timeout, Duration::from_secs(1));
-    assert_eq!(config.network.nar_timeout, Duration::from_secs(1));
-}
-
-#[test]
-fn zero_tolerance_is_clamped_to_one() {
-    let config = AppConfiguration::deserialize(&make_config_string_overriden(
-        r#"
-[network]
-tolerance_msecs = 0
-"#,
-    ))
-    .unwrap();
-
-    assert_eq!(config.network.tolerance, 1);
 }
 
 #[test]

--- a/crates/selector4nix-core/tests/integration/config_test.rs
+++ b/crates/selector4nix-core/tests/integration/config_test.rs
@@ -40,10 +40,10 @@ fn defaults_are_applied_when_sections_omitted() {
     assert_eq!(config.cache_info.store_dir, "/nix/store");
     assert!(config.cache_info.want_mass_query);
     assert_eq!(config.cache_info.priority.value(), 40);
-    assert_eq!(config.cache.nar_info_lookup_capacity, 4096);
-    assert_eq!(config.cache.nar_info_lookup_ttl, Duration::from_secs(14400));
-    assert_eq!(config.cache.nar_location_capacity, 4096);
-    assert_eq!(config.cache.nar_location_ttl, Duration::from_secs(14400));
+    assert_eq!(config.cache.nar_info_cache_capacity, 4096);
+    assert_eq!(config.cache.nar_info_ttl, Duration::from_secs(14400));
+    assert_eq!(config.cache.nar_file_cache_capacity, 4096);
+    assert_eq!(config.cache.nar_file_ttl, Duration::from_secs(14400));
     assert_eq!(config.substituters.len(), 1);
     assert!(config.substituters[0].storage_url.is_none());
     assert!(config.substituters[0].nar_info_timeout.is_none());

--- a/crates/selector4nix-streaming/src/client.rs
+++ b/crates/selector4nix-streaming/src/client.rs
@@ -31,7 +31,7 @@ pub struct StreamingClient {
 impl StreamingClient {
     pub fn new(
         client: ClientBuilder,
-        max_concurrent_requests: usize,
+        max_concurrent_requests: NonZeroUsize,
         enable_chunked_streaming: bool,
         chunk_max_len: NonZeroUsize,
         window_max_len: NonZeroUsize,

--- a/crates/selector4nix-streaming/src/stream/chunked_tests.rs
+++ b/crates/selector4nix-streaming/src/stream/chunked_tests.rs
@@ -110,7 +110,9 @@ fn make_stream(
     });
 
     let throttler = Box::new(ThrottlerAdapter::new(
-        Arc::new(PerHostHttpThrottler::new(max_concurrent_requests)),
+        Arc::new(PerHostHttpThrottler::new(
+            NonZeroUsize::new(max_concurrent_requests).unwrap(),
+        )),
         "example.com".to_string(),
     ));
     let initial_permit = throttler

--- a/crates/selector4nix-streaming/src/throttler/per_host.rs
+++ b/crates/selector4nix-streaming/src/throttler/per_host.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -6,12 +7,12 @@ use tokio::sync::{Semaphore, TryAcquireError};
 use crate::throttler::ThrottlerPermit;
 
 pub struct PerHostHttpThrottler {
-    max_concurrent_requests: usize,
+    max_concurrent_requests: NonZeroUsize,
     semaphores: DashMap<String, Arc<Semaphore>>,
 }
 
 impl PerHostHttpThrottler {
-    pub fn new(max_concurrent_requests: usize) -> Self {
+    pub fn new(max_concurrent_requests: NonZeroUsize) -> Self {
         Self {
             max_concurrent_requests,
             semaphores: DashMap::new(),
@@ -42,8 +43,8 @@ impl PerHostHttpThrottler {
         } else {
             let entry = self.semaphores.entry(host.into());
             // Use `or_insert_with()` to prevent duplicated insertion.
-            let entry =
-                entry.or_insert_with(|| Arc::new(Semaphore::new(self.max_concurrent_requests)));
+            let entry = entry
+                .or_insert_with(|| Arc::new(Semaphore::new(self.max_concurrent_requests.get())));
             Arc::clone(entry.value())
         }
     }

--- a/crates/selector4nix-web/src/api/status.rs
+++ b/crates/selector4nix-web/src/api/status.rs
@@ -123,7 +123,7 @@ fn to_response(snapshot: StatusSnapshot) -> StatusResponse {
             tolerance_msecs: config.network.tolerance,
             nar_info_timeout_secs: config.network.nar_info_timeout.as_secs(),
             nar_timeout_secs: config.network.nar_timeout.as_secs(),
-            max_concurrent_requests: config.network.max_concurrent_requests,
+            max_concurrent_requests: config.network.max_concurrent_requests.get(),
             ignore_nar_info_error: config.network.ignore_nar_info_error,
             chunked_streaming: config.network.chunked_streaming,
             streaming_chunk_max_len: usize::from(config.network.streaming_chunk_max_len),
@@ -138,11 +138,11 @@ fn to_response(snapshot: StatusSnapshot) -> StatusResponse {
         cache_stats: CacheStatsStatus {
             nar_info_cache: CacheStatus {
                 entries: snapshot.nar_info_actor_entries,
-                capacity: config.cache.nar_info_cache_capacity,
+                capacity: config.cache.nar_info_cache_capacity.get(),
             },
             nar_file_cache: CacheStatus {
                 entries: snapshot.nar_file_actor_entries,
-                capacity: config.cache.nar_file_cache_capacity,
+                capacity: config.cache.nar_file_cache_capacity.get(),
             },
             nar_info_store: StoreStatus {
                 entries: snapshot.nar_info_persistent_entries,

--- a/crates/selector4nix-web/src/api/status.rs
+++ b/crates/selector4nix-web/src/api/status.rs
@@ -138,19 +138,19 @@ fn to_response(snapshot: StatusSnapshot) -> StatusResponse {
         cache_stats: CacheStatsStatus {
             nar_info_cache: CacheStatus {
                 entries: snapshot.nar_info_actor_entries,
-                capacity: config.cache.nar_info_lookup_capacity,
+                capacity: config.cache.nar_info_cache_capacity,
             },
             nar_file_cache: CacheStatus {
                 entries: snapshot.nar_file_actor_entries,
-                capacity: config.cache.nar_location_capacity,
+                capacity: config.cache.nar_file_cache_capacity,
             },
             nar_info_store: StoreStatus {
                 entries: snapshot.nar_info_persistent_entries,
-                ttl_secs: config.cache.nar_info_lookup_ttl.as_secs(),
+                ttl_secs: config.cache.nar_info_ttl.as_secs(),
             },
             nar_file_store: StoreStatus {
                 entries: snapshot.nar_file_persistent_entries,
-                ttl_secs: config.cache.nar_location_ttl.as_secs(),
+                ttl_secs: config.cache.nar_file_ttl.as_secs(),
             },
         },
         transferring: TransferringStatus {

--- a/crates/selector4nix/src/bootstrap.rs
+++ b/crates/selector4nix/src/bootstrap.rs
@@ -207,7 +207,7 @@ pub async fn init_context(
     let nar_file_service = Arc::new(NarFileService::new(
         nar_stream_provider,
         substituter_repository.clone(),
-        config.cache.nar_location_ttl,
+        config.cache.nar_file_ttl,
     ));
 
     let substituter_registry = Arc::new({
@@ -235,12 +235,12 @@ pub async fn init_context(
 
     let nar_info_registry = Arc::new(
         RegistryBuilder::new()
-            .capacity(CapacityOption::Lru(config.cache.nar_info_lookup_capacity))
-            .expiration(ExpirationOption::Ttl(config.cache.nar_info_lookup_ttl))
+            .capacity(CapacityOption::Lru(config.cache.nar_info_cache_capacity))
+            .expiration(ExpirationOption::Ttl(config.cache.nar_info_ttl))
             .factory(AsyncFactory::new({
                 let nar_info_service = nar_info_service.clone();
                 let nar_info_repository = nar_info_repository.clone();
-                let nar_info_ttl = config.cache.nar_info_lookup_ttl;
+                let nar_info_ttl = config.cache.nar_info_ttl;
                 move |hash: &StorePathHash| {
                     let addr = NarInfoActor::new(
                         hash.clone(),
@@ -257,12 +257,12 @@ pub async fn init_context(
 
     let nar_file_registry = Arc::new(
         RegistryBuilder::new()
-            .capacity(CapacityOption::Lru(config.cache.nar_location_capacity))
-            .expiration(ExpirationOption::Ttl(config.cache.nar_location_ttl))
+            .capacity(CapacityOption::Lru(config.cache.nar_file_cache_capacity))
+            .expiration(ExpirationOption::Ttl(config.cache.nar_file_ttl))
             .factory(AsyncFactory::new({
                 let nar_file_servicee = nar_file_service.clone();
                 let nar_file_repository = nar_file_repository.clone();
-                let nar_file_ttl = config.cache.nar_location_ttl;
+                let nar_file_ttl = config.cache.nar_file_ttl;
                 move |key: &NarFileKey| {
                     let addr = NarFileActor::new(
                         key.clone(),
@@ -321,7 +321,7 @@ pub async fn init_context(
         nar_info_registry.clone(),
         nar_transfer_metric.clone(),
         credentials,
-        config.cache.nar_info_lookup_capacity,
+        config.cache.nar_info_cache_capacity,
         has_persistent_cache,
     );
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,18 +146,20 @@ Substituter priority advertised to Nix clients.
 
 ## `cache`
 
-Internal LRU cache settings for NAR info and NAR location data.
+Cache settings for NAR info content and NAR file location data.
 
-NAR info cache stores the NAR info content for each store path hash. NAR location cache stores the reverse mapping from NAR file names back to their corresponding NAR info, used to locate the correct upstream substituter when proxying NAR file downloads.
+There are two kinds of cache in this server: "cache" and "store". The former kind of caches are used to speed up accessing to entries, while the latter ones are for long-period storage, although "stores" are in-memory by default and you need to explicitly set a disk directory to enable persistence. These terms may seem confusing at first but it is how the server implements the caching mechanism in reality.
 
-### `cache.nar_info_lookup_capacity`
+NAR info cache/store contains the NAR info content for each store path hash. NAR file cache/store keeps the location index mapping NAR file names to their source substituter, which is used when the server proxies NAR file download requests.
+
+### `cache.nar_info_cache_capacity`
 
 - Type: Natural
 - Default: `4096`
 
-Maximum number of cached NAR info entries.
+Maximum number of cached NAR info entries in the NAR info cache. This has no effect on the capacity of the NAR info store.
 
-### `cache.nar_info_lookup_ttl_secs`
+### `cache.nar_info_ttl_secs`
 
 - Type: Natural
 - Default: `14400`
@@ -165,20 +167,20 @@ Maximum number of cached NAR info entries.
 
 Time-to-live in seconds for cached NAR info entries.
 
-### `cache.nar_location_capacity`
+### `cache.nar_file_cache_capacity`
 
 - Type: Natural
 - Default: `4096`
 
-Maximum number of cached NAR location entries.
+Maximum number of cached NAR file location entries. This has no effect on the capacity of the NAR file store.
 
-### `cache.nar_location_ttl_secs`
+### `cache.nar_file_ttl_secs`
 
 - Type: Natural
 - Default: `14400`
 - Minimum: `1`
 
-Time-to-live in seconds for cached NAR location entries.
+Time-to-live in seconds for cached NAR file location entries.
 
 ## `substituters`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,23 +30,21 @@ Network request settings.
 
 ### `network.nar_info_timeout_secs`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `30`
-- Minimum: `1`
 
 Timeout in seconds for NAR info lookup requests.
 
 ### `network.nar_timeout_secs`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `30`
-- Minimum: `1`
 
 Timeout in seconds for NAR file downloads, also used as connect timeout.
 
 ### `network.max_concurrent_requests`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `12`
 
 Maximum number of concurrent outgoing NAR file streaming requests, applied per distinct substituter host. The overall ceiling across the proxy is `max_concurrent_requests` multiplied by the number of distinct substituter hosts.
@@ -76,7 +74,6 @@ Maximum number of chunks that may be in flight simultaneously for a single NAR f
 
 - Type: Natural
 - Default: `50`
-- Minimum: `1`
 
 Latency tolerance window in milliseconds. The preference of a substituter is calculated as `-tolerance * priority - latency`. After the fastest substituter responds, other substituters have additional milliseconds equal to the difference between their preference and the current best before being pruned.
 
@@ -139,7 +136,7 @@ Whether to advertise support for mass queries.
 
 ### `cache_info.priority`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `40`
 
 Substituter priority advertised to Nix clients.
@@ -154,31 +151,29 @@ NAR info cache/store contains the NAR info content for each store path hash. NAR
 
 ### `cache.nar_info_cache_capacity`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `4096`
 
 Maximum number of cached NAR info entries in the NAR info cache. This has no effect on the capacity of the NAR info store.
 
 ### `cache.nar_info_ttl_secs`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `14400`
-- Minimum: `1`
 
 Time-to-live in seconds for cached NAR info entries.
 
 ### `cache.nar_file_cache_capacity`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `4096`
 
 Maximum number of cached NAR file location entries. This has no effect on the capacity of the NAR file store.
 
 ### `cache.nar_file_ttl_secs`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `14400`
-- Minimum: `1`
 
 Time-to-live in seconds for cached NAR file location entries.
 
@@ -201,21 +196,21 @@ Override the base URL used for NAR file downloads.
 
 ### `substituters[].priority`
 
-- Type: Natural
+- Type: Positive Integer
 - Default: `40`
 
 Priority of this substituter. Higher values mean lower priority.
 
 ### `substituters[].nar_info_timeout_secs`
 
-- Type: Natural | None
+- Type: Positive Integer | None
 - Default: none
 
 Per-substituter override for NAR info lookup timeout in seconds. When unset, falls back to `network.nar_info_timeout_secs`.
 
 ### `substituters[].nar_timeout_secs`
 
-- Type: Natural | None
+- Type: Positive Integer | None
 - Default: none
 
 Per-substituter override for NAR file download timeout in seconds. When unset, falls back to `network.nar_timeout_secs`.

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -51,16 +51,16 @@ want_mass_query = true
 # Cache priority advertised to Nix clients (default: 40).
 priority = 40
 
-# Internal LRU cache settings for NAR info and NAR location data.
+# Internal LRU cache settings for NAR info content and NAR file location data.
 [cache]
 # Maximum number of cached NAR info entries (default: 4096).
-nar_info_lookup_capacity = 4096
+nar_info_cache_capacity = 4096
 # Time-to-live in seconds for cached NAR info entries (default: 14400, minimum: 1).
-nar_info_lookup_ttl_secs = 14400
-# Maximum number of cached NAR location entries (default: 4096).
-nar_location_capacity = 4096
-# Time-to-live in seconds for cached NAR location entries (default: 14400, minimum: 1).
-nar_location_ttl_secs = 14400
+nar_info_ttl_secs = 14400
+# Maximum number of cached NAR file location entries (default: 4096).
+nar_file_cache_capacity = 4096
+# Time-to-live in seconds for cached NAR file location entries (default: 14400, minimum: 1).
+nar_file_ttl_secs = 14400
 
 # Upstream substituter list (at least one required).
 [[substituters]]

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -17,7 +17,7 @@ nar_timeout_secs = 30
 # Maximum number of concurrent NAR file streaming requests per distinct substituter host (default: 12).
 max_concurrent_requests = 12
 # Latency tolerance window in milliseconds. After the fastest substituter responds,
-# others have this many additional milliseconds before being pruned (default: 50, minimum: 1).
+# others have this many additional milliseconds before being pruned (default: 50).
 tolerance_msecs = 50
 # Treat NAR info lookup errors as not-found (default: false).
 # WARNING: setting this to true may cause incorrect judgments about whether a NAR info actually exists.

--- a/frontend/templates/cache.html.jinja
+++ b/frontend/templates/cache.html.jinja
@@ -19,10 +19,7 @@
             <span class="text-sm text-muted">/ {{ model.cache.nar_info.capacity }} max capacity</span>
           </div>
           <div class="mt-1.5 text-xs text-muted">
-            {% with percentage = 0.0 %}
-              {% if model.cache.nar_info.capacity > 0 %}
-                {% set percentage = model.cache.nar_info.size / model.cache.nar_info.capacity * 100 %}
-              {% endif %}
+            {% with percentage = model.cache.nar_info.size / model.cache.nar_info.capacity * 100 %}
               Usage {{ percentage | round(1) }}%
             {% endwith %}
           </div>
@@ -35,10 +32,7 @@
             <span class="text-sm text-muted">/ {{ model.cache.nar_file.capacity }} max capacity</span>
           </div>
           <div class="mt-1.5 text-xs text-muted">
-            {% with percentage = 0.0 %}
-              {% if model.cache.nar_file.capacity > 0 %}
-                {% set percentage = model.cache.nar_file.size / model.cache.nar_file.capacity * 100 %}
-              {% endif %}
+            {% with percentage = model.cache.nar_file.size / model.cache.nar_file.capacity * 100 %}
               Usage {{ percentage | round(1) }}%
             {% endwith %}
           </div>


### PR DESCRIPTION
Rename the following entries:

- `cache.nar_info_lookup_capacity` -> `cache.nar_info_cache_capacity`
- `cache.nar_info_lookup_ttl_secs` -> `cache.nar_info_ttl_secs`
- `cache.nar_location_capacity` -> `cache.nar_file_cache_capacity`
- `cache.nar_location_ttl_secs` -> `cache.nar_file_ttl_secs`

For the following configuration entries, `0` is now rejected instead of being converting to another default value:

- `network.nar_info_timeout_secs`
- `network.nar_timeout_secs`
- `network.max_concurrent_requests`
- `cache.nar_info_cache_capacity`
- `cache.nar_info_ttl_secs`
- `cache.nar_file_cache_capacity`
- `cache.nar_file_ttl_secs`
- `substituters[].nar_info_timeout_secs`
- `substituters[].nar_timeout_secs`

For `substituters[]`, an empty list is rejected now.

Configuration validation now rejects unknown entries.