### PR TITLE
Improve flake-compat's compatibility with NixOS/flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,1 @@
-let
-  lockFile = builtins.fromJSON (builtins.readFile ./nix/flake/dev/flake.lock);
-  flake-compat-node = lockFile.nodes.${lockFile.nodes.root.inputs.flake-compat};
-  flake-compat = builtins.fetchTarball {
-    inherit (flake-compat-node.locked) url;
-    sha256 = flake-compat-node.locked.narHash;
-  };
-  flake = import flake-compat {
-    src = ./.;
-    copySourceTreeToStore = false;
-    useBuiltinsFetchTree = true;
-  };
-in
-flake.defaultNix
+(import ./nix/flake-compat.nix).defaultNix

--- a/nix/flake-compat.nix
+++ b/nix/flake-compat.nix
@@ -1,0 +1,33 @@
+let
+  lockFile = builtins.fromJSON (builtins.readFile ./flake/dev/flake.lock);
+  flakeCompatNode = lockFile.nodes.${lockFile.nodes.root.inputs.flake-compat}.locked;
+  flakeCompatSrc = builtins.fetchTarball {
+    url =
+      flakeCompatNode.url or (
+        if flakeCompatNode.type == "github" then
+          let
+            inherit (flakeCompatNode) owner repo rev;
+          in
+          "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"
+        else
+          builtins.abort "unsupported input type for flake-compat, unable to fetch the flake-compat repository"
+      );
+    sha256 = flakeCompatNode.narHash;
+  };
+
+  flakeCompat = import flakeCompatSrc;
+  flakeCompatArgSet = builtins.functionArgs flakeCompat;
+
+  optionalAttrs = cond: attrs: if cond then attrs else { };
+  optionalAttrsIfHasArg = arg: optionalAttrs (builtins.hasAttr arg flakeCompatArgSet);
+  optionalArgValue = arg: value: optionalAttrsIfHasArg arg { ${arg} = value; };
+
+  flake = flakeCompat (
+    {
+      src = ../.;
+    }
+    // (optionalArgValue "copySourceTreeToStore" false)
+    // (optionalArgValue "useBuiltinsFetchTree" true)
+  );
+in
+flake

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,1 @@
-let
-  lockFile = builtins.fromJSON (builtins.readFile ./nix/flake/dev/flake.lock);
-  flake-compat-node = lockFile.nodes.${lockFile.nodes.root.inputs.flake-compat};
-  flake-compat = builtins.fetchTarball {
-    inherit (flake-compat-node.locked) url;
-    sha256 = flake-compat-node.locked.narHash;
-  };
-  flake = import flake-compat {
-    src = ./.;
-    copySourceTreeToStore = false;
-    useBuiltinsFetchTree = true;
-  };
-in
-flake.shellNix
+(import ./nix/flake-compat.nix).shellNix


### PR DESCRIPTION
Currently we use flake-compat from <https://git.lix.systems/lix-project/flake-compat> and use some special arguments that are only supported by it.

To support <https://github.com/NixOS/flake-compat>, the code detects accepted arguments and only pass additional ones if supported.