### PR TITLE
Refactor by enforcing invariants of parsing NAR query parameters

### DIFF
--- a/crates/selector4nix-core/src/domain/common/query_parameters.rs
+++ b/crates/selector4nix-core/src/domain/common/query_parameters.rs
@@ -12,7 +12,10 @@ pub struct QueryParameters(String);
 
 impl QueryParameters {
     pub fn try_extract(url: &Url) -> Option<Self> {
-        url.inner().query().map(|qp| Self(qp.into()))
+        url.inner()
+            .query()
+            .filter(|qp| !qp.is_empty())
+            .map(|qp| Self(qp.into()))
     }
 
     pub fn try_from_raw(raw: &str) -> Option<Self> {
@@ -73,6 +76,9 @@ mod tests {
     #[test]
     fn try_extract_returns_none_given_url_without_query() {
         let url = Url::new("https://example.com/nar/abc.nar.xz").unwrap();
+        assert!(QueryParameters::try_extract(&url).is_none());
+
+        let url = Url::new("https://example.com/nar/abc.nar.xz?").unwrap();
         assert!(QueryParameters::try_extract(&url).is_none());
     }
 

--- a/crates/selector4nix-web/src/api/nar.rs
+++ b/crates/selector4nix-web/src/api/nar.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -9,27 +10,22 @@ use selector4nix_core::domain::common::passthrough_headers::PassthroughHeaders;
 use selector4nix_core::domain::common::query_parameters::QueryParameters;
 use selector4nix_core::domain::nar_file::model::NarFileKey;
 use selector4nix_core::domain::nar_file::port::NarStreamData;
-use selector4nix_core::domain::nar_info::model::NarFileName;
-use serde::Deserialize;
+use selector4nix_core::domain::nar_info::model::{NarFileName, ProxyNarInfoData};
 
 use crate::WebAppError;
-
-#[derive(Debug, Deserialize)]
-pub struct GetNarQueryParameters {
-    upstream_query: Option<String>,
-}
 
 pub async fn get_nar(
     State(ctx): State<Arc<AppContext>>,
     Path(path): Path<String>,
-    Query(GetNarQueryParameters { upstream_query }): Query<GetNarQueryParameters>,
+    Query(query): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Result<Response<Body>, WebAppError> {
     let nar_file = NarFileName::new(path)?;
     let key = NarFileKey::from_file_name(&nar_file);
 
-    let upstream_query = upstream_query
-        .map(|qp| QueryParameters::decode(&qp))
+    let upstream_query = query
+        .get(ProxyNarInfoData::UPSTREAM_QUERY_KEY)
+        .map(|qp| QueryParameters::decode(qp))
         .transpose()?;
 
     let headers = PassthroughHeaders::extract(headers).proxyed();


### PR DESCRIPTION
Replace hardcoded query parameter `upstream_query` with a predefined constant.

Don't allow empty query parameter when extracting it from a URL.