### PR TITLE
feat: add substituters[].max_concurrent_requests for per-substituter concurrency limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 ### Added
 
 - Added `/{storePathHash}.ls` endpoint, which lists the recursive directory structure of a particular store path.
+- Added the `substituters[].max_concurrent_requests` configuration option to override the per-host NAR streaming concurrency limit per substituter, useful for upstream servers that fail under high concurrency.
 
 ## [0.9.1] - 2026-08-15
 

--- a/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
@@ -239,6 +239,7 @@ pub struct SubstituterConfiguration {
     pub priority: Priority,
     pub nar_info_timeout: Option<Duration>,
     pub nar_timeout: Option<Duration>,
+    pub max_concurrent_requests: Option<NonZeroUsize>,
 }
 
 impl TryFrom<SubstituterRawConfiguration> for SubstituterConfiguration {
@@ -253,6 +254,7 @@ impl TryFrom<SubstituterRawConfiguration> for SubstituterConfiguration {
                 .nar_info_timeout_secs
                 .map(|s| Duration::from_secs(s.get())),
             nar_timeout: raw.nar_timeout_secs.map(|s| Duration::from_secs(s.get())),
+            max_concurrent_requests: raw.max_concurrent_requests,
         })
     }
 }

--- a/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
@@ -74,4 +74,5 @@ pub struct SubstituterRawConfiguration {
     pub priority: Option<u32>,
     pub nar_info_timeout_secs: Option<NonZeroU64>,
     pub nar_timeout_secs: Option<NonZeroU64>,
+    pub max_concurrent_requests: Option<NonZeroUsize>,
 }

--- a/crates/selector4nix-core/tests/integration/config_test.rs
+++ b/crates/selector4nix-core/tests/integration/config_test.rs
@@ -57,6 +57,7 @@ fn defaults_are_applied_when_sections_omitted() {
     assert!(config.substituters[0].storage_url.is_none());
     assert!(config.substituters[0].nar_info_timeout.is_none());
     assert!(config.substituters[0].nar_timeout.is_none());
+    assert!(config.substituters[0].max_concurrent_requests.is_none());
 }
 
 #[test]

--- a/crates/selector4nix-streaming/src/client.rs
+++ b/crates/selector4nix-streaming/src/client.rs
@@ -14,7 +14,9 @@ use crate::SBoxStream;
 use crate::stream::{
     BoundedHttpStream, ChunkedStream, ChunkedStreamArgs, FullStream, HttpChunkConnector,
 };
-use crate::throttler::{PerHostHttpThrottler, ThrottlerAdapter, ThrottlerPermit};
+use crate::throttler::{
+    PerHostHttpThrottler, ThrottlerAdapter, ThrottlerPermit, ThrottlingOptions,
+};
 
 struct StreamingClientContext {
     client: Client,
@@ -31,7 +33,7 @@ pub struct StreamingClient {
 impl StreamingClient {
     pub fn new(
         client: ClientBuilder,
-        max_concurrent_requests: NonZeroUsize,
+        throttling: ThrottlingOptions,
         enable_chunked_streaming: bool,
         chunk_max_len: NonZeroUsize,
         window_max_len: NonZeroUsize,
@@ -42,7 +44,7 @@ impl StreamingClient {
                     .http1_only()
                     .build()
                     .expect("invalid reqwest client configuration"),
-                throttler: Arc::new(PerHostHttpThrottler::new(max_concurrent_requests)),
+                throttler: Arc::new(PerHostHttpThrottler::new(throttling)),
                 enable_chunked_streaming,
                 chunk_max_len,
                 window_max_len,

--- a/crates/selector4nix-streaming/src/lib.rs
+++ b/crates/selector4nix-streaming/src/lib.rs
@@ -4,6 +4,7 @@ pub mod throttler;
 mod client;
 
 pub use client::{StreamHttpBodyError, StreamingClient, StreamingRequest, StreamingResponse};
+pub use throttler::ThrottlingOptions;
 
 use std::pin::Pin;
 

--- a/crates/selector4nix-streaming/src/stream/chunked_tests.rs
+++ b/crates/selector4nix-streaming/src/stream/chunked_tests.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use futures::{Stream, StreamExt};
 
 use crate::stream::{ChunkConnector, ChunkTrottler, ChunkedStream, ChunkedStreamArgs};
-use crate::throttler::{PerHostHttpThrottler, ThrottlerAdapter};
+use crate::throttler::{PerHostHttpThrottler, ThrottlerAdapter, ThrottlingOptions};
 use crate::{SBoxFuture, SBoxStream};
 
 const PIECE_LEN: usize = 8;
@@ -110,9 +110,9 @@ fn make_stream(
     });
 
     let throttler = Box::new(ThrottlerAdapter::new(
-        Arc::new(PerHostHttpThrottler::new(
+        Arc::new(PerHostHttpThrottler::new(ThrottlingOptions::new(
             NonZeroUsize::new(max_concurrent_requests).unwrap(),
-        )),
+        ))),
         "example.com".to_string(),
     ));
     let initial_permit = throttler

--- a/crates/selector4nix-streaming/src/throttler/mod.rs
+++ b/crates/selector4nix-streaming/src/throttler/mod.rs
@@ -2,7 +2,7 @@ mod adapter;
 mod per_host;
 
 pub use adapter::ThrottlerAdapter;
-pub use per_host::PerHostHttpThrottler;
+pub use per_host::{PerHostHttpThrottler, ThrottlingOptions};
 
 use tokio::sync::OwnedSemaphorePermit;
 

--- a/crates/selector4nix-streaming/src/throttler/per_host.rs
+++ b/crates/selector4nix-streaming/src/throttler/per_host.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -6,15 +7,32 @@ use tokio::sync::{Semaphore, TryAcquireError};
 
 use crate::throttler::ThrottlerPermit;
 
+/// Throttling configuration: the default per-host concurrency limit, plus
+/// optional overrides for specific hosts.
+#[derive(Debug, Clone)]
+pub struct ThrottlingOptions {
+    pub default_max_concurrent_requests: NonZeroUsize,
+    pub per_host_max_concurrent_requests: HashMap<String, NonZeroUsize>,
+}
+
+impl ThrottlingOptions {
+    pub fn new(default_max_concurrent_requests: NonZeroUsize) -> Self {
+        Self {
+            default_max_concurrent_requests,
+            per_host_max_concurrent_requests: HashMap::new(),
+        }
+    }
+}
+
 pub struct PerHostHttpThrottler {
-    max_concurrent_requests: NonZeroUsize,
+    options: ThrottlingOptions,
     semaphores: DashMap<String, Arc<Semaphore>>,
 }
 
 impl PerHostHttpThrottler {
-    pub fn new(max_concurrent_requests: NonZeroUsize) -> Self {
+    pub fn new(options: ThrottlingOptions) -> Self {
         Self {
-            max_concurrent_requests,
+            options,
             semaphores: DashMap::new(),
         }
     }
@@ -43,9 +61,63 @@ impl PerHostHttpThrottler {
         } else {
             let entry = self.semaphores.entry(host.into());
             // Use `or_insert_with()` to prevent duplicated insertion.
-            let entry = entry
-                .or_insert_with(|| Arc::new(Semaphore::new(self.max_concurrent_requests.get())));
+            let entry = entry.or_insert_with(|| Arc::new(Semaphore::new(self.limit_for(host))));
             Arc::clone(entry.value())
         }
+    }
+
+    fn limit_for(&self, host: &str) -> usize {
+        self.options
+            .per_host_max_concurrent_requests
+            .get(host)
+            .map_or(
+                self.options.default_max_concurrent_requests.get(),
+                |limit| limit.get(),
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_limit_applies_to_unregistered_hosts() {
+        let throttler =
+            PerHostHttpThrottler::new(ThrottlingOptions::new(NonZeroUsize::new(2).unwrap()));
+
+        // Hold the permits so they are not released by dropping temporaries.
+        let permits: Vec<_> = (0..2)
+            .map(|_| throttler.try_acquire("default.example.com").unwrap())
+            .collect();
+        assert!(throttler.try_acquire("default.example.com").is_none());
+        drop(permits);
+        assert!(throttler.try_acquire("default.example.com").is_some());
+    }
+
+    #[test]
+    fn per_host_limit_overrides_default() {
+        let options = ThrottlingOptions {
+            default_max_concurrent_requests: NonZeroUsize::new(2).unwrap(),
+            per_host_max_concurrent_requests: [(
+                "limited.example.com".to_string(),
+                NonZeroUsize::new(1).unwrap(),
+            )]
+            .into(),
+        };
+        let throttler = PerHostHttpThrottler::new(options);
+
+        let limited_permit = throttler.try_acquire("limited.example.com").unwrap();
+        assert!(throttler.try_acquire("limited.example.com").is_none());
+        drop(limited_permit);
+        assert!(throttler.try_acquire("limited.example.com").is_some());
+
+        // Unregistered hosts keep the default limit.
+        let permits: Vec<_> = (0..2)
+            .map(|_| throttler.try_acquire("default.example.com").unwrap())
+            .collect();
+        assert!(throttler.try_acquire("default.example.com").is_none());
+        drop(permits);
+        assert!(throttler.try_acquire("default.example.com").is_some());
     }
 }

--- a/crates/selector4nix/src/bootstrap.rs
+++ b/crates/selector4nix/src/bootstrap.rs
@@ -36,7 +36,7 @@ use selector4nix_core::infrastructure::metric::NarTransferMetric;
 use selector4nix_core::infrastructure::provider::*;
 use selector4nix_core::infrastructure::repository::*;
 use selector4nix_db::cache_kv::CacheKv;
-use selector4nix_streaming::StreamingClient;
+use selector4nix_streaming::{StreamingClient, ThrottlingOptions};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer, Registry};
@@ -135,7 +135,7 @@ pub async fn init_context(
 
     let streaming_http_client = Arc::new(StreamingClient::new(
         http_client_builder_factory(config),
-        config.network.max_concurrent_requests,
+        ThrottlingOptions::new(config.network.max_concurrent_requests),
         config.network.chunked_streaming,
         config.network.streaming_chunk_max_len,
         config.network.streaming_window_max_len,

--- a/crates/selector4nix/src/bootstrap.rs
+++ b/crates/selector4nix/src/bootstrap.rs
@@ -135,7 +135,29 @@ pub async fn init_context(
 
     let streaming_http_client = Arc::new(StreamingClient::new(
         http_client_builder_factory(config),
-        ThrottlingOptions::new(config.network.max_concurrent_requests),
+        {
+            // Per-substituter concurrency limits are keyed by the host NAR
+            // requests actually go to, i.e. the storage host, so a storage
+            // host shared by multiple substituters gets the last configured
+            // limit.
+            let per_host_max_concurrent_requests = config
+                .substituters
+                .iter()
+                .filter_map(|sub_config| {
+                    sub_config.max_concurrent_requests.map(|limit| {
+                        let host = sub_config
+                            .storage_url
+                            .as_ref()
+                            .map_or(sub_config.url.host(), |storage_url| storage_url.host());
+                        (host.to_string(), limit)
+                    })
+                })
+                .collect();
+            ThrottlingOptions {
+                default_max_concurrent_requests: config.network.max_concurrent_requests,
+                per_host_max_concurrent_requests,
+            }
+        },
         config.network.chunked_streaming,
         config.network.streaming_chunk_max_len,
         config.network.streaming_window_max_len,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@ Timeout in seconds for NAR file downloads, also used as connect timeout.
 - Type: Positive Integer
 - Default: `12`
 
-Maximum number of concurrent outgoing NAR file streaming requests, applied per distinct substituter host. The overall ceiling across the proxy is `max_concurrent_requests` multiplied by the number of distinct substituter hosts.
+Maximum number of concurrent outgoing NAR file streaming requests, applied per distinct substituter host. The overall ceiling across the proxy is `max_concurrent_requests` multiplied by the number of distinct substituter hosts. Individual hosts can deviate from this default via `substituters[].max_concurrent_requests`.
 
 ### `network.chunked_streaming`
 
@@ -214,3 +214,10 @@ Per-substituter override for NAR info lookup timeout in seconds. When unset, fal
 - Default: none
 
 Per-substituter override for NAR file download timeout in seconds. When unset, falls back to `network.nar_timeout_secs`.
+
+### `substituters[].max_concurrent_requests`
+
+- Type: Positive Integer | None
+- Default: none
+
+Per-substituter override for the maximum number of concurrent NAR file streaming requests to this substituter, useful for upstream servers that fail under high concurrency (e.g. rate-limited or self-hosted instances). The limit is keyed by the host the NAR requests are initially issued to: the `storage_url` host when configured, otherwise the `url` host; if multiple substituters share one storage host, the last configured limit wins. NAR requests whose upstream-provided URL points to a third-party host are not covered by this limit and keep the default one. When unset, falls back to `network.max_concurrent_requests`.

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -100,3 +100,10 @@ url = "https://cache.garnix.io/"
 # Garnix does not serve NAR files at https://cache.garnix.io/nar/.
 storage_url = "https://garnix-cache.com/"
 priority = 40
+
+[[substituters]]
+url = "https://attic.example.com/"
+# Per-substituter override for concurrent NAR streaming requests to this
+# substituter's host, useful for servers sensitive to concurrency (default:
+# none, i.e. fall back to network.max_concurrent_requests).
+max_concurrent_requests = 4


### PR DESCRIPTION
## What

Adds a new per-substituter option `substituters[].max_concurrent_requests` (default: unset). When set, it overrides `network.max_concurrent_requests` for NAR streaming requests initially issued to that substituter's (storage) host; all other hosts keep the global default.

## Why

An upstream server's concurrency capacity — whether it is an operator-imposed rate limit or simply what a self-hosted instance can carry — is an intrinsic property of that server instance, varying from host to host. It therefore belongs in per-substituter configuration, like the existing `nar_info_timeout_secs` / `nar_timeout_secs` overrides, rather than in a single global knob. With only the global `network.max_concurrent_requests`, protecting one fragile upstream (e.g. a rate-limited attic instance) means throttling every healthy mirror as well.

## How

- The streaming client's throttler is now constructed from a `ThrottlingOptions` struct carrying the default limit plus a host → limit map, initialized in one shot (no post-construction mutation).
- Limits are keyed by the host that NAR requests are initially issued to — the `storage_url` host when configured, otherwise the `url` host. If two substituters share one storage host, the last configured limit wins.
- The per-host map is derived from the configuration inside the `streaming_http_client` creation block in `bootstrap.rs`.
- Documentation (configuration reference, example config, changelog) is updated in a separate docs commit placed last.

## Testing

- Unit tests for the throttler covering the default limit for unregistered hosts, the per-host override, and permit-release behavior.
- Added a default-value assertion for the new field to the existing `defaults_are_applied_when_sections_omitted` config test.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --check` all pass; `selector4nix check` validates the updated example config.
