### PR TITLE
Update substituter's status after acquiring a NAR stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 ### Added
 
 - Added a temporary workaround for [harmonia](https://github.com/nix-community/harmonia) and other potential misbehaved servers when requesting NARs from them using chunked streaming. Harmonia won't respond correctly for such requests until [this fix](https://github.com/nix-community/harmonia/pull/1139) is merged.
+- Substituter's status is now updated after opening a NAR stream, if the response of the corresponding request to that substituter arrives.
 
 ## [0.9.0] - 2026-08-04
 

--- a/crates/selector4nix-core/src/application/actor/nar_file/runner.rs
+++ b/crates/selector4nix-core/src/application/actor/nar_file/runner.rs
@@ -9,7 +9,7 @@ use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::nar_file::model::{NarFile, NarFileKey, NarFileLocation};
 use crate::domain::nar_file::port::NarStreamData;
-use crate::domain::nar_file::{NarFileRepository, NarFileService};
+use crate::domain::nar_file::{NarFileRepository, NarFileService, StreamNarFileEvent};
 use crate::domain::nar_info::model::StorePathHash;
 use crate::domain::substituter::model::SubstituterMeta;
 
@@ -21,13 +21,18 @@ pub struct StreamNarFileResult {
 
 pub enum NarFileRequest {
     StreamNarFile {
-        reply_to: OneshotSender<Result<StreamNarFileResult, AppError>>,
+        reply_to: OneshotSender<StreamNarFileResponse>,
         headers: PassthroughHeaders,
     },
     SetLocation {
         location: NarFileLocation,
         store_path_hash: StorePathHash,
     },
+}
+
+pub struct StreamNarFileResponse {
+    pub result: Result<StreamNarFileResult, AppError>,
+    pub events: Vec<StreamNarFileEvent>,
 }
 
 pub struct NarFileActor {
@@ -86,7 +91,7 @@ impl Actor for NarFileActor {
             NarFileRequest::StreamNarFile { reply_to, headers } => {
                 let now = SystemTime::now();
                 let state = state.check_expiry_and_update(now);
-                let (state, result, _events) =
+                let (state, result, events) =
                     self.nar_file_service.stream(state, headers, now).await;
                 let result = result.map(|stream| StreamNarFileResult {
                     stream,
@@ -98,7 +103,7 @@ impl Actor for NarFileActor {
                     store_path_hash: state.store_path_hash().cloned(),
                 });
 
-                let _ = reply_to.send(result);
+                let _ = reply_to.send(StreamNarFileResponse { result, events });
                 if let Err(err) = self.nar_file_repository.save(state.clone()).await {
                     tracing::warn!(file_hash = %state.key().file_hash(), %err, "failed to write nar file to persistent cache, ignore");
                 }

--- a/crates/selector4nix-core/src/application/actor/nar_file/runner.rs
+++ b/crates/selector4nix-core/src/application/actor/nar_file/runner.rs
@@ -86,7 +86,8 @@ impl Actor for NarFileActor {
             NarFileRequest::StreamNarFile { reply_to, headers } => {
                 let now = SystemTime::now();
                 let state = state.check_expiry_and_update(now);
-                let (state, result) = self.nar_file_service.stream(state, headers, now).await;
+                let (state, result, _events) =
+                    self.nar_file_service.stream(state, headers, now).await;
                 let result = result.map(|stream| StreamNarFileResult {
                     stream,
                     substituter: state

--- a/crates/selector4nix-core/src/application/actor/substituter/runner.rs
+++ b/crates/selector4nix-core/src/application/actor/substituter/runner.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use selector4nix_actor::actor::{Actor, ActorPre, ActorPreBuilder, Context};
 use tokio::time::Instant;
@@ -56,7 +57,7 @@ impl SubstituterActor {
     async fn exec_event(&mut self, substituter: &Substituter, event: UpdateSubstituterEvent) {
         match event {
             UpdateSubstituterEvent::ScheduleRetryReady(instant) => {
-                self.dispatch_internal(std::time::Duration::ZERO, async move {
+                self.dispatch_internal(Duration::ZERO, async move {
                     tokio::time::sleep_until(instant).await;
                     SubstituterInternal::NextRetryReady
                 });
@@ -64,7 +65,7 @@ impl SubstituterActor {
             UpdateSubstituterEvent::ScheduleProbing(instant) => {
                 let substituter = substituter.target().clone();
                 let provider = Arc::clone(&self.substituter_probing_provider);
-                self.dispatch_internal(std::time::Duration::ZERO, async move {
+                self.dispatch_internal(Duration::ZERO, async move {
                     if let Some(instant) = instant {
                         tokio::time::sleep_until(instant).await;
                     }

--- a/crates/selector4nix-core/src/application/usecase/nar_file/stream.rs
+++ b/crates/selector4nix-core/src/application/usecase/nar_file/stream.rs
@@ -7,7 +7,9 @@ use bytes::Bytes;
 use futures::Stream;
 
 use crate::application::actor::nar_file::{NarFileActorRegistry, NarFileRequest};
+use crate::application::actor::substituter::{SubstituterActorRegistry, SubstituterRequest};
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
+use crate::domain::nar_file::StreamNarFileEvent;
 use crate::domain::nar_file::model::NarFileKey;
 use crate::domain::nar_file::port::NarStreamData;
 use crate::domain::nar_info::NarInfoRepository;
@@ -16,6 +18,7 @@ use crate::infrastructure::metric::{NarTransferHandle, NarTransferMeta, NarTrans
 use crate::{AppError, AppResultExt};
 
 pub struct StreamNarFileUseCase {
+    substituter_registry: Arc<SubstituterActorRegistry>,
     nar_file_registry: Arc<NarFileActorRegistry>,
     nar_info_repository: Arc<dyn NarInfoRepository>,
     nar_transfer_metric: Arc<NarTransferMetric>,
@@ -23,11 +26,13 @@ pub struct StreamNarFileUseCase {
 
 impl StreamNarFileUseCase {
     pub fn new(
+        substituter_registry: Arc<SubstituterActorRegistry>,
         nar_file_registry: Arc<NarFileActorRegistry>,
         nar_info_repository: Arc<dyn NarInfoRepository>,
         nar_transfer_metric: Arc<NarTransferMetric>,
     ) -> Self {
         Self {
+            substituter_registry,
             nar_file_registry,
             nar_info_repository,
             nar_transfer_metric,
@@ -48,7 +53,10 @@ impl StreamNarFileUseCase {
             .await
             .throw_catastrophic("`NarFileActor` terminated unexpectedly")?;
 
+        self.exec_events(response.events).await;
+
         let result = response
+            .result
             .inspect(|result| tracing::info!(nar_file = %key.to_file_name().value(), source_url = %result.stream.source_url, substituter = %result.substituter.url(), "streamed nar from substituter"))
             .inspect_err(|err| tracing::warn!(nar_file = %key.to_file_name().value(), %err, "failed to stream nar"))?;
 
@@ -70,6 +78,29 @@ impl StreamNarFileUseCase {
         nar_info
             .nar_info()
             .and_then(|data| data.store_path().map(ToString::to_string))
+    }
+
+    async fn exec_events(&self, events: Vec<StreamNarFileEvent>) {
+        for event in events {
+            self.exec_event(event).await;
+        }
+    }
+
+    async fn exec_event(&self, event: StreamNarFileEvent) {
+        match event {
+            StreamNarFileEvent::SubstituterSucceeded(url) => {
+                let sender = self.substituter_registry.get(&url).await;
+                let _ = sender.tell(SubstituterRequest::ServiceSuccessful).await;
+            }
+            StreamNarFileEvent::SubstituterOffline(url) => {
+                let sender = self.substituter_registry.get(&url).await;
+                let _ = sender.tell(SubstituterRequest::ServiceOffline).await;
+            }
+            StreamNarFileEvent::SubstituterError(url) => {
+                let sender = self.substituter_registry.get(&url).await;
+                let _ = sender.tell(SubstituterRequest::ServiceError).await;
+            }
+        }
     }
 }
 

--- a/crates/selector4nix-core/src/domain/nar_file/mod.rs
+++ b/crates/selector4nix-core/src/domain/nar_file/mod.rs
@@ -5,4 +5,4 @@ mod repository;
 mod service;
 
 pub use repository::NarFileRepository;
-pub use service::NarFileService;
+pub use service::{NarFileService, StreamNarFileEvent};

--- a/crates/selector4nix-core/src/domain/nar_file/port/mod.rs
+++ b/crates/selector4nix-core/src/domain/nar_file/port/mod.rs
@@ -1,3 +1,5 @@
 mod nar_stream_provider;
 
-pub use nar_stream_provider::{NarStreamData, NarStreamHeaders, NarStreamProvider};
+pub use nar_stream_provider::{
+    NarStreamData, NarStreamHeaders, NarStreamOpenAttempt, NarStreamProvider,
+};

--- a/crates/selector4nix-core/src/domain/nar_file/port/nar_stream_provider.rs
+++ b/crates/selector4nix-core/src/domain/nar_file/port/nar_stream_provider.rs
@@ -15,7 +15,10 @@ pub trait NarStreamProvider: Send + Sync {
         &self,
         locations: &[NarFileLocation],
         headers: &PassthroughHeaders,
-    ) -> AnyhowResult<Option<NarStreamData>>;
+    ) -> (
+        AnyhowResult<Option<NarStreamData>>,
+        Vec<NarStreamOpenAttempt>,
+    );
 }
 
 pub struct NarStreamData {
@@ -43,4 +46,11 @@ pub struct NarStreamHeaders {
     pub content_length: Option<u64>,
     pub content_type: Option<String>,
     pub content_encoding: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NarStreamOpenAttempt {
+    Successful { source_url: Url },
+    Offline { source_url: Url },
+    ServiceError { source_url: Url },
 }

--- a/crates/selector4nix-core/src/domain/nar_file/port/nar_stream_provider.rs
+++ b/crates/selector4nix-core/src/domain/nar_file/port/nar_stream_provider.rs
@@ -54,3 +54,13 @@ pub enum NarStreamOpenAttempt {
     Offline { source_url: Url },
     ServiceError { source_url: Url },
 }
+
+impl NarStreamOpenAttempt {
+    pub fn source_url(&self) -> &Url {
+        match self {
+            Self::Successful { source_url } => source_url,
+            Self::Offline { source_url } => source_url,
+            Self::ServiceError { source_url } => source_url,
+        }
+    }
+}

--- a/crates/selector4nix-core/src/domain/nar_file/service.rs
+++ b/crates/selector4nix-core/src/domain/nar_file/service.rs
@@ -3,11 +3,20 @@ use std::time::{Duration, SystemTime};
 
 use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
+use crate::domain::common::url::Url;
 use crate::domain::nar_file::model::{NarFile, NarFileLocation};
-use crate::domain::nar_file::port::{NarStreamData, NarStreamProvider};
+use crate::domain::nar_file::port::{NarStreamData, NarStreamOpenAttempt, NarStreamProvider};
 use crate::domain::nar_info::model::NarFileName;
 use crate::domain::substituter::SubstituterRepository;
 use crate::{AppError, AppResultExt};
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StreamNarFileEvent {
+    SubstituterSucceeded(Url),
+    SubstituterOffline(Url),
+    SubstituterError(Url),
+}
 
 pub struct NarFileService {
     nar_stream_provider: Arc<dyn NarStreamProvider>,
@@ -33,7 +42,11 @@ impl NarFileService {
         nar_file: NarFile,
         headers: PassthroughHeaders,
         now: SystemTime,
-    ) -> (NarFile, Result<NarStreamData, AppError>) {
+    ) -> (
+        NarFile,
+        Result<NarStreamData, AppError>,
+        Vec<StreamNarFileEvent>,
+    ) {
         let nar_file_name = nar_file.key().to_file_name();
 
         if let Some(location) = nar_file.location() {
@@ -50,13 +63,14 @@ impl NarFileService {
                 tracing::trace!(nar_file = %nar_file_name.value(), source_url = %location.source_url(), "use cached nar file location");
 
                 let locations = [location.clone()];
-                let (outcome, _attempts) = self
+                let (outcome, attempts) = self
                     .nar_stream_provider
                     .stream_nar(&locations, &headers)
                     .await;
 
                 if let Ok(Some(data)) = outcome {
-                    return (nar_file, Ok(data));
+                    let events = Self::map_attempts_to_events(&locations, &attempts);
+                    return (nar_file, Ok(data), events);
                 }
             }
 
@@ -76,11 +90,16 @@ impl NarFileService {
         headers: PassthroughHeaders,
         candidates: Vec<NarFileLocation>,
         now: SystemTime,
-    ) -> (NarFile, Result<NarStreamData, AppError>) {
-        let (outcome, _attempts) = self
+    ) -> (
+        NarFile,
+        Result<NarStreamData, AppError>,
+        Vec<StreamNarFileEvent>,
+    ) {
+        let (outcome, attempts) = self
             .nar_stream_provider
             .stream_nar(&candidates, &headers)
             .await;
+        let events = Self::map_attempts_to_events(&candidates, &attempts);
 
         match outcome {
             Ok(Some(data)) => {
@@ -95,17 +114,19 @@ impl NarFileService {
                         nar_file.on_located(location, expire_at, None)
                     }
                 };
-                (nar_file, Ok(data))
+                (nar_file, Ok(data), events)
             }
             Ok(None) => (
                 nar_file,
                 Err(AppError::not_found(
                     "failed to acquire stream for non-existent nar file",
                 )),
+                events,
             ),
             Err(err) => (
                 nar_file,
                 Err(err).chain_infrastructure("failed to acquire nar stream from substituters"),
+                events,
             ),
         }
     }
@@ -119,6 +140,34 @@ impl NarFileService {
                 let source_url = nar_file_name.with_storage_prefix(sub.meta().storage_url());
                 let timeout = sub.meta().nar_timeout();
                 NarFileLocation::new(source_url, sub.meta().clone(), timeout)
+            })
+            .collect()
+    }
+
+    fn map_attempts_to_events(
+        locations: &[NarFileLocation],
+        attempts: &[NarStreamOpenAttempt],
+    ) -> Vec<StreamNarFileEvent> {
+        locations
+            .iter()
+            .filter_map(|location| {
+                attempts
+                    .iter()
+                    .find(|attempt| attempt.source_url() == location.source_url())
+                    .map(|attempt| {
+                        let substituter_url = location.substituter().url().clone();
+                        match attempt {
+                            NarStreamOpenAttempt::Successful { .. } => {
+                                StreamNarFileEvent::SubstituterSucceeded(substituter_url)
+                            }
+                            NarStreamOpenAttempt::Offline { .. } => {
+                                StreamNarFileEvent::SubstituterOffline(substituter_url)
+                            }
+                            NarStreamOpenAttempt::ServiceError { .. } => {
+                                StreamNarFileEvent::SubstituterError(substituter_url)
+                            }
+                        }
+                    })
             })
             .collect()
     }

--- a/crates/selector4nix-core/src/domain/nar_file/service.rs
+++ b/crates/selector4nix-core/src/domain/nar_file/service.rs
@@ -50,7 +50,7 @@ impl NarFileService {
                 tracing::trace!(nar_file = %nar_file_name.value(), source_url = %location.source_url(), "use cached nar file location");
 
                 let locations = [location.clone()];
-                let outcome = self
+                let (outcome, _attempts) = self
                     .nar_stream_provider
                     .stream_nar(&locations, &headers)
                     .await;
@@ -77,7 +77,7 @@ impl NarFileService {
         candidates: Vec<NarFileLocation>,
         now: SystemTime,
     ) -> (NarFile, Result<NarStreamData, AppError>) {
-        let outcome = self
+        let (outcome, _attempts) = self
             .nar_stream_provider
             .stream_nar(&candidates, &headers)
             .await;

--- a/crates/selector4nix-core/src/infrastructure/provider/nar_stream_provider.rs
+++ b/crates/selector4nix-core/src/infrastructure/provider/nar_stream_provider.rs
@@ -9,7 +9,9 @@ use tokio::task::JoinSet;
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::common::url::Url;
 use crate::domain::nar_file::model::NarFileLocation;
-use crate::domain::nar_file::port::{NarStreamData, NarStreamHeaders, NarStreamProvider};
+use crate::domain::nar_file::port::{
+    NarStreamData, NarStreamHeaders, NarStreamOpenAttempt, NarStreamProvider,
+};
 use crate::infrastructure::config::AppCredential;
 
 pub struct ReqwestNarStreamProvider {
@@ -54,11 +56,14 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
         &self,
         locations: &[NarFileLocation],
         headers: &PassthroughHeaders,
-    ) -> AnyhowResult<Option<NarStreamData>> {
+    ) -> (
+        AnyhowResult<Option<NarStreamData>>,
+        Vec<NarStreamOpenAttempt>,
+    ) {
         tracing::debug!(urls = ?locations.iter().map(|l| l.source_url()).collect::<Vec<_>>(), "opening nar file streams from substituters");
 
         if locations.is_empty() {
-            return Ok(None);
+            return (Ok(None), Vec::new());
         }
 
         let mut set = JoinSet::new();
@@ -94,6 +99,7 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
         }
 
         let mut not_found_count = 0;
+        let mut attempts = Vec::new();
 
         while let Some(result) = set.join_next().await {
             let Ok((location, response)) = result else {
@@ -102,15 +108,30 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
             let url = location.source_url();
 
             match response {
-                Ok(Ok(response)) => return Self::wrap_ok_response(url.clone(), response),
+                Ok(Ok(response)) => {
+                    attempts.push(NarStreamOpenAttempt::Successful {
+                        source_url: url.clone(),
+                    });
+                    let response = Self::wrap_ok_response(url.clone(), response);
+                    return (response, attempts);
+                }
                 Ok(Err(StreamHttpBodyError::NotFound)) => {
                     not_found_count += 1;
+                    attempts.push(NarStreamOpenAttempt::Successful {
+                        source_url: url.clone(),
+                    });
                 }
                 Ok(Err(e)) => {
+                    attempts.push(NarStreamOpenAttempt::ServiceError {
+                        source_url: url.clone(),
+                    });
                     tracing::debug!(%url, error = %e, "failed to request nar from substituter");
                 }
                 Err(_) => {
                     if let Some(timeout) = location.timeout() {
+                        attempts.push(NarStreamOpenAttempt::Offline {
+                            source_url: url.clone(),
+                        });
                         tracing::debug!(%url, timeout_secs = %timeout.as_secs(), "timeout for requesting nar from substituter elapsed");
                     }
                 }
@@ -118,9 +139,10 @@ impl NarStreamProvider for ReqwestNarStreamProvider {
         }
 
         if not_found_count == locations.len() {
-            Ok(None)
+            (Ok(None), attempts)
         } else {
-            Err(anyhow::anyhow!("could not fetch nar from any substituter"))
+            let err = Err(anyhow::anyhow!("could not fetch nar from any substituter"));
+            (err, attempts)
         }
     }
 }

--- a/crates/selector4nix-core/tests/integration/mock/nar_stream_provider.rs
+++ b/crates/selector4nix-core/tests/integration/mock/nar_stream_provider.rs
@@ -7,7 +7,7 @@ use selector4nix_core::domain::common::passthrough_headers::PassthroughHeaders;
 use selector4nix_core::domain::common::url::Url;
 use selector4nix_core::domain::nar_file::model::NarFileLocation;
 use selector4nix_core::domain::nar_file::port::{
-    NarStreamData, NarStreamHeaders, NarStreamProvider,
+    NarStreamData, NarStreamHeaders, NarStreamOpenAttempt, NarStreamProvider,
 };
 
 pub struct MockNarStreamProvider {
@@ -37,7 +37,10 @@ impl NarStreamProvider for MockNarStreamProvider {
         &self,
         locations: &[NarFileLocation],
         _headers: &PassthroughHeaders,
-    ) -> AnyhowResult<Option<NarStreamData>> {
+    ) -> (
+        AnyhowResult<Option<NarStreamData>>,
+        Vec<NarStreamOpenAttempt>,
+    ) {
         {
             let mut contacted = self.contacted.lock().unwrap();
             for loc in locations {
@@ -45,7 +48,11 @@ impl NarStreamProvider for MockNarStreamProvider {
             }
         }
 
+        let mut attempts = Vec::new();
         for loc in locations {
+            attempts.push(NarStreamOpenAttempt::Successful {
+                source_url: loc.source_url().clone(),
+            });
             if self.success_urls.contains(loc.source_url()) {
                 let data = NarStreamData::new(
                     NarStreamHeaders {
@@ -56,9 +63,9 @@ impl NarStreamProvider for MockNarStreamProvider {
                     Box::pin(futures::stream::empty()),
                     loc.source_url().clone(),
                 );
-                return Ok(Some(data));
+                return (Ok(Some(data)), attempts);
             }
         }
-        Ok(None)
+        (Ok(None), attempts)
     }
 }

--- a/crates/selector4nix-core/tests/integration/nar_file_service_test.rs
+++ b/crates/selector4nix-core/tests/integration/nar_file_service_test.rs
@@ -51,7 +51,7 @@ async fn run_test(
     let provider = Arc::new(MockNarStreamProvider::new(env.success_urls));
     let service = NarFileService::new(provider.clone(), repo, Duration::from_secs(14400));
 
-    let (nar_file, result) = service
+    let (nar_file, result, _events) = service
         .stream(
             input.nar_file,
             PassthroughHeaders::empty(),

--- a/crates/selector4nix/src/bootstrap.rs
+++ b/crates/selector4nix/src/bootstrap.rs
@@ -277,6 +277,7 @@ pub async fn init_context(
     );
 
     let stream_nar_file_usecase = StreamNarFileUseCase::new(
+        substituter_registry.clone(),
         nar_file_registry.clone(),
         nar_info_repository.clone(),
         nar_transfer_metric.clone(),


### PR DESCRIPTION
When serving NAR streaming requests for clients, requests are sent to upstream substituters, so the proxy can know those substituters' status. Update each substituter's status more eagerly so that we don't just rely on periodically probing.