### PR TITLE
Fix stateful parameters preserving and forgetting NAR URL's query parameters from upstream on cache miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 - Added a temporary workaround for [harmonia](https://github.com/nix-community/harmonia) and other potential misbehaved servers when requesting NARs from them using chunked streaming. Harmonia won't respond correctly for such requests until [this fix](https://github.com/nix-community/harmonia/pull/1139) is merged.
 - Substituter's status is now updated after opening a NAR stream, if the response of the corresponding request to that substituter arrives.
 
+### Fixed
+
+- Fixed NAR request returning 404 when encountering cache miss after restart and the actual upstream NAR URL contains query parameters. This is because previously the query parameters were only stored in the proxy's memory and were hidden from the client. So the server couldn't remember the query parameters after cache invalidation. Now the original query parameters are encoded and returned to the client as a new parameter `upstream_query` within NAR info's `URL` field, so the proxy can reconstruct parameters from clients' requests even if it forgot them.
+
 ## [0.9.0] - 2026-08-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,7 +477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -787,7 +793,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1309,7 +1315,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1394,7 +1400,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1504,7 +1510,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1561,7 +1567,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1681,6 +1687,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "base64 0.23.1",
  "bytes",
  "dashmap",
  "futures",
@@ -2098,7 +2105,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2574,7 +2581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = "1.0.102"
 arc-swap = "1.9.1"
 async-trait = "0.1.89"
 axum = { version = "0.8.9", features = ["http2"] }
+base64 = "0.23.1"
 bytes = "1.11.1"
 clap = { version = "4", features = ["derive", "env"] }
 dashmap = "6.2.1"

--- a/crates/selector4nix-core/Cargo.toml
+++ b/crates/selector4nix-core/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = { workspace = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }

--- a/crates/selector4nix-core/src/application/actor/nar_file/runner.rs
+++ b/crates/selector4nix-core/src/application/actor/nar_file/runner.rs
@@ -7,6 +7,7 @@ use tokio::sync::oneshot::Sender as OneshotSender;
 use crate::AppError;
 use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
+use crate::domain::common::query_parameters::QueryParameters;
 use crate::domain::nar_file::model::{NarFile, NarFileKey, NarFileLocation};
 use crate::domain::nar_file::port::NarStreamData;
 use crate::domain::nar_file::{NarFileRepository, NarFileService, StreamNarFileEvent};
@@ -22,6 +23,7 @@ pub struct StreamNarFileResult {
 pub enum NarFileRequest {
     StreamNarFile {
         reply_to: OneshotSender<StreamNarFileResponse>,
+        upstream_query: Option<QueryParameters>,
         headers: PassthroughHeaders,
     },
     SetLocation {
@@ -88,11 +90,19 @@ impl Actor for NarFileActor {
         request: Self::Request,
     ) -> Option<Self::State> {
         match request {
-            NarFileRequest::StreamNarFile { reply_to, headers } => {
+            NarFileRequest::StreamNarFile {
+                reply_to,
+                upstream_query,
+                headers,
+            } => {
                 let now = SystemTime::now();
                 let state = state.check_expiry_and_update(now);
-                let (state, result, events) =
-                    self.nar_file_service.stream(state, headers, now).await;
+
+                let (state, result, events) = self
+                    .nar_file_service
+                    .stream(state, upstream_query, headers, now)
+                    .await;
+
                 let result = result.map(|stream| StreamNarFileResult {
                     stream,
                     substituter: state

--- a/crates/selector4nix-core/src/application/usecase/nar_file/stream.rs
+++ b/crates/selector4nix-core/src/application/usecase/nar_file/stream.rs
@@ -9,6 +9,7 @@ use futures::Stream;
 use crate::application::actor::nar_file::{NarFileActorRegistry, NarFileRequest};
 use crate::application::actor::substituter::{SubstituterActorRegistry, SubstituterRequest};
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
+use crate::domain::common::query_parameters::QueryParameters;
 use crate::domain::nar_file::StreamNarFileEvent;
 use crate::domain::nar_file::model::NarFileKey;
 use crate::domain::nar_file::port::NarStreamData;
@@ -42,6 +43,7 @@ impl StreamNarFileUseCase {
     pub async fn run(
         &self,
         key: NarFileKey,
+        upstream_query: Option<QueryParameters>,
         headers: PassthroughHeaders,
     ) -> Result<NarStreamData, AppError> {
         tracing::info!(nar_file = %key.to_file_name().value(), "acquiring nar stream from substituter");
@@ -49,7 +51,11 @@ impl StreamNarFileUseCase {
         let address = self.nar_file_registry.get(&key).await;
 
         let response = address
-            .ask(|reply_to| NarFileRequest::StreamNarFile { reply_to, headers })
+            .ask(|reply_to| NarFileRequest::StreamNarFile {
+                reply_to,
+                upstream_query,
+                headers,
+            })
             .await
             .throw_catastrophic("`NarFileActor` terminated unexpectedly")?;
 

--- a/crates/selector4nix-core/src/domain/common/mod.rs
+++ b/crates/selector4nix-core/src/domain/common/mod.rs
@@ -1,3 +1,4 @@
 pub mod expire_at;
 pub mod passthrough_headers;
+pub mod query_parameters;
 pub mod url;

--- a/crates/selector4nix-core/src/domain/common/query_parameters.rs
+++ b/crates/selector4nix-core/src/domain/common/query_parameters.rs
@@ -1,3 +1,9 @@
+use std::string::FromUtf8Error;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::{DecodeError, Engine};
+use snafu::{ResultExt, Snafu};
+
 use crate::domain::common::url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -20,5 +26,121 @@ impl QueryParameters {
 
     pub fn value(&self) -> &str {
         &self.0
+    }
+
+    pub fn encode(&self) -> String {
+        URL_SAFE_NO_PAD.encode(&self.0)
+    }
+
+    pub fn decode(encoded: &str) -> Result<Self, DecodeQueryParametersError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(encoded)
+            .context(InvalidEncodedSnafu)?;
+        let qp_str = String::from_utf8(bytes).context(InvalidUtf8Snafu)?;
+        let Some(qp) = Self::try_from_raw(&qp_str) else {
+            return EmptySnafu.fail();
+        };
+        Ok(qp)
+    }
+}
+
+#[derive(Debug, Snafu, Clone, PartialEq, Eq)]
+pub enum DecodeQueryParametersError {
+    #[snafu(display("the encoded query parameter is not valid URL-safe Base64 string"))]
+    InvalidEncoded { source: DecodeError },
+    #[snafu(display("the decoded query parameter is not valid UTF-8 string"))]
+    InvalidUtf8 { source: FromUtf8Error },
+    #[snafu(display("the decoded query parameter should not be empty"))]
+    Empty,
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    use crate::domain::common::url::Url;
+
+    use super::*;
+
+    #[test]
+    fn try_extract_returns_none_given_url_without_query() {
+        let url = Url::new("https://example.com/nar/abc.nar.xz").unwrap();
+        assert!(QueryParameters::try_extract(&url).is_none());
+    }
+
+    #[test]
+    fn try_extract_returns_query_preserving_multiple_params() {
+        let url = Url::new(
+            "https://storage.example.com/nar/abc.nar.xz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=f776",
+        )
+        .unwrap();
+        let qp = QueryParameters::try_extract(&url).unwrap();
+        assert_eq!(
+            qp.value(),
+            "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=f776"
+        );
+    }
+
+    #[test]
+    fn try_from_raw_returns_none_given_empty_or_whitespace() {
+        assert!(QueryParameters::try_from_raw("").is_none());
+        assert!(QueryParameters::try_from_raw("   ").is_none());
+        assert!(QueryParameters::try_from_raw("\t\n").is_none());
+    }
+
+    #[test]
+    fn try_from_raw_normalizes_value() {
+        let qp = QueryParameters::try_from_raw("  a=1&name=café world  ").unwrap();
+        assert_eq!(qp.value(), "a=1&name=caf%C3%A9%20world");
+    }
+
+    #[test]
+    fn encode_decode_round_trips() {
+        let simple = QueryParameters::try_from_raw("a=1").unwrap();
+        assert_eq!(simple.encode(), "YT0x");
+        assert_eq!(QueryParameters::decode("YT0x").unwrap(), simple);
+
+        let qp =
+            QueryParameters::try_from_raw("X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=f776")
+                .unwrap();
+        assert_eq!(QueryParameters::decode(&qp.encode()).unwrap(), qp);
+    }
+
+    #[test]
+    fn decode_returns_invalid_encoded_error_given_non_base64() {
+        assert!(matches!(
+            QueryParameters::decode("not@valid"),
+            Err(DecodeQueryParametersError::InvalidEncoded { .. }),
+        ));
+    }
+
+    #[test]
+    fn decode_returns_invalid_utf8_error_given_non_utf8_bytes() {
+        let encoded = URL_SAFE_NO_PAD.encode([0xFF_u8, 0xFE]);
+        assert!(matches!(
+            QueryParameters::decode(&encoded),
+            Err(DecodeQueryParametersError::InvalidUtf8 { .. }),
+        ));
+    }
+
+    #[test]
+    fn decode_returns_empty_error_given_empty_or_whitespace_payload() {
+        assert!(matches!(
+            QueryParameters::decode(""),
+            Err(DecodeQueryParametersError::Empty),
+        ));
+        let encoded = URL_SAFE_NO_PAD.encode("   ");
+        assert!(matches!(
+            QueryParameters::decode(&encoded),
+            Err(DecodeQueryParametersError::Empty),
+        ));
+    }
+
+    #[test]
+    fn decode_normalizes_value_via_try_from_raw() {
+        let encoded = URL_SAFE_NO_PAD.encode("a=b c");
+        let qp = QueryParameters::decode(&encoded).unwrap();
+        assert_eq!(qp.value(), "a=b%20c");
     }
 }

--- a/crates/selector4nix-core/src/domain/common/query_parameters.rs
+++ b/crates/selector4nix-core/src/domain/common/query_parameters.rs
@@ -5,6 +5,7 @@ use base64::{DecodeError, Engine};
 use snafu::{ResultExt, Snafu};
 
 use crate::domain::common::url::Url;
+use crate::{AppError, AppErrorKind};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QueryParameters(String);
@@ -52,6 +53,12 @@ pub enum DecodeQueryParametersError {
     InvalidUtf8 { source: FromUtf8Error },
     #[snafu(display("the decoded query parameter should not be empty"))]
     Empty,
+}
+
+impl From<DecodeQueryParametersError> for AppError {
+    fn from(error: DecodeQueryParametersError) -> Self {
+        Self::new(AppErrorKind::Input, error)
+    }
 }
 
 #[cfg(test)]

--- a/crates/selector4nix-core/src/domain/common/query_parameters.rs
+++ b/crates/selector4nix-core/src/domain/common/query_parameters.rs
@@ -1,0 +1,24 @@
+use crate::domain::common::url::Url;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueryParameters(String);
+
+impl QueryParameters {
+    pub fn try_extract(url: &Url) -> Option<Self> {
+        url.inner().query().map(|qp| Self(qp.into()))
+    }
+
+    pub fn try_from_raw(raw: &str) -> Option<Self> {
+        let raw = raw.trim();
+        if !raw.is_empty() {
+            // Use `url::Url::set_query()` to encode the raw string to safe URL string.
+            Self::try_extract(&Url::new(&format!("https://example.com/?{raw}")).ok()?)
+        } else {
+            None
+        }
+    }
+
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}

--- a/crates/selector4nix-core/src/domain/common/url.rs
+++ b/crates/selector4nix-core/src/domain/common/url.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu, ensure};
 use url::{ParseError, Url as UrlInner};
 
-use crate::{AppError, AppErrorKind};
+use crate::{AppError, AppErrorKind, domain::common::query_parameters::QueryParameters};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Url(UrlInner);
@@ -22,8 +22,8 @@ impl Url {
         Ok(Self(parsed))
     }
 
-    pub fn with_query_params(mut self, query_params: Option<&str>) -> Self {
-        self.0.set_query(query_params);
+    pub fn with_query_params(mut self, query_params: Option<&QueryParameters>) -> Self {
+        self.0.set_query(query_params.map(|qp| qp.value()));
         self
     }
 

--- a/crates/selector4nix-core/src/domain/nar_file/service.rs
+++ b/crates/selector4nix-core/src/domain/nar_file/service.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, SystemTime};
 
 use crate::domain::common::expire_at::ExpireAt;
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
+use crate::domain::common::query_parameters::QueryParameters;
 use crate::domain::common::url::Url;
 use crate::domain::nar_file::model::{NarFile, NarFileLocation};
 use crate::domain::nar_file::port::{NarStreamData, NarStreamOpenAttempt, NarStreamProvider};
@@ -40,6 +41,7 @@ impl NarFileService {
     pub async fn stream(
         &self,
         nar_file: NarFile,
+        upstream_query: Option<QueryParameters>,
         headers: PassthroughHeaders,
         now: SystemTime,
     ) -> (
@@ -62,7 +64,10 @@ impl NarFileService {
             {
                 tracing::trace!(nar_file = %nar_file_name.value(), source_url = %location.source_url(), "use cached nar file location");
 
+                // `upstream_query` is unused here because `source_url` in `location` already
+                // contains those query parameters.
                 let locations = [location.clone()];
+
                 let (outcome, attempts) = self
                     .nar_stream_provider
                     .stream_nar(&locations, &headers)
@@ -79,7 +84,9 @@ impl NarFileService {
             tracing::trace!(nar_file = %nar_file_name.value(), "query all substituters for nar file location");
         }
 
-        let candidates = self.build_candidates_from_all(&nar_file_name).await;
+        let candidates = self
+            .build_candidates_from_all(&nar_file_name, upstream_query)
+            .await;
         self.stream_from_all(nar_file, headers, candidates, now)
             .await
     }
@@ -131,13 +138,23 @@ impl NarFileService {
         }
     }
 
-    async fn build_candidates_from_all(&self, nar_file_name: &NarFileName) -> Vec<NarFileLocation> {
+    async fn build_candidates_from_all(
+        &self,
+        nar_file_name: &NarFileName,
+        upstream_query: Option<QueryParameters>,
+    ) -> Vec<NarFileLocation> {
         self.substituter_repository
             .query_all_available()
             .await
             .iter()
             .map(|sub| {
-                let source_url = nar_file_name.with_storage_prefix(sub.meta().storage_url());
+                // Since we are concatenating all substituters with the NAR file name manually,
+                // the original query parameters (if exist) are lost, so we need to append these
+                // parameters. These parameters may only make sense to a portion of substituters,
+                // but it should have no impact on other substituters, so append unconditionally.
+                let source_url = nar_file_name
+                    .with_storage_prefix(sub.meta().storage_url())
+                    .with_query_params(upstream_query.as_ref());
                 let timeout = sub.meta().nar_timeout();
                 NarFileLocation::new(source_url, sub.meta().clone(), timeout)
             })

--- a/crates/selector4nix-core/src/domain/nar_info/model/proxy_nar_info_data.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/model/proxy_nar_info_data.rs
@@ -13,6 +13,8 @@ pub struct ProxyNarInfoData {
 }
 
 impl ProxyNarInfoData {
+    pub const UPSTREAM_QUERY_KEY: &'static str = "upstream_query";
+
     pub fn proxy_by_keep_url(
         upstream_data: &UpstreamNarInfoData,
         substituter: &SubstituterMeta,
@@ -29,10 +31,19 @@ impl ProxyNarInfoData {
         upstream_data: &UpstreamNarInfoData,
         substituter: &SubstituterMeta,
     ) -> (Self, Url) {
+        let maybe_query_params = if let Some(qp) = upstream_data.query_params() {
+            format!("?{}={}", Self::UPSTREAM_QUERY_KEY, qp.encode())
+        } else {
+            String::new()
+        };
         let proxy_data = Self {
             content: Self::replace_url(
                 upstream_data.content(),
-                &format!("nar/{}", upstream_data.nar_file().value()),
+                &format!(
+                    "nar/{}{}",
+                    upstream_data.nar_file().value(),
+                    maybe_query_params
+                ),
             ),
             nar_file: upstream_data.nar_file().clone(),
         };
@@ -84,6 +95,7 @@ impl ProxyNarInfoData {
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::common::query_parameters::QueryParameters;
     use crate::domain::nar_info::model::test_support::STORE_PATH_HASH_RUBY;
     use crate::domain::substituter::model::test_support::{DEFAULT_URL, make_substituter_meta};
 
@@ -138,13 +150,17 @@ mod tests {
     }
 
     #[test]
-    fn to_self_strips_query_param_given_relative_url() {
+    fn to_self_encodes_query_param_given_relative_url() {
         let (proxy, nar_source_url) = ProxyNarInfoData::proxy_by_rewrite_url_to_self(
             &make_upstream_relative(),
             &make_substituter_meta(),
         );
         assert_eq!(proxy.nar_file().value(), "abc.nar.xz");
-        assert!(proxy.content().contains("URL: nar/abc.nar.xz\n"));
+        assert!(proxy.content().contains(&format!(
+            "URL: nar/abc.nar.xz?{}={}\n",
+            ProxyNarInfoData::UPSTREAM_QUERY_KEY,
+            QueryParameters::try_from_raw("query=abc").unwrap().encode(),
+        )));
         assert_eq!(
             nar_source_url.value(),
             &format!("{DEFAULT_URL}/nar/abc.nar.xz?query=abc")

--- a/crates/selector4nix-core/src/domain/nar_info/model/upstream_nar_info_data.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/model/upstream_nar_info_data.rs
@@ -1,6 +1,7 @@
 use getset::Getters;
 use snafu::{OptionExt, ResultExt, Snafu};
 
+use crate::domain::common::query_parameters::QueryParameters;
 use crate::domain::common::url::Url;
 use crate::domain::nar_info::model::{NarFileName, TryNewNarFileNameError};
 use crate::{AppError, AppErrorKind};
@@ -12,7 +13,7 @@ pub struct UpstreamNarInfoData {
     #[getset(get = "pub")]
     nar_file: NarFileName,
     nar_source_url: Option<Url>,
-    query_params: Option<String>,
+    query_params: Option<QueryParameters>,
 }
 
 impl UpstreamNarInfoData {
@@ -34,7 +35,7 @@ impl UpstreamNarInfoData {
                 .unwrap_or("")
                 .to_string();
             let nar_file = NarFileName::new(nar_file).context(InvalidNarFileNameSnafu)?;
-            let query_params = nar_source_url.inner().query().map(ToString::to_string);
+            let query_params = QueryParameters::try_extract(&nar_source_url);
             (nar_file, Some(nar_source_url), query_params)
         } else {
             let (nar_path, query_params) = raw_url.split_once('?').unwrap_or((raw_url, ""));
@@ -43,7 +44,7 @@ impl UpstreamNarInfoData {
                 .map_or(nar_path, |pos| &nar_path[pos + 1..])
                 .to_string();
             let nar_file = NarFileName::new(nar_file).context(InvalidNarFileNameSnafu)?;
-            let query_params = (!query_params.is_empty()).then(|| query_params.to_string());
+            let query_params = QueryParameters::try_from_raw(query_params);
             (nar_file, None, query_params)
         };
 
@@ -59,8 +60,8 @@ impl UpstreamNarInfoData {
         self.nar_source_url.as_ref()
     }
 
-    pub fn query_params(&self) -> Option<&str> {
-        self.query_params.as_deref()
+    pub fn query_params(&self) -> Option<&QueryParameters> {
+        self.query_params.as_ref()
     }
 }
 
@@ -81,7 +82,10 @@ impl From<TryUpstreamNewNarInfoData> for AppError {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::nar_info::model::test_support::make_upstream_nar_info_data_with_url;
+    use crate::domain::{
+        common::query_parameters::QueryParameters,
+        nar_info::model::test_support::make_upstream_nar_info_data_with_url,
+    };
 
     #[test]
     fn source_url_is_some_given_absolute_url() {
@@ -104,7 +108,10 @@ mod tests {
         let data = make_upstream_nar_info_data_with_url("nar/abc.nar.xz?X-Amz-Signature=abc123");
         assert_eq!(data.nar_file().value(), "abc.nar.xz");
         assert!(data.nar_source_url().is_none());
-        assert_eq!(data.query_params(), Some("X-Amz-Signature=abc123"));
+        assert_eq!(
+            data.query_params(),
+            QueryParameters::try_from_raw("X-Amz-Signature=abc123").as_ref(),
+        );
     }
 
     #[test]

--- a/crates/selector4nix-core/tests/integration/nar_file_service_test.rs
+++ b/crates/selector4nix-core/tests/integration/nar_file_service_test.rs
@@ -54,6 +54,7 @@ async fn run_test(
     let (nar_file, result, _events) = service
         .stream(
             input.nar_file,
+            None,
             PassthroughHeaders::empty(),
             SystemTime::now(),
         )

--- a/crates/selector4nix-web/src/api/nar.rs
+++ b/crates/selector4nix-web/src/api/nar.rs
@@ -21,7 +21,7 @@ pub async fn get_nar(
     let key = NarFileKey::from_file_name(&nar_file);
 
     let headers = PassthroughHeaders::extract(headers).proxyed();
-    let data = ctx.stream_nar_file_usecase.run(key, headers).await?;
+    let data = ctx.stream_nar_file_usecase.run(key, None, headers).await?;
     Ok(build_response(data))
 }
 

--- a/crates/selector4nix-web/src/api/nar.rs
+++ b/crates/selector4nix-web/src/api/nar.rs
@@ -1,27 +1,42 @@
 use std::sync::Arc;
 
 use axum::body::Body;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use futures::StreamExt;
 use http::{HeaderMap, Response, header};
 use selector4nix_core::AppContext;
 use selector4nix_core::domain::common::passthrough_headers::PassthroughHeaders;
+use selector4nix_core::domain::common::query_parameters::QueryParameters;
 use selector4nix_core::domain::nar_file::model::NarFileKey;
 use selector4nix_core::domain::nar_file::port::NarStreamData;
 use selector4nix_core::domain::nar_info::model::NarFileName;
+use serde::Deserialize;
 
 use crate::WebAppError;
+
+#[derive(Debug, Deserialize)]
+pub struct GetNarQueryParameters {
+    upstream_query: Option<String>,
+}
 
 pub async fn get_nar(
     State(ctx): State<Arc<AppContext>>,
     Path(path): Path<String>,
+    Query(GetNarQueryParameters { upstream_query }): Query<GetNarQueryParameters>,
     headers: HeaderMap,
 ) -> Result<Response<Body>, WebAppError> {
     let nar_file = NarFileName::new(path)?;
     let key = NarFileKey::from_file_name(&nar_file);
 
+    let upstream_query = upstream_query
+        .map(|qp| QueryParameters::decode(&qp))
+        .transpose()?;
+
     let headers = PassthroughHeaders::extract(headers).proxyed();
-    let data = ctx.stream_nar_file_usecase.run(key, None, headers).await?;
+    let data = ctx
+        .stream_nar_file_usecase
+        .run(key, upstream_query, headers)
+        .await?;
     Ok(build_response(data))
 }
 


### PR DESCRIPTION
Closes #162

When a client sends a cache-missed NAR request whose corresponding real upstream URL contains query parameters, the proxy can't remember those query parameters and no fallback upstream request will succeed due to lack of critical parameters. Such issue occurs when the proxy restarts without a persistent cache, or the NAR entry expires, etc.. In a word, the current way the proxy keeps those query parameters is stateful and prone to cache invalidation.

This PR make preserving query parameters stateless by passing them to clients and let clients provide them when requesting NARs. So the proxy can reconstruct the upstream query parameters, which frees the proxy from managing and "predicting" too many states.