### PR TITLE
feat: add proxy.resolution_policy for tiered substituter querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 - Added `/{storePathHash}.ls` endpoint, which lists the recursive directory structure of a particular store path.
 - Added the `substituters[].max_concurrent_requests` configuration option to override the per-host NAR streaming concurrency limit per substituter, useful for upstream servers that fail under high concurrency.
+- Added the `proxy.resolution_policy` configuration option. Setting it to `"tier"` queries substituters in strict priority tiers instead of all at once: substituters sharing a priority value still race against each other, but lower-priority substituters are only queried when every higher-priority tier lacks the NAR info. Useful for keeping traffic on preferred mirrors (e.g. region-local ones) and saving upstream bandwidth. The default `"preference"` keeps the existing behavior.
 
 ## [0.9.1] - 2026-08-15
 

--- a/crates/selector4nix-core/src/application/usecase/dashboard/get_config_summary.rs
+++ b/crates/selector4nix-core/src/application/usecase/dashboard/get_config_summary.rs
@@ -50,7 +50,7 @@ impl GetDashboardConfigSummaryUseCase {
             entries: vec![
                 ConfigSummaryEntryData {
                     name: "Tolerance",
-                    description: "Latency tolerance window in milliseconds per unit of difference of priority between two substituters.",
+                    description: "Latency tolerance window in milliseconds per unit of difference of priority between two substituters. Only effective under the `preference` resolution policy.",
                     value: format!("{}ms", cfg.tolerance),
                 },
                 ConfigSummaryEntryData {
@@ -116,6 +116,11 @@ impl GetDashboardConfigSummaryUseCase {
                         NarUrlRewriteOption::ToUpstream => "upstream",
                     }
                     .to_string(),
+                },
+                ConfigSummaryEntryData {
+                    name: "Resolution policy",
+                    description: "How substituters are queried for NAR info: `preference` races all substituters and picks the winner by preference; `tier` queries priority tiers one after another, keeping traffic on preferred substituters.",
+                    value: cfg.resolution_policy.as_str_value().to_string(),
                 },
             ],
         }

--- a/crates/selector4nix-core/src/domain/nar_info/mod.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/mod.rs
@@ -1,4 +1,5 @@
 pub mod model;
+pub mod policy;
 pub mod port;
 
 mod repository;
@@ -6,6 +7,8 @@ mod service;
 mod util;
 
 pub use repository::NarInfoRepository;
-pub use service::{NarInfoService, ResolveNarInfoEvent};
+pub use service::{
+    NarInfoResolutionPolicy, NarInfoService, ResolutionPolicyOption, ResolveNarInfoEvent,
+};
 
 use util::DeadlineGroup;

--- a/crates/selector4nix-core/src/domain/nar_info/policy/mod.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/policy/mod.rs
@@ -1,0 +1,5 @@
+mod preference;
+mod tier;
+
+pub use preference::PreferencePolicy;
+pub use tier::TierPolicy;

--- a/crates/selector4nix-core/src/domain/nar_info/policy/preference.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/policy/preference.rs
@@ -1,0 +1,187 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::task::JoinSet;
+use tokio::time::Instant;
+
+use crate::AppError;
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
+use crate::domain::nar_info::DeadlineGroup;
+use crate::domain::nar_info::model::{StorePathHash, UpstreamNarInfoData};
+use crate::domain::nar_info::port::NarInfoProvider;
+use crate::domain::nar_info::service::{
+    NarInfoResolutionPolicy, QueryOutcome, ResolveNarInfoEvent, indeterminate_existence_error,
+    query_substituter,
+};
+use crate::domain::substituter::SubstituterCandidate;
+use crate::domain::substituter::model::SubstituterMeta;
+
+pub struct PreferencePolicy {
+    provider: Arc<dyn NarInfoProvider>,
+    tolerance: Duration,
+    ignore_query_error: bool,
+}
+
+impl PreferencePolicy {
+    pub fn new(
+        provider: Arc<dyn NarInfoProvider>,
+        tolerance: Duration,
+        ignore_query_error: bool,
+    ) -> Self {
+        Self {
+            provider,
+            tolerance,
+            ignore_query_error,
+        }
+    }
+}
+
+#[async_trait]
+impl NarInfoResolutionPolicy for PreferencePolicy {
+    async fn resolve(
+        &self,
+        hash: &StorePathHash,
+        headers: &PassthroughHeaders,
+        substituters: Arc<Vec<SubstituterCandidate>>,
+    ) -> (
+        Result<Option<(UpstreamNarInfoData, SubstituterMeta)>, AppError>,
+        Vec<ResolveNarInfoEvent>,
+    ) {
+        let tolerance = self.tolerance.as_millis() as i64;
+        let headers = Arc::new(headers.clone());
+        let mut substituter_graces = HashMap::new();
+        for substituter in substituters.iter() {
+            substituter_graces.insert(substituter, substituter.grace(tolerance));
+        }
+
+        let start = Instant::now();
+        let mut query_tracker = JoinSet::new();
+        let mut query_cancellers = HashMap::new();
+        let mut query_deadlines: DeadlineGroup<&SubstituterCandidate> = DeadlineGroup::new();
+
+        for substituter in substituters.iter() {
+            let handle = query_tracker.spawn({
+                let provider = Arc::clone(&self.provider);
+                let sub = substituter.clone();
+                let headers = Arc::clone(&headers);
+                let hash = hash.clone();
+                async move {
+                    let (outcome, event) =
+                        query_substituter(provider.as_ref(), &hash, headers.as_ref(), &sub).await;
+                    (sub, outcome, event)
+                }
+            });
+            query_cancellers.insert(substituter, handle);
+        }
+
+        let mut has_error = false;
+        let mut events = Vec::new();
+        let mut optimal = None;
+        loop {
+            let query_res = tokio::select! {
+                Some(substituter) = query_deadlines.wait_earliest(), if !query_deadlines.is_empty() => {
+                    tracing::trace!(hash = %hash.value(), substituter = %substituter.url(), elapsed = ?start.elapsed(), "prune substituter query");
+                    if let Some(canceller) = query_cancellers.remove(substituter) {
+                        canceller.abort()
+                    };
+                    query_deadlines.remove(substituter);
+                    substituter_graces.remove(substituter);
+                    continue;
+                }
+                res = query_tracker.join_next() => res,
+            };
+
+            match query_res {
+                Some(Ok((substituter, outcome, event))) => {
+                    query_cancellers.remove(&substituter);
+                    query_deadlines.remove(&substituter);
+                    match outcome {
+                        QueryOutcome::Responded(data) => {
+                            // A pruned substituter's late response contributes nothing.
+                            let Some(current_grace) = substituter_graces.remove(&substituter)
+                            else {
+                                continue;
+                            };
+                            events.extend(event);
+                            if let Some(data) = data {
+                                let current = NarInfoQueryCandidate {
+                                    substituter,
+                                    nar_info: data.upstream_data,
+                                    grace: current_grace,
+                                    latency: data.latency,
+                                };
+                                update_optimal_and_deadlines(
+                                    current,
+                                    &mut optimal,
+                                    start,
+                                    &mut query_deadlines,
+                                    &substituter_graces,
+                                    hash.value(),
+                                );
+                            }
+                        }
+                        QueryOutcome::Offline => {
+                            substituter_graces.remove(&substituter);
+                            events.extend(event);
+                        }
+                        QueryOutcome::Error => {
+                            substituter_graces.remove(&substituter);
+                            if !self.ignore_query_error {
+                                has_error = true;
+                            }
+                            events.extend(event);
+                        }
+                    }
+                }
+                Some(Err(_)) => (),
+                None => break,
+            }
+        }
+
+        match optimal {
+            Some(optimal) => {
+                let meta = optimal.substituter.meta().clone();
+                (Ok(Some((optimal.nar_info, meta))), events)
+            }
+            None if !has_error => (Ok(None), events),
+            None => (Err(indeterminate_existence_error()), events),
+        }
+    }
+}
+
+struct NarInfoQueryCandidate {
+    substituter: SubstituterCandidate,
+    nar_info: UpstreamNarInfoData,
+    grace: i64,
+    latency: Duration,
+}
+
+impl NarInfoQueryCandidate {
+    fn calc_preference(&self) -> i64 {
+        self.grace - self.latency.as_millis() as i64
+    }
+}
+
+fn update_optimal_and_deadlines<'a>(
+    current: NarInfoQueryCandidate,
+    optimal: &mut Option<NarInfoQueryCandidate>,
+    start: Instant,
+    deadlines: &mut DeadlineGroup<&'a SubstituterCandidate>,
+    graces: &HashMap<&'a SubstituterCandidate, i64>,
+    hash: &str,
+) {
+    match optimal {
+        Some(prev) if prev.calc_preference() > current.calc_preference() => (),
+        _ => {
+            tracing::trace!(%hash, substituter = %current.substituter.url().value(), preference = %current.calc_preference(), latency = ?current.latency, elapsed = ?start.elapsed(), "update optimal candidate");
+            for (substituter, grace) in graces {
+                let max_latency = 0.max(grace - current.calc_preference()) as u64;
+                let deadline = start + Duration::from_millis(max_latency);
+                deadlines.insert_or_set_earlier(substituter, deadline);
+            }
+            *optimal = Some(current);
+        }
+    }
+}

--- a/crates/selector4nix-core/src/domain/nar_info/policy/tier.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/policy/tier.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
+
+use crate::AppError;
+use crate::domain::common::passthrough_headers::PassthroughHeaders;
+use crate::domain::nar_info::model::{StorePathHash, UpstreamNarInfoData};
+use crate::domain::nar_info::port::NarInfoProvider;
+use crate::domain::nar_info::service::{
+    NarInfoResolutionPolicy, QueryOutcome, ResolveNarInfoEvent, indeterminate_existence_error,
+    query_substituter,
+};
+use crate::domain::substituter::SubstituterCandidate;
+use crate::domain::substituter::model::SubstituterMeta;
+
+pub struct TierPolicy {
+    provider: Arc<dyn NarInfoProvider>,
+    ignore_query_error: bool,
+}
+
+impl TierPolicy {
+    pub fn new(provider: Arc<dyn NarInfoProvider>, ignore_query_error: bool) -> Self {
+        Self {
+            provider,
+            ignore_query_error,
+        }
+    }
+    async fn query_tier(
+        &self,
+        hash: &StorePathHash,
+        headers: &PassthroughHeaders,
+        tier: Vec<&SubstituterCandidate>,
+    ) -> (TierOutcome, Vec<ResolveNarInfoEvent>) {
+        let headers = Arc::new(headers.clone());
+        let mut queries = FuturesUnordered::new();
+        for substituter in tier {
+            let sub = substituter.clone();
+            let provider = Arc::clone(&self.provider);
+            let headers = Arc::clone(&headers);
+            let hash = hash.clone();
+            queries.push(async move {
+                let (outcome, event) =
+                    query_substituter(provider.as_ref(), &hash, headers.as_ref(), &sub).await;
+                (sub, outcome, event)
+            });
+        }
+
+        let mut events = Vec::new();
+        let mut has_error = false;
+        while let Some((substituter, outcome, event)) = queries.next().await {
+            events.extend(event);
+            if let QueryOutcome::Responded(Some(data)) = outcome {
+                // Dropping the stream aborts the remaining tier queries.
+                return (
+                    TierOutcome::Found(data.upstream_data, substituter.meta().clone()),
+                    events,
+                );
+            }
+            if matches!(outcome, QueryOutcome::Error) {
+                has_error = true;
+            }
+        }
+
+        if has_error && !self.ignore_query_error {
+            (TierOutcome::Error, events)
+        } else {
+            (TierOutcome::NotFound, events)
+        }
+    }
+}
+
+#[async_trait]
+impl NarInfoResolutionPolicy for TierPolicy {
+    async fn resolve(
+        &self,
+        hash: &StorePathHash,
+        headers: &PassthroughHeaders,
+        substituters: Arc<Vec<SubstituterCandidate>>,
+    ) -> (
+        Result<Option<(UpstreamNarInfoData, SubstituterMeta)>, AppError>,
+        Vec<ResolveNarInfoEvent>,
+    ) {
+        let mut all_events = Vec::new();
+        let mut sticky_error = false;
+
+        for tier in group_by_priority(&substituters) {
+            let tier_priority = tier[0].priority().value();
+            tracing::trace!(hash = %hash.value(), tier_priority, tier_len = tier.len(), "querying priority tier");
+            let (outcome, events) = self.query_tier(hash, headers, tier).await;
+            all_events.extend(events);
+            match outcome {
+                TierOutcome::Found(data, meta) => {
+                    tracing::trace!(hash = %hash.value(), tier_priority, "tier found nar info");
+                    return (Ok(Some((data, meta))), all_events);
+                }
+                TierOutcome::NotFound => {
+                    tracing::trace!(hash = %hash.value(), tier_priority, "tier exhausted with not-found or ignorable errors, falling to next tier");
+                }
+                TierOutcome::Error => {
+                    tracing::trace!(hash = %hash.value(), tier_priority, "tier exhausted with errors, falling to next tier");
+                    sticky_error = true;
+                }
+            }
+        }
+
+        if sticky_error {
+            (Err(indeterminate_existence_error()), all_events)
+        } else {
+            (Ok(None), all_events)
+        }
+    }
+}
+
+enum TierOutcome {
+    Found(UpstreamNarInfoData, SubstituterMeta),
+    NotFound,
+    Error,
+}
+fn group_by_priority(substituters: &[SubstituterCandidate]) -> Vec<Vec<&SubstituterCandidate>> {
+    let mut sorted = substituters.iter().collect::<Vec<_>>();
+    sorted.sort_by_key(|s| s.priority().value());
+    let mut tiers: Vec<Vec<&SubstituterCandidate>> = Vec::new();
+    for sub in sorted {
+        match tiers.last_mut() {
+            Some(tier) if tier[0].priority() == sub.priority() => tier.push(sub),
+            _ => tiers.push(vec![sub]),
+        }
+    }
+    tiers
+}

--- a/crates/selector4nix-core/src/domain/nar_info/service.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/service.rs
@@ -1,43 +1,34 @@
-use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
-use tokio::task::JoinSet;
-use tokio::time::Instant;
+use async_trait::async_trait;
 
 use crate::AppError;
 use crate::domain::common::passthrough_headers::PassthroughHeaders;
 use crate::domain::common::url::Url;
-use crate::domain::nar_info::DeadlineGroup;
 use crate::domain::nar_info::model::{
     NarFileName, NarInfoResolution, NarUrlRewriteOption, StorePathHash, UpstreamNarInfoData,
 };
-use crate::domain::nar_info::port::{NarInfoProvider, QueryNarInfoError};
+use crate::domain::nar_info::port::{NarInfoProvider, NarInfoQueryData, QueryNarInfoError};
+use crate::domain::substituter::SubstituterCandidate;
+use crate::domain::substituter::SubstituterRepository;
 use crate::domain::substituter::model::SubstituterMeta;
-use crate::domain::substituter::{SubstituterCandidate, SubstituterRepository};
 
 pub struct NarInfoService {
-    nar_info_provider: Arc<dyn NarInfoProvider>,
+    resolution_policy: Arc<dyn NarInfoResolutionPolicy>,
     substituter_repository: Arc<dyn SubstituterRepository>,
     rewrite_nar_url: NarUrlRewriteOption,
-    tolerance: u64,
-    ignore_query_error: bool,
 }
 
 impl NarInfoService {
     pub fn new(
-        nar_info_provider: Arc<dyn NarInfoProvider>,
+        resolution_policy: Arc<dyn NarInfoResolutionPolicy>,
         substituter_repository: Arc<dyn SubstituterRepository>,
         rewrite_nar_url: NarUrlRewriteOption,
-        tolerance: u64,
-        ignore_query_error: bool,
     ) -> Self {
         Self {
-            nar_info_provider,
+            resolution_policy,
             substituter_repository,
             rewrite_nar_url,
-            tolerance,
-            ignore_query_error,
         }
     }
 
@@ -89,126 +80,9 @@ impl NarInfoService {
     ) {
         let substituters = self.substituter_repository.query_all_available().await;
 
-        let (res, events) = self
-            .query_substituters(hash, headers, substituters, self.tolerance)
-            .await;
-        (res, events)
-    }
-
-    async fn query_substituters(
-        &self,
-        hash: &StorePathHash,
-        headers: PassthroughHeaders,
-        substituters: Arc<Vec<SubstituterCandidate>>,
-        tolerance: u64,
-    ) -> (
-        Result<Option<(UpstreamNarInfoData, SubstituterMeta)>, AppError>,
-        Vec<ResolveNarInfoEvent>,
-    ) {
-        let headers = Arc::new(headers);
-        let mut substituter_graces = HashMap::new();
-        for substituter in substituters.iter() {
-            substituter_graces.insert(substituter, substituter.grace(tolerance as i64));
-        }
-
-        let start = Instant::now();
-        let mut query_tracker = JoinSet::new();
-        let mut query_cancellers = HashMap::new();
-        let mut query_deadlines: DeadlineGroup<&SubstituterCandidate> = DeadlineGroup::new();
-
-        for substituter in substituters.iter() {
-            let handle = query_tracker.spawn({
-                let provider = Arc::clone(&self.nar_info_provider);
-                let sub = substituter.clone();
-                let url = hash.on_substituter(sub.meta());
-                let headers = Arc::clone(&headers);
-                let timeout = sub.meta().nar_info_timeout();
-                async move { (sub, provider.query_nar_info(&url, &headers, timeout).await) }
-            });
-            query_cancellers.insert(substituter, handle);
-        }
-
-        let mut has_error = false;
-        let mut events = Vec::new();
-        let mut optimal = None;
-        loop {
-            let query_res = tokio::select! {
-                Some(substituter) = query_deadlines.wait_earliest(), if !query_deadlines.is_empty() => {
-                    tracing::trace!(hash = %hash.value(), substituter = %substituter.url(), elapsed = ?start.elapsed(), "prune substituter query");
-                    if let Some(canceller) = query_cancellers.remove(substituter) {
-                        canceller.abort()
-                    };
-                    query_deadlines.remove(substituter);
-                    substituter_graces.remove(substituter);
-                    continue;
-                }
-                res = query_tracker.join_next() => res,
-            };
-
-            match query_res {
-                Some(Ok((substituter, Ok(outcome)))) => {
-                    query_cancellers.remove(&substituter);
-                    query_deadlines.remove(&substituter);
-                    let Some(current_grace) = substituter_graces.remove(&substituter) else {
-                        continue;
-                    };
-                    if substituter.is_maybe_ready() {
-                        let url = substituter.url().clone();
-                        events.push(ResolveNarInfoEvent::SubstituterSucceeded(url));
-                    }
-
-                    if let Some(data) = outcome {
-                        let current = NarInfoQueryCandidate {
-                            substituter,
-                            nar_info: data.upstream_data,
-                            grace: current_grace,
-                            latency: data.latency,
-                        };
-                        update_optimal_and_deadlines(
-                            current,
-                            &mut optimal,
-                            start,
-                            &mut query_deadlines,
-                            &substituter_graces,
-                            hash.value(),
-                        );
-                    }
-                }
-                Some(Ok((substituter, Err(e)))) => {
-                    if !self.ignore_query_error && matches!(e, QueryNarInfoError::Service { .. }) {
-                        has_error = true;
-                    }
-                    query_cancellers.remove(&substituter);
-                    query_deadlines.remove(&substituter);
-                    substituter_graces.remove(&substituter);
-                    let url = substituter.url().clone();
-                    match e {
-                        QueryNarInfoError::Offline { .. } => {
-                            events.push(ResolveNarInfoEvent::SubstituterOffline(url));
-                        }
-                        QueryNarInfoError::Service { .. } => {
-                            events.push(ResolveNarInfoEvent::SubstituterError(url));
-                        }
-                    }
-                }
-                Some(Err(_)) => (),
-                None => break,
-            }
-        }
-
-        match optimal {
-            Some(optimal) => {
-                let meta = optimal.substituter.meta().clone();
-                (Ok(Some((optimal.nar_info, meta))), events)
-            }
-            None if !has_error => (Ok(None), events),
-            None => (
-                Err(AppError::infrastructure(
-                    "could not get results from all substituters to determine whether the nar info exists",
-                )),
-                events,
-            ),
-        }
+        self.resolution_policy
+            .resolve(hash, &headers, substituters)
+            .await
     }
 }
 
@@ -225,37 +99,81 @@ pub enum ResolveNarInfoEvent {
     },
 }
 
-struct NarInfoQueryCandidate {
-    substituter: SubstituterCandidate,
-    nar_info: UpstreamNarInfoData,
-    grace: i64,
-    latency: Duration,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResolutionPolicyOption {
+    Preference,
+    Tier,
 }
 
-impl NarInfoQueryCandidate {
-    fn calc_preference(&self) -> i64 {
-        self.grace - self.latency.as_millis() as i64
-    }
-}
-
-fn update_optimal_and_deadlines<'a>(
-    current: NarInfoQueryCandidate,
-    optimal: &mut Option<NarInfoQueryCandidate>,
-    start: Instant,
-    deadlines: &mut DeadlineGroup<&'a SubstituterCandidate>,
-    graces: &HashMap<&'a SubstituterCandidate, i64>,
-    hash: &str,
-) {
-    match optimal {
-        Some(prev) if prev.calc_preference() > current.calc_preference() => (),
-        _ => {
-            tracing::trace!(%hash, substituter = %current.substituter.url().value(), preference = %current.calc_preference(), latency = ?current.latency, elapsed = ?start.elapsed(), "update optimal candidate");
-            for (substituter, grace) in graces {
-                let max_latency = 0.max(grace - current.calc_preference()) as u64;
-                let deadline = start + Duration::from_millis(max_latency);
-                deadlines.insert_or_set_earlier(substituter, deadline);
-            }
-            *optimal = Some(current);
+impl ResolutionPolicyOption {
+    pub fn as_str_value(&self) -> &'static str {
+        match self {
+            Self::Preference => "preference",
+            Self::Tier => "tier",
         }
     }
+}
+
+#[async_trait]
+pub trait NarInfoResolutionPolicy: Send + Sync {
+    async fn resolve(
+        &self,
+        hash: &StorePathHash,
+        headers: &PassthroughHeaders,
+        substituters: Arc<Vec<SubstituterCandidate>>,
+    ) -> (
+        Result<Option<(UpstreamNarInfoData, SubstituterMeta)>, AppError>,
+        Vec<ResolveNarInfoEvent>,
+    );
+}
+
+#[derive(Debug)]
+pub(crate) enum QueryOutcome {
+    Responded(Option<NarInfoQueryData>),
+    Offline,
+    Error,
+}
+
+// The implementations and this helper must stay panic-free: unlike the racing
+// policy, which isolates task panics via `JoinSet`, the tiered policy polls
+// its query futures inline within the caller's task, so a panic here would
+// tear down the whole NAR info actor.
+pub(crate) async fn query_substituter(
+    provider: &dyn NarInfoProvider,
+    hash: &StorePathHash,
+    headers: &PassthroughHeaders,
+    substituter: &SubstituterCandidate,
+) -> (QueryOutcome, Option<ResolveNarInfoEvent>) {
+    let url = hash.on_substituter(substituter.meta());
+    let timeout = substituter.meta().nar_info_timeout();
+    match provider.query_nar_info(&url, headers, timeout).await {
+        Ok(data) => {
+            let event = if substituter.is_maybe_ready() {
+                Some(ResolveNarInfoEvent::SubstituterSucceeded(
+                    substituter.url().clone(),
+                ))
+            } else {
+                None
+            };
+            (QueryOutcome::Responded(data), event)
+        }
+        Err(QueryNarInfoError::Offline { .. }) => (
+            QueryOutcome::Offline,
+            Some(ResolveNarInfoEvent::SubstituterOffline(
+                substituter.url().clone(),
+            )),
+        ),
+        Err(QueryNarInfoError::Service { .. }) => (
+            QueryOutcome::Error,
+            Some(ResolveNarInfoEvent::SubstituterError(
+                substituter.url().clone(),
+            )),
+        ),
+    }
+}
+
+pub(crate) fn indeterminate_existence_error() -> AppError {
+    AppError::infrastructure(
+        "could not get results from all substituters to determine whether the nar info exists",
+    )
 }

--- a/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use anyhow::{Context, Error as AnyhowError, Result as AnyhowResult};
 
 use crate::domain::common::url::Url;
+use crate::domain::nar_info::ResolutionPolicyOption;
 use crate::domain::nar_info::model::NarUrlRewriteOption;
 use crate::domain::substituter::model::{PeriodicProbingOption, Priority};
 use crate::infrastructure::config::general_raw::{
@@ -152,6 +153,7 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ProxyConfiguration {
     pub rewrite_nar_url: NarUrlRewriteOption,
+    pub resolution_policy: ResolutionPolicyOption,
 }
 
 impl TryFrom<ProxyRawConfiguration> for ProxyConfiguration {
@@ -172,6 +174,16 @@ impl TryFrom<ProxyRawConfiguration> for ProxyConfiguration {
             } else {
                 NarUrlRewriteOption::Keep
             },
+            resolution_policy: raw.resolution_policy.map_or(
+                Ok(ResolutionPolicyOption::Preference),
+                |value| match value.as_str() {
+                    "preference" => Ok(ResolutionPolicyOption::Preference),
+                    "tier" => Ok(ResolutionPolicyOption::Tier),
+                    _ => Err(anyhow::anyhow!(
+                        "`proxy.resolution_policy` should be `\"preference\"` or `\"tier\"`"
+                    )),
+                },
+            )?,
         })
     }
 }

--- a/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
@@ -47,6 +47,7 @@ pub struct NetworkRawConfiguration {
 pub struct ProxyRawConfiguration {
     pub rewrite_nar_url: Option<bool>,
     pub rewrite_to_target: Option<String>,
+    pub resolution_policy: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]

--- a/crates/selector4nix-core/tests/integration/config_test.rs
+++ b/crates/selector4nix-core/tests/integration/config_test.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
+use selector4nix_core::domain::nar_info::ResolutionPolicyOption;
 use selector4nix_core::domain::nar_info::model::NarUrlRewriteOption;
 use selector4nix_core::domain::substituter::model::PeriodicProbingOption;
 use selector4nix_core::infrastructure::config::AppConfiguration;
@@ -40,6 +41,10 @@ fn defaults_are_applied_when_sections_omitted() {
         NonZeroUsize::new(8).unwrap(),
     );
     assert_eq!(config.proxy.rewrite_nar_url, NarUrlRewriteOption::ToSelf);
+    assert_eq!(
+        config.proxy.resolution_policy,
+        ResolutionPolicyOption::Preference,
+    );
     assert_eq!(config.cache_info.store_dir, "/nix/store");
     assert!(config.cache_info.want_mass_query);
     assert_eq!(config.cache_info.priority.value(), 40);
@@ -66,6 +71,18 @@ fn invalid_rewrite_to_target_is_rejected() {
         r#"
 [proxy]
 rewrite_to_target = "invalid"
+"#,
+    ));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn invalid_resolution_policy_is_rejected() {
+    let result = AppConfiguration::deserialize(&make_config_string_overriden(
+        r#"
+[proxy]
+resolution_policy = "invalid"
 "#,
     ));
 

--- a/crates/selector4nix-core/tests/integration/main.rs
+++ b/crates/selector4nix-core/tests/integration/main.rs
@@ -4,4 +4,5 @@ pub mod mock;
 mod config_test;
 mod credential_test;
 mod nar_file_service_test;
-mod nar_info_service_test;
+mod preference_policy_test;
+mod tier_policy_test;

--- a/crates/selector4nix-core/tests/integration/mock/nar_info_provider.rs
+++ b/crates/selector4nix-core/tests/integration/mock/nar_info_provider.rs
@@ -9,10 +9,12 @@ use selector4nix_core::domain::nar_info::port::{
     NarInfoProvider, NarInfoQueryData, QueryNarInfoError,
 };
 use snafu::ResultExt;
+use tokio::sync::Mutex;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct MockNarInfoProvider {
     queries: HashMap<Url, Result<NarInfoQueryData, String>>,
+    queried_urls: Mutex<Vec<Url>>,
 }
 
 impl MockNarInfoProvider {
@@ -22,7 +24,12 @@ impl MockNarInfoProvider {
     {
         Self {
             queries: queries.into_iter().collect(),
+            queried_urls: Mutex::new(Vec::new()),
         }
+    }
+
+    pub async fn queried_urls(&self) -> Vec<Url> {
+        self.queried_urls.lock().await.clone()
     }
 }
 
@@ -34,6 +41,8 @@ impl NarInfoProvider for MockNarInfoProvider {
         _headers: &PassthroughHeaders,
         timeout: Option<Duration>,
     ) -> Result<Option<NarInfoQueryData>, QueryNarInfoError> {
+        self.queried_urls.lock().await.push(url.clone());
+
         let Some(data) = self.queries.get(url) else {
             return Ok(None);
         };

--- a/crates/selector4nix-core/tests/integration/preference_policy_test.rs
+++ b/crates/selector4nix-core/tests/integration/preference_policy_test.rs
@@ -8,6 +8,7 @@ use selector4nix_core::domain::nar_info::model::test_support::{
     make_nar_file_name, make_store_path_hash,
 };
 use selector4nix_core::domain::nar_info::model::{NarUrlRewriteOption, StorePathHash};
+use selector4nix_core::domain::nar_info::policy::PreferencePolicy;
 use selector4nix_core::domain::nar_info::port::NarInfoQueryData;
 use selector4nix_core::domain::nar_info::{NarInfoService, ResolveNarInfoEvent};
 use selector4nix_core::domain::substituter::SubstituterRepository;
@@ -59,14 +60,16 @@ async fn run_test(
         repo.save(sub.clone()).await;
     }
 
-    let nar_info_provider = MockNarInfoProvider::new(env.nar_info_entries);
+    let nar_info_provider = Arc::new(MockNarInfoProvider::new(env.nar_info_entries));
 
     let nar_resolution_service = NarInfoService::new(
-        Arc::new(nar_info_provider),
+        Arc::new(PreferencePolicy::new(
+            nar_info_provider,
+            Duration::from_millis(env.tolerance),
+            env.ignore_query_error,
+        )),
         repo,
         NarUrlRewriteOption::ToSelf,
-        env.tolerance,
-        env.ignore_query_error,
     );
 
     let (res, events) = nar_resolution_service

--- a/crates/selector4nix-core/tests/integration/tier_policy_test.rs
+++ b/crates/selector4nix-core/tests/integration/tier_policy_test.rs
@@ -1,0 +1,397 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use selector4nix_core::domain::common::passthrough_headers::PassthroughHeaders;
+use selector4nix_core::domain::common::url::Url;
+use selector4nix_core::domain::nar_info::model::test_support::{
+    make_nar_file_name, make_store_path_hash,
+};
+use selector4nix_core::domain::nar_info::model::{NarUrlRewriteOption, StorePathHash};
+use selector4nix_core::domain::nar_info::policy::TierPolicy;
+use selector4nix_core::domain::nar_info::port::NarInfoQueryData;
+use selector4nix_core::domain::nar_info::{NarInfoService, ResolveNarInfoEvent};
+use selector4nix_core::domain::substituter::SubstituterRepository;
+use selector4nix_core::domain::substituter::model::Substituter;
+use selector4nix_core::domain::substituter::model::test_support::{
+    make_substituter_meta_with_url_pri, make_substituter_normal_with_url_pri,
+};
+use selector4nix_core::infrastructure::repository::InMemorySubstituterRepository;
+
+use crate::fixture::nar_file::make_source_url;
+use crate::fixture::nar_info::{make_nar_info_query_data, make_nar_info_url};
+use crate::fixture::substituter::make_substituter_normal_with_nar_info_timeout;
+use crate::mock::nar_info_provider::MockNarInfoProvider;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TestCaseEnvironment {
+    substituters: Vec<Substituter>,
+    nar_info_entries: Vec<(Url, Result<NarInfoQueryData, String>)>,
+    ignore_query_error: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TestCaseInput {
+    hash: StorePathHash,
+}
+
+#[derive(Debug)]
+struct TestCaseExpectation {
+    source_url: Result<Option<Url>, ()>,
+    events: Vec<ResolveNarInfoEvent>,
+    not_queried: Vec<Url>,
+}
+
+async fn run_test(
+    env: TestCaseEnvironment,
+    input: TestCaseInput,
+    expectation: TestCaseExpectation,
+) {
+    let _time_advancer = tokio::spawn(async {
+        loop {
+            tokio::time::advance(Duration::from_millis(1)).await;
+            tokio::task::yield_now().await;
+        }
+    });
+
+    let repo = Arc::new(InMemorySubstituterRepository::new());
+    for sub in env.substituters.iter() {
+        repo.save(sub.clone()).await;
+    }
+
+    let nar_info_provider = Arc::new(MockNarInfoProvider::new(env.nar_info_entries));
+
+    let nar_resolution_service = NarInfoService::new(
+        Arc::new(TierPolicy::new(
+            nar_info_provider.clone(),
+            env.ignore_query_error,
+        )),
+        repo,
+        NarUrlRewriteOption::ToSelf,
+    );
+
+    let (res, events) = nar_resolution_service
+        .resolve(&input.hash, PassthroughHeaders::empty())
+        .await;
+
+    assert_eq!(
+        res.map(|resolution| resolution.source_url().cloned())
+            .map_err(|_| ()),
+        expectation.source_url,
+    );
+
+    assert_eq!(
+        events.into_iter().collect::<HashSet<_>>(),
+        expectation.events.into_iter().collect::<HashSet<_>>(),
+    );
+
+    let queried = nar_info_provider.queried_urls().await;
+    for url in &expectation.not_queried {
+        let nar_info_url = make_nar_info_url(url, &input.hash);
+        assert!(
+            !queried.contains(&nar_info_url),
+            "expected {url} to not be queried, but it was"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn lower_tier_queried_when_higher_tier_lacks_nar_info() {
+    let mirror_url = Url::new("https://mirror.example.com").unwrap();
+    let official_url = Url::new("https://cache.nixos.org").unwrap();
+    let mirror = make_substituter_normal_with_url_pri(&mirror_url, 10);
+    let official = make_substituter_normal_with_url_pri(&official_url, 40);
+    let hash = make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![mirror, official],
+            // The mirror tier lacks the NAR info (absent from entries = not
+            // found), so the official tier is queried and wins.
+            nar_info_entries: vec![(
+                make_nar_info_url(&official_url, &hash),
+                Ok(make_nar_info_query_data(Duration::from_millis(0))),
+            )],
+            ignore_query_error: false,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Ok(Some(make_source_url(&official_url, 40))),
+            events: vec![ResolveNarInfoEvent::NarFileLocated {
+                nar_file: make_nar_file_name(),
+                substituter: make_substituter_meta_with_url_pri(&official_url, 40),
+                source_url: make_source_url(&official_url, 40),
+                store_path_hash: make_store_path_hash(),
+            }],
+            not_queried: vec![],
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn slow_higher_tier_beats_fast_lower_tier() {
+    let mirror_url = Url::new("https://mirror.example.com").unwrap();
+    let official_url = Url::new("https://cache.nixos.org").unwrap();
+    let mirror = make_substituter_normal_with_url_pri(&mirror_url, 10);
+    let official = make_substituter_normal_with_url_pri(&official_url, 40);
+    let hash = make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![mirror, official],
+            // The mirror is slow (1600ms) but holds the NAR info, while the
+            // official cache would answer instantly: under strict tiering the
+            // official tier is never queried, so the mirror wins.
+            nar_info_entries: vec![
+                (
+                    make_nar_info_url(&mirror_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(1600))),
+                ),
+                (
+                    make_nar_info_url(&official_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(0))),
+                ),
+            ],
+            ignore_query_error: false,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Ok(Some(make_source_url(&mirror_url, 10))),
+            events: vec![ResolveNarInfoEvent::NarFileLocated {
+                nar_file: make_nar_file_name(),
+                substituter: make_substituter_meta_with_url_pri(&mirror_url, 10),
+                source_url: make_source_url(&mirror_url, 10),
+                store_path_hash: make_store_path_hash(),
+            }],
+            not_queried: vec![official_url],
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn lower_tier_queried_when_higher_tier_errors() {
+    let mirror_url = Url::new("https://mirror.example.com").unwrap();
+    let official_url = Url::new("https://cache.nixos.org").unwrap();
+    let mirror = make_substituter_normal_with_url_pri(&mirror_url, 10);
+    let official = make_substituter_normal_with_url_pri(&official_url, 40);
+    let hash = make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![mirror, official],
+            // The mirror tier fails with a service error rather than
+            // not-found; strict tiering still queries the official tier.
+            nar_info_entries: vec![
+                (
+                    make_nar_info_url(&mirror_url, &hash),
+                    Err("stub error".into()),
+                ),
+                (
+                    make_nar_info_url(&official_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(0))),
+                ),
+            ],
+            ignore_query_error: false,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Ok(Some(make_source_url(&official_url, 40))),
+            events: vec![
+                ResolveNarInfoEvent::SubstituterError(mirror_url),
+                ResolveNarInfoEvent::NarFileLocated {
+                    nar_file: make_nar_file_name(),
+                    substituter: make_substituter_meta_with_url_pri(&official_url, 40),
+                    source_url: make_source_url(&official_url, 40),
+                    store_path_hash: make_store_path_hash(),
+                },
+            ],
+            not_queried: vec![],
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn races_within_same_tier() {
+    let mirror_a_url = Url::new("https://mirror-a.example.com").unwrap();
+    let mirror_b_url = Url::new("https://mirror-b.example.com").unwrap();
+    let official_url = Url::new("https://cache.nixos.org").unwrap();
+    let mirror_a = make_substituter_normal_with_url_pri(&mirror_a_url, 10);
+    let mirror_b = make_substituter_normal_with_url_pri(&mirror_b_url, 10);
+    let official = make_substituter_normal_with_url_pri(&official_url, 40);
+    let hash = make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![mirror_a, mirror_b, official],
+            // Within the tier of priority 10 the faster mirror_a wins over
+            // the slower mirror_b; the official tier (40) answers instantly
+            // but is never queried because the higher tier found the NAR info.
+            nar_info_entries: vec![
+                (
+                    make_nar_info_url(&mirror_a_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(0))),
+                ),
+                (
+                    make_nar_info_url(&mirror_b_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(1600))),
+                ),
+                (
+                    make_nar_info_url(&official_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(0))),
+                ),
+            ],
+            ignore_query_error: false,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Ok(Some(make_source_url(&mirror_a_url, 10))),
+            events: vec![ResolveNarInfoEvent::NarFileLocated {
+                nar_file: make_nar_file_name(),
+                substituter: make_substituter_meta_with_url_pri(&mirror_a_url, 10),
+                source_url: make_source_url(&mirror_a_url, 10),
+                store_path_hash: make_store_path_hash(),
+            }],
+            not_queried: vec![official_url],
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn all_tiers_error_yields_infrastructure_error() {
+    let mirror_url = Url::new("https://mirror.example.com").unwrap();
+    let official_url = Url::new("https://cache.nixos.org").unwrap();
+    let mirror = make_substituter_normal_with_url_pri(&mirror_url, 10);
+    let official = make_substituter_normal_with_url_pri(&official_url, 40);
+    let hash = make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![mirror, official],
+            // Every tier errors and no tier is rescued: the sticky error
+            // makes the overall lookup fail, mirroring racing semantics.
+            nar_info_entries: vec![
+                (
+                    make_nar_info_url(&mirror_url, &hash),
+                    Err("stub error".into()),
+                ),
+                (
+                    make_nar_info_url(&official_url, &hash),
+                    Err("stub error".into()),
+                ),
+            ],
+            ignore_query_error: false,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Err(()),
+            events: vec![
+                ResolveNarInfoEvent::SubstituterError(mirror_url),
+                ResolveNarInfoEvent::SubstituterError(official_url),
+            ],
+            not_queried: vec![],
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn errors_treated_as_not_found_with_ignore_error() {
+    let mirror_url = Url::new("https://mirror.example.com").unwrap();
+    let official_url = Url::new("https://cache.nixos.org").unwrap();
+    let mirror = make_substituter_normal_with_url_pri(&mirror_url, 10);
+    let official = make_substituter_normal_with_url_pri(&official_url, 40);
+    let hash = make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![mirror, official],
+            // Every tier errors, but query errors are ignored: the sticky
+            // error is downgraded to not-found instead of failing the lookup.
+            nar_info_entries: vec![
+                (
+                    make_nar_info_url(&mirror_url, &hash),
+                    Err("stub error".into()),
+                ),
+                (
+                    make_nar_info_url(&official_url, &hash),
+                    Err("stub error".into()),
+                ),
+            ],
+            ignore_query_error: true,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Ok(None),
+            events: vec![
+                ResolveNarInfoEvent::SubstituterError(mirror_url),
+                ResolveNarInfoEvent::SubstituterError(official_url),
+            ],
+            not_queried: vec![],
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn all_offline_treated_as_not_found() {
+    let mirror_url = Url::new("https://mirror.example.com").unwrap();
+    let official_url = Url::new("https://cache.nixos.org").unwrap();
+    let mirror =
+        make_substituter_normal_with_nar_info_timeout(&mirror_url, 10, Duration::from_millis(10));
+    let official =
+        make_substituter_normal_with_nar_info_timeout(&official_url, 40, Duration::from_millis(20));
+    let hash = make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![mirror, official],
+            // Both tiers time out (offline): offline is not an error, so the
+            // overall lookup resolves to not-found, mirroring racing semantics.
+            nar_info_entries: vec![
+                (
+                    make_nar_info_url(&mirror_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(100))),
+                ),
+                (
+                    make_nar_info_url(&official_url, &hash),
+                    Ok(make_nar_info_query_data(Duration::from_millis(200))),
+                ),
+            ],
+            ignore_query_error: false,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Ok(None),
+            events: vec![
+                ResolveNarInfoEvent::SubstituterOffline(mirror_url),
+                ResolveNarInfoEvent::SubstituterOffline(official_url),
+            ],
+            not_queried: vec![],
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn no_substituter_yields_not_found() {
+    let hash = make_store_path_hash();
+
+    run_test(
+        TestCaseEnvironment {
+            substituters: vec![],
+            nar_info_entries: vec![],
+            ignore_query_error: false,
+        },
+        TestCaseInput { hash },
+        TestCaseExpectation {
+            source_url: Ok(None),
+            events: vec![],
+            not_queried: vec![],
+        },
+    )
+    .await;
+}

--- a/crates/selector4nix/src/bootstrap.rs
+++ b/crates/selector4nix/src/bootstrap.rs
@@ -1,6 +1,7 @@
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result as AnyhowResult};
 use redb::Database;
@@ -27,8 +28,11 @@ use selector4nix_core::application::usecase::nar_info::{
 use selector4nix_core::domain::common::passthrough_headers::SELF_USER_AGENT;
 use selector4nix_core::domain::nar_file::NarFileService;
 use selector4nix_core::domain::nar_file::model::NarFileKey;
-use selector4nix_core::domain::nar_info::NarInfoService;
 use selector4nix_core::domain::nar_info::model::StorePathHash;
+use selector4nix_core::domain::nar_info::policy::{PreferencePolicy, TierPolicy};
+use selector4nix_core::domain::nar_info::{
+    NarInfoResolutionPolicy, NarInfoService, ResolutionPolicyOption,
+};
 use selector4nix_core::domain::substituter::model::{Availability, Substituter, SubstituterMeta};
 use selector4nix_core::domain::substituter::{SubstituterRepository, SubstituterService};
 use selector4nix_core::infrastructure::config::{AppConfiguration, AppCredential};
@@ -224,13 +228,25 @@ pub async fn init_context(
 
     let substituter_service = Arc::new(SubstituterService::new(config.network.periodic_probing));
 
-    let nar_info_service = Arc::new(NarInfoService::new(
-        nar_info_provider,
-        substituter_repository.clone(),
-        config.proxy.rewrite_nar_url,
-        config.network.tolerance,
-        config.network.ignore_nar_info_error,
-    ));
+    let nar_info_service = {
+        let resolution_policy: Arc<dyn NarInfoResolutionPolicy> =
+            match config.proxy.resolution_policy {
+                ResolutionPolicyOption::Preference => Arc::new(PreferencePolicy::new(
+                    nar_info_provider.clone(),
+                    Duration::from_millis(config.network.tolerance),
+                    config.network.ignore_nar_info_error,
+                )),
+                ResolutionPolicyOption::Tier => Arc::new(TierPolicy::new(
+                    nar_info_provider.clone(),
+                    config.network.ignore_nar_info_error,
+                )),
+            };
+        Arc::new(NarInfoService::new(
+            resolution_policy,
+            substituter_repository.clone(),
+            config.proxy.rewrite_nar_url,
+        ))
+    };
 
     let nar_file_service = Arc::new(NarFileService::new(
         nar_stream_provider,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ Maximum number of chunks that may be in flight simultaneously for a single NAR f
 - Type: Natural
 - Default: `50`
 
-Latency tolerance window in milliseconds. The preference of a substituter is calculated as `-tolerance * priority - latency`. After the fastest substituter responds, other substituters have additional milliseconds equal to the difference between their preference and the current best before being pruned.
+Latency tolerance window in milliseconds. The preference of a substituter is calculated as `-tolerance * priority - latency`. After the fastest substituter responds, other substituters have additional milliseconds equal to the difference between their preference and the current best before being pruned. Only effective under the `preference` resolution policy (see `proxy.resolution_policy`).
 
 ### `network.ignore_nar_info_error`
 
@@ -115,6 +115,16 @@ Controls how the `URL` field is rewritten when `rewrite_nar_url` is enabled. Onl
 - `"upstream"`: Rewrite to the winning upstream substituter's storage URL (e.g. `URL: https://cache.nixos.org/nar/<hash>.nar.xz`). This normalizes URLs to a consistent upstream address rather than preserving whatever format each substituter returns. NAR file requests will go directly to the upstream substituter, bypassing `selector4nix`.
 
 Note that the `URL` field in NAR info is opaque and varies across substituters: a given store path may map to different NAR URLs on different substituters, so fallback is not guaranteed to succeed when the NAR files are not identical across substituters.
+
+### `proxy.resolution_policy`
+
+- Type: String of `"preference"` or `"tier"`
+- Default: `"preference"`
+
+Controls how substituters are queried to resolve a NAR info.
+
+- `"preference"`: All substituters are queried at once and the winner is picked by preference (`-tolerance * priority - latency`, governed by `network.tolerance_msecs`).
+- `"tier"`: Substituters are queried tier by tier, from the highest priority (the lowest priority value) to the lowest. Substituters sharing the same `priority` value still race against each other, but a lower-priority tier is only queried when every higher-priority tier responded with not-found or an error. This keeps traffic on preferred mirrors (e.g. region-local ones), at the cost of serial lookup latency when higher-priority tiers lack the store path.
 
 ## `cache_info`
 

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -41,6 +41,12 @@ rewrite_nar_url = true
 # - "self": rewrite to a relative path so NAR requests go through selector4nix.
 # - "upstream": rewrite to the winning upstream substituter's storage URL.
 rewrite_to_target = "self"
+# How substituters are queried for NAR info (default: "preference").
+# - "preference": query all substituters at once, pick the winner by
+#   preference (-tolerance * priority - latency).
+# - "tier": query priority tiers one after another; lower-priority
+#   tiers are only queried when every higher-priority tier lacks the NAR info.
+resolution_policy = "preference"
 
 # Cache info exposed via /nix-cache-info endpoint.
 [cache_info]


### PR DESCRIPTION
## What

Adds a new `proxy.resolution_policy` option (default `"preference_racing"`). Setting it to `"strict_tiered"` queries substituters in strict priority tiers instead of all at once: substituters sharing the same `priority` value still race against each other, but lower-priority substituters (i.e. higher priority values) are only queried once every higher-priority tier has responded with not-found or an error. NAR info resolution is restructured behind the `NarInfoResolutionPolicy` port so the two strategies stay independent.

## Why

The default racing trades priority for latency: a saturated or slow high-priority mirror loses the race to a fast low-priority one, so traffic silently migrates off preferred mirrors. For deployments that want to keep traffic on region-local mirrors (e.g. to save upstream bandwidth or respect rate limits), strict-fallback semantics are desirable. Today this can only be approximated by inflating `tolerance_msecs`, which is fragile: the grace window must stay at least as long as every higher tier's `nar_info_timeout_secs` to remain strict.

## How

- `domain/nar_info/port/resolution_policy.rs` declares the `NarInfoResolutionPolicy` port, the resolution events, and the shared single-substituter query helper.
- `domain/nar_info/policy/racing.rs` holds the previous racing implementation, behavior-preserving; `domain/nar_info/policy/tiered.rs` races each priority tier via `FuturesUnordered` (first found wins, remaining queries are dropped on win) and falls through to the next tier only after every substituter of the current tier answered.
- Tier errors are sticky: if no lower tier rescues a failed tier, the overall lookup fails with an infrastructure error, mirroring the error semantics of racing (including the `ignore_nar_info_error` interaction).
- `proxy.resolution_policy` selects the implementation at bootstrap via `build_resolution_policy`; NAR file streaming is unaffected: cached NAR file locations and the fallback-to-all-substituters behavior are unchanged.

## Testing

- 8 strict-tiered integration tests in `nar_info_service_test.rs` covering: lower tier queried when the higher tier lacks the NAR info, lower tier queried when the higher tier errors, a slow higher tier still beating a fast lower tier, racing within the same tier, a sticky infrastructure error when all tiers fail, `ignore_nar_info_error` downgrading errors to not-found, offline treated as not-found, and an empty substituter list.
- The mock provider now records queried URLs, letting tests assert that lower tiers are never queried when a higher tier hits.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --check` all pass; `selector4nix check` validates the updated example config.
