### PR TITLE
Stop updating nixpkgs-nix-serve-ng digest in flake.nix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,12 @@
       "commitMessageAction": "bump",
       "commitMessageTopic": "Nix Flake input {{depName}}",
       "commitMessageExtra": "to {{newDigest}}"
+    },
+    {
+      "description": "Stop updating nixpkgs-nix-serve-ng digest in flake.nix",
+      "matchManagers": ["nix"],
+      "matchPackageNames": ["nixpkgs-nix-serve-ng"],
+      "enabled": false
     }
   ],
   "nix": {


### PR DESCRIPTION
That should remain pinned, due to [NixOS/nixpkgs#539200](https://redirect.github.com/NixOS/nixpkgs/issues/539200)

> [!NOTE]
> Merge into `renovate/reconfigure` first, then create another PR following [Renovate docs on Reconfigure via PR](https://docs.renovatebot.com/getting-started/installing-onboarding/#reconfigure-via-pr)