### PR TITLE
Polish configuration page in dashboard for better UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 ### Added
 
 - Added `/{storePathHash}.ls` endpoint, which lists the recursive directory structure of a particular store path.
-- Added the `substituters[].max_concurrent_requests` configuration option to override the per-host NAR streaming concurrency limit per substituter, useful for upstream servers that fail under high concurrency.
-- Added the `proxy.resolution_policy` configuration option. Setting it to `"tier"` queries substituters in strict priority tiers instead of all at once: substituters sharing a priority value still race against each other, but lower-priority substituters are only queried when every higher-priority tier lacks the NAR info. Useful for keeping traffic on preferred mirrors (e.g. region-local ones) and saving upstream bandwidth. The default `"preference"` keeps the existing behavior.
+- Added the `substituters[].max_concurrent_requests` configuration option to override the per-host NAR streaming concurrency limit per substituter, useful for upstream servers that fail under high concurrency. [@luochen1990]
+- Added the `proxy.resolution_policy` configuration option. [@luochen1990]
+    - When its value is `"preference"`, the original resolution policy based on preference values that is calculated from latency and other metrics is used. This is the default policy.
+    - When its value is `"tier"`, substituters are queried in strict priority tiers instead of all at once. Substituters of higher priority are queried first and those of lower priority are queried only after the former resolution doesn't succeed. Substituters of the same priority still race against each other.
+    - The tiered policy might be useful for keeping traffic on preferred substituters and saving upstream bandwidth.
+
+### Changed
+
+- Changed the configuration page in dashboard for better user experience.
+    - Shrinked excessively long explanation text of some configuration field.
+    - Changed DOM structure and stylesheet to optimize aligning of tables.
 
 ## [0.9.1] - 2026-08-15
 
@@ -228,5 +237,6 @@ This is the first release of `selector4nix`, a Nix substituter proxy with parall
 <!-- Contributors -->
 
 [@XYenon]: https://github.com/XYenon
+[@luochen1990]: https://github.com/luochen1990
 [@lxl66566]: https://github.com/lxl66566
 [@mio-19]: https://github.com/mio-19

--- a/crates/selector4nix-core/src/application/usecase/dashboard/get_config_summary.rs
+++ b/crates/selector4nix-core/src/application/usecase/dashboard/get_config_summary.rs
@@ -50,7 +50,7 @@ impl GetDashboardConfigSummaryUseCase {
             entries: vec![
                 ConfigSummaryEntryData {
                     name: "Tolerance",
-                    description: "Latency tolerance window in milliseconds per unit of difference of priority between two substituters. Only effective under the `preference` resolution policy.",
+                    description: "Latency tolerance window in milliseconds per unit of difference of priority between two substituters.",
                     value: format!("{}ms", cfg.tolerance),
                 },
                 ConfigSummaryEntryData {
@@ -119,7 +119,7 @@ impl GetDashboardConfigSummaryUseCase {
                 },
                 ConfigSummaryEntryData {
                     name: "Resolution policy",
-                    description: "How substituters are queried for NAR info: `preference` races all substituters and picks the winner by preference; `tier` queries priority tiers one after another, keeping traffic on preferred substituters.",
+                    description: "How substituters are queried for NAR info.",
                     value: cfg.resolution_policy.as_str_value().to_string(),
                 },
             ],

--- a/crates/selector4nix-streaming/src/throttler/per_host.rs
+++ b/crates/selector4nix-streaming/src/throttler/per_host.rs
@@ -7,8 +7,6 @@ use tokio::sync::{Semaphore, TryAcquireError};
 
 use crate::throttler::ThrottlerPermit;
 
-/// Throttling configuration: the default per-host concurrency limit, plus
-/// optional overrides for specific hosts.
 #[derive(Debug, Clone)]
 pub struct ThrottlingOptions {
     pub default_max_concurrent_requests: NonZeroUsize,

--- a/frontend/templates/configuration.html.jinja
+++ b/frontend/templates/configuration.html.jinja
@@ -6,16 +6,22 @@
       <section>
         <h2 class="mb-3 font-semibold">{{ section.title }}</h2>
 
-        <div class="divide-y divide-line-soft overflow-hidden rounded-card border border-line bg-surface">
-          {% for entry in section.entries %}
-            <div class="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-              <div class="flex flex-col gap-1">
-                <span class="text-sm font-medium">{{ entry.name }}</span>
-                <span class="text-xs text-muted">{{ entry.description }}</span>
-              </div>
-              <span class="font-mono text-sm text-muted tabular-nums">{{ entry.value }}</span>
-            </div>
-          {% endfor %}
+        <div class="overflow-hidden rounded-card border border-line bg-surface">
+          <table class="w-full">
+            <tbody class="divide-y divide-line-soft">
+              {% for entry in section.entries %}
+                <tr class="transition-colors hover:bg-canvas/50">
+                  <td class="flex flex-col gap-1 px-4 py-3">
+                    <span class="text-sm font-medium">{{ entry.name }}</span>
+                    <span class="text-xs text-muted">{{ entry.description }}</span>
+                  </td>
+                  <td class="px-4 py-3 text-right whitespace-nowrap">
+                    <span class="font-mono text-sm text-muted tabular-nums">{{ entry.value }}</span>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
       </section>
     {% endfor %}


### PR DESCRIPTION
Shrink some excessively long explanation text in configuration page.

Use `<table>` to structure the configuration summary to prevent alignment inconsistency.