### PR TITLE
Add a workaround for harmonia when requesting NARs using chunked streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a temporary workaround for [harmonia](https://github.com/nix-community/harmonia) and other potential misbehaved servers when requesting NARs from them using chunked streaming. Harmonia won't respond correctly for such requests until [this fix](https://github.com/nix-community/harmonia/pull/1139) is merged.
+
 ## [0.9.0] - 2026-08-04
 
 ### Added

--- a/crates/selector4nix-streaming/src/client.rs
+++ b/crates/selector4nix-streaming/src/client.rs
@@ -141,7 +141,7 @@ impl StreamingResponse {
         permit: ThrottlerPermit,
     ) -> Result<StreamingResponse, StreamHttpBodyError> {
         match response.status() {
-            StatusCode::OK => {
+            StatusCode::OK if response.headers().get(header::CONTENT_RANGE).is_none() => {
                 tracing::debug!(url = %response.url(), "select full (unchunked) stream");
                 Ok(StreamingResponse(StreamingResponseInner::Full {
                     content_length: response.content_length(),
@@ -149,7 +149,7 @@ impl StreamingResponse {
                     permit,
                 }))
             }
-            StatusCode::PARTIAL_CONTENT => {
+            StatusCode::PARTIAL_CONTENT | StatusCode::OK => {
                 let bytes_total = response
                     .headers()
                     .get(header::CONTENT_RANGE)


### PR DESCRIPTION
Harmonia's ranged NAR responses use 200 as status code, rather than 206. This tricks selector4nix to consider such responses to be full and ignore the subsequent chunks. Eventually only the first chunk of NARs are returned to the Nix client, causing error `NAR for ... from ... is incomplete`.

This PR adds a workaround for such responses, although https://github.com/nix-community/harmonia/pull/1139 will address the root cause.