### PR TITLE
Change some error kinds from `Rule` to `Input`

### DIFF
--- a/crates/selector4nix-core/src/domain/common/url.rs
+++ b/crates/selector4nix-core/src/domain/common/url.rs
@@ -73,7 +73,7 @@ pub enum TryNewUrlError {
 
 impl From<TryNewUrlError> for AppError {
     fn from(error: TryNewUrlError) -> Self {
-        Self::new(AppErrorKind::Rule, error)
+        Self::new(AppErrorKind::Input, error)
     }
 }
 

--- a/crates/selector4nix-core/src/domain/nar_info/model/nar_file_name.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/model/nar_file_name.rs
@@ -45,7 +45,7 @@ pub enum TryNewNarFileNameError {
 
 impl From<TryNewNarFileNameError> for AppError {
     fn from(error: TryNewNarFileNameError) -> Self {
-        Self::new(AppErrorKind::Rule, error)
+        Self::new(AppErrorKind::Input, error)
     }
 }
 

--- a/crates/selector4nix-core/src/domain/nar_info/model/store_path_hash.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/model/store_path_hash.rs
@@ -46,7 +46,7 @@ pub enum TryNewStorePathHashError {
 
 impl From<TryNewStorePathHashError> for AppError {
     fn from(error: TryNewStorePathHashError) -> Self {
-        Self::new(AppErrorKind::Rule, error)
+        Self::new(AppErrorKind::Input, error)
     }
 }
 

--- a/crates/selector4nix-core/src/domain/nar_info/model/upstream_nar_info_data.rs
+++ b/crates/selector4nix-core/src/domain/nar_info/model/upstream_nar_info_data.rs
@@ -76,7 +76,7 @@ pub enum TryUpstreamNewNarInfoData {
 
 impl From<TryUpstreamNewNarInfoData> for AppError {
     fn from(error: TryUpstreamNewNarInfoData) -> Self {
-        Self::new(AppErrorKind::Rule, error)
+        Self::new(AppErrorKind::Input, error)
     }
 }
 

--- a/crates/selector4nix-core/src/domain/substituter/model/priority.rs
+++ b/crates/selector4nix-core/src/domain/substituter/model/priority.rs
@@ -31,7 +31,7 @@ pub enum TryNewPriorityError {
 
 impl From<TryNewPriorityError> for AppError {
     fn from(error: TryNewPriorityError) -> Self {
-        Self::new(AppErrorKind::Rule, error)
+        Self::new(AppErrorKind::Input, error)
     }
 }
 


### PR DESCRIPTION
These errors are used to represent failures that occur at the system boundary. They are more related to user input validations than complex business rules.