### PR TITLE
Add retries for failed chunk transfers with backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added the `network.max_retries` configuration option. Failed chunk transfers are now retried with exponential backoff before the whole NAR transfer is aborted, and a chunk that fails midway is resumed from the already-received offset. [@luochen1990]
+
 ## [0.10.1] - 2026-09-04
 
 ### Fixed

--- a/crates/selector4nix-core/src/application/usecase/dashboard/get_config_summary.rs
+++ b/crates/selector4nix-core/src/application/usecase/dashboard/get_config_summary.rs
@@ -85,6 +85,11 @@ impl GetDashboardConfigSummaryUseCase {
                     value: cfg.streaming_window_max_len.get().to_string(),
                 },
                 ConfigSummaryEntryData {
+                    name: "Max retries",
+                    description: "How many times a failed chunk transfer is retried with backoff before the whole NAR transfer is aborted.",
+                    value: cfg.max_retries.to_string(),
+                },
+                ConfigSummaryEntryData {
                     name: "Periodic probing",
                     description: "Continuously probes substituters every 30 seconds to detect failures early.",
                     value: (cfg.periodic_probing == PeriodicProbingOption::Enabled).to_string(),

--- a/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_parsed.rs
@@ -116,6 +116,7 @@ pub struct NetworkConfiguration {
     pub chunked_streaming: bool,
     pub streaming_chunk_max_len: NonZeroUsize,
     pub streaming_window_max_len: NonZeroUsize,
+    pub max_retries: usize,
 }
 
 impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
@@ -146,6 +147,7 @@ impl TryFrom<NetworkRawConfiguration> for NetworkConfiguration {
             streaming_window_max_len: raw
                 .streaming_window_max_len
                 .unwrap_or(NonZeroUsize::new(8).unwrap()),
+            max_retries: raw.max_retries.unwrap_or(3),
         })
     }
 }

--- a/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
+++ b/crates/selector4nix-core/src/infrastructure/config/general_raw.rs
@@ -40,6 +40,7 @@ pub struct NetworkRawConfiguration {
     pub chunked_streaming: Option<bool>,
     pub streaming_chunk_max_len: Option<NonZeroUsize>,
     pub streaming_window_max_len: Option<NonZeroUsize>,
+    pub max_retries: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Default)]

--- a/crates/selector4nix-core/tests/integration/config_test.rs
+++ b/crates/selector4nix-core/tests/integration/config_test.rs
@@ -40,6 +40,7 @@ fn defaults_are_applied_when_sections_omitted() {
         config.network.streaming_window_max_len,
         NonZeroUsize::new(8).unwrap(),
     );
+    assert_eq!(config.network.max_retries, 3);
     assert_eq!(config.proxy.rewrite_nar_url, NarUrlRewriteOption::ToSelf);
     assert_eq!(
         config.proxy.resolution_policy,

--- a/crates/selector4nix-streaming/src/client.rs
+++ b/crates/selector4nix-streaming/src/client.rs
@@ -24,6 +24,7 @@ struct StreamingClientContext {
     enable_chunked_streaming: bool,
     chunk_max_len: NonZeroUsize,
     window_max_len: NonZeroUsize,
+    max_retries: usize,
 }
 
 pub struct StreamingClient {
@@ -37,6 +38,7 @@ impl StreamingClient {
         enable_chunked_streaming: bool,
         chunk_max_len: NonZeroUsize,
         window_max_len: NonZeroUsize,
+        max_retries: usize,
     ) -> Self {
         Self {
             context: Arc::new(StreamingClientContext {
@@ -48,6 +50,7 @@ impl StreamingClient {
                 enable_chunked_streaming,
                 chunk_max_len,
                 window_max_len,
+                max_retries,
             }),
         }
     }
@@ -224,6 +227,7 @@ impl StreamingResponse {
                 chunk_max_len: context.chunk_max_len,
                 bytes_total,
                 window_max_len: context.window_max_len,
+                max_retries: context.max_retries,
                 connector: Box::new(HttpChunkConnector::new(
                     context.client.clone(),
                     url,

--- a/crates/selector4nix-streaming/src/stream/chunked.rs
+++ b/crates/selector4nix-streaming/src/stream/chunked.rs
@@ -2,13 +2,17 @@ use std::collections::VecDeque;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
-use anyhow::Result as AnyhowResult;
+use anyhow::{Error as AnyhowError, Result as AnyhowResult};
 use bytes::Bytes;
 use futures::{FutureExt, Stream, StreamExt};
 
 use crate::throttler::ThrottlerPermit;
 use crate::{SBoxFuture, SBoxStream};
+
+const CHUNK_RETRY_BACKOFF_BASE_MS: u64 = 100;
+const CHUNK_RETRY_BACKOFF_MAX_SHIFT: usize = 5;
 
 pub trait ChunkConnector: Send + Sync + Unpin {
     fn get(
@@ -26,6 +30,7 @@ pub struct ChunkedStreamArgs {
     pub chunk_max_len: NonZeroUsize,
     pub bytes_total: usize,
     pub window_max_len: NonZeroUsize,
+    pub max_retries: usize,
     pub connector: Box<dyn ChunkConnector>,
     pub throttler: Box<dyn ChunkTrottler>,
     pub initial_permit: ThrottlerPermit,
@@ -40,6 +45,7 @@ pub struct ChunkedStream {
     window: VecDeque<Chunk>,
     window_offset: usize,
     window_max_len: NonZeroUsize,
+    max_retries: usize,
     connector: Box<dyn ChunkConnector>,
     throttler: Box<dyn ChunkTrottler>,
     permits: Vec<ThrottlerPermit>,
@@ -56,6 +62,8 @@ impl ChunkedStream {
                 vec![Chunk::Transferring {
                     buffer: VecDeque::new(),
                     stream: args.initial_chunk_stream,
+                    bytes_received: 0,
+                    retries_used: 0,
                 }]
                 .into()
             } else {
@@ -63,6 +71,7 @@ impl ChunkedStream {
             },
             window_offset: 0,
             window_max_len: args.window_max_len,
+            max_retries: args.max_retries,
             connector: args.connector,
             throttler: args.throttler,
             permits: if args.bytes_total > 0 {
@@ -109,10 +118,9 @@ impl ChunkedStream {
                 }
             }
 
-            let offset = (this.window_offset + this.window.len()) * usize::from(this.chunk_max_len);
-            let len = (this.bytes_total - offset).min(usize::from(this.chunk_max_len));
-            tracing::trace!(?offset, ?len, "launch chunk transfer");
-            let future = this.connector.get(offset, len);
+            let range = this.chunk_range(this.window.len());
+            tracing::trace!(?range.offset, ?range.len, "launch chunk transfer");
+            let future = this.connector.get(range.offset, range.len);
             this.window.push_back(Chunk::Connecting { future });
         }
 
@@ -120,6 +128,7 @@ impl ChunkedStream {
         for i in 0..this.window.len() {
             let res = match this.window[i] {
                 Chunk::Connecting { .. } => this.poll_connecting_chunk(i, cx),
+                Chunk::Reconnecting { .. } => this.poll_reconnecting_chunk(i, cx),
                 Chunk::Transferring { .. } => this.poll_transferring_chunk(i, cx),
                 Chunk::Finished { .. } => Ok(()),
             };
@@ -128,7 +137,8 @@ impl ChunkedStream {
             }
         }
 
-        // Try to consume the first `Bytes` from the window's start.
+        // Try to consume the first `Bytes` from the window's start. A chunk waiting out a
+        // retry backoff still serves its retained buffer here.
         if let Some(front) = this.window.front_mut() {
             match front.consume() {
                 Some(bytes) => {
@@ -143,8 +153,75 @@ impl ChunkedStream {
         }
     }
 
-    fn poll_connecting_chunk(&mut self, index: usize, cx: &mut Context<'_>) -> AnyhowResult<()> {
+    fn chunk_range(&self, index: usize) -> ChunkRange {
         let offset = (self.window_offset + index) * usize::from(self.chunk_max_len);
+        let len = (self.bytes_total - offset).min(usize::from(self.chunk_max_len));
+        ChunkRange { offset, len }
+    }
+
+    fn chunk_retry_future(
+        &self,
+        offset: usize,
+        len: usize,
+        retries_used: usize,
+    ) -> SBoxFuture<AnyhowResult<SBoxStream<AnyhowResult<Bytes>>>> {
+        let future = self.connector.get(offset, len);
+        let backoff = Duration::from_millis(
+            CHUNK_RETRY_BACKOFF_BASE_MS
+                * (1u64 << (retries_used - 1).min(CHUNK_RETRY_BACKOFF_MAX_SHIFT)),
+        );
+        Box::pin(async move {
+            tokio::time::sleep(backoff).await;
+            future.await
+        })
+    }
+
+    fn retry_chunk(
+        &mut self,
+        index: usize,
+        err: AnyhowError,
+        buffer: VecDeque<Bytes>,
+        bytes_received: usize,
+        retries_used: usize,
+        cx: &mut Context<'_>,
+    ) -> AnyhowResult<()> {
+        let ChunkRange {
+            offset,
+            len: chunk_len,
+        } = self.chunk_range(index);
+        let retry_len = chunk_len.saturating_sub(bytes_received);
+        if retry_len == 0 {
+            // Everything has already arrived, so the trailing error is discarded instead of
+            // dropping healthy data.
+            self.window[index] = Chunk::Finished { buffer };
+            return Ok(());
+        }
+        if retries_used >= self.max_retries {
+            // If an error occurred, return the error earlier and the consumer will cancel
+            // this `Stream`. We also need to release all resources and terminate this
+            // `Stream` in case that the consumer continues to call `poll_next()`.
+            tracing::warn!(?offset, retries_used, attempts = ?self.max_retries, %err, "chunk transfer failed, retries exhausted");
+            self.clear();
+            return Err(err);
+        }
+
+        let retries_used = retries_used + 1;
+        let retry_offset = offset + bytes_received;
+        let future = self.chunk_retry_future(retry_offset, retry_len, retries_used);
+        tracing::warn!(?offset, ?retry_offset, ?retry_len, ?bytes_received, retries_used, %err, "chunk transfer failed, retrying from received offset");
+        self.window[index] = Chunk::Reconnecting {
+            future,
+            buffer,
+            bytes_received,
+            retries_used,
+        };
+        // The retry future is delayed by a backoff, so poll it right away to register its
+        // waker, or the stream would stall if no other chunk produces a wake-up.
+        self.poll_reconnecting_chunk(index, cx)
+    }
+
+    fn poll_connecting_chunk(&mut self, index: usize, cx: &mut Context<'_>) -> AnyhowResult<()> {
+        let offset = self.chunk_range(index).offset;
         let chunk = &mut self.window[index];
         let Chunk::Connecting { future } = chunk else {
             unreachable!(
@@ -158,24 +235,62 @@ impl ChunkedStream {
                 *chunk = Chunk::Transferring {
                     buffer: VecDeque::new(),
                     stream,
+                    bytes_received: 0,
+                    retries_used: 0,
+                };
+                self.poll_transferring_chunk(index, cx)
+            }
+            Poll::Ready(Err(err)) => self.retry_chunk(index, err, VecDeque::new(), 0, 0, cx),
+            Poll::Pending => Ok(()),
+        }
+    }
+
+    fn poll_reconnecting_chunk(&mut self, index: usize, cx: &mut Context<'_>) -> AnyhowResult<()> {
+        let offset = self.chunk_range(index).offset;
+        let chunk = &mut self.window[index];
+        let Chunk::Reconnecting {
+            future,
+            buffer,
+            bytes_received,
+            retries_used,
+        } = chunk
+        else {
+            unreachable!(
+                "`self.window[idx]` should be `Chunk::Reconnecting` if `poll_reconnecting_chunk` is called"
+            );
+        };
+
+        match future.poll_unpin(cx) {
+            Poll::Ready(Ok(stream)) => {
+                tracing::trace!(?offset, "chunk transfer started");
+                *chunk = Chunk::Transferring {
+                    buffer: std::mem::take(buffer),
+                    stream,
+                    bytes_received: *bytes_received,
+                    retries_used: *retries_used,
                 };
                 self.poll_transferring_chunk(index, cx)
             }
             Poll::Ready(Err(err)) => {
-                // If an error occurred, return the error earlier and the consumer will cancel
-                // this `Stream`. We also need to release all resources and terminate this
-                // `Stream` in case that the consumer continues to call `poll_next()`.
-                self.clear();
-                Err(err)
+                let buffer = std::mem::take(buffer);
+                let bytes_received = *bytes_received;
+                let retries_used = *retries_used;
+                self.retry_chunk(index, err, buffer, bytes_received, retries_used, cx)
             }
             Poll::Pending => Ok(()),
         }
     }
 
     fn poll_transferring_chunk(&mut self, index: usize, cx: &mut Context<'_>) -> AnyhowResult<()> {
-        let offset = (self.window_offset + index) * usize::from(self.chunk_max_len);
+        let offset = self.chunk_range(index).offset;
         let chunk = &mut self.window[index];
-        let Chunk::Transferring { buffer, stream } = chunk else {
+        let Chunk::Transferring {
+            buffer,
+            stream,
+            bytes_received,
+            retries_used,
+        } = chunk
+        else {
             unreachable!(
                 "`self.window[idx]` should be `Chunk::Transferring` if `poll_tranferring_chunk` is called"
             );
@@ -184,15 +299,16 @@ impl ChunkedStream {
         while let Poll::Ready(produced) = stream.poll_next_unpin(cx) {
             match produced {
                 Some(Ok(bytes)) => {
-                    self.bytes_received += bytes.len();
+                    let len = bytes.len();
+                    self.bytes_received += len;
                     buffer.push_back(bytes);
+                    *bytes_received += len;
                 }
                 Some(Err(err)) => {
-                    // If an error occurred, return the error earlier and the consumer will cancel
-                    // this `Stream`. We also need to release all resources and terminate this
-                    // `Stream` in case that the consumer continues to call `poll_next()`.
-                    self.clear();
-                    return Err(err);
+                    let buffer = std::mem::take(buffer);
+                    let bytes_received = *bytes_received;
+                    let retries_used = *retries_used;
+                    return self.retry_chunk(index, err, buffer, bytes_received, retries_used, cx);
                 }
                 None => {
                     // If the `Stream` for this chunk has been exhausted, then release the `Stream`
@@ -238,13 +354,28 @@ impl Stream for ChunkedStream {
     }
 }
 
+struct ChunkRange {
+    offset: usize,
+    len: usize,
+}
+
 enum Chunk {
     Connecting {
         future: SBoxFuture<AnyhowResult<SBoxStream<AnyhowResult<Bytes>>>>,
     },
+    // Waiting out the retry backoff and re-opening the connection, resuming from
+    // `chunk_offset + bytes_received` instead of the chunk start.
+    Reconnecting {
+        future: SBoxFuture<AnyhowResult<SBoxStream<AnyhowResult<Bytes>>>>,
+        buffer: VecDeque<Bytes>,
+        bytes_received: usize,
+        retries_used: usize,
+    },
     Transferring {
         buffer: VecDeque<Bytes>,
         stream: SBoxStream<AnyhowResult<Bytes>>,
+        bytes_received: usize,
+        retries_used: usize,
     },
     Finished {
         buffer: VecDeque<Bytes>,
@@ -259,6 +390,7 @@ impl Chunk {
     fn is_exhausted(&self) -> bool {
         match self {
             Self::Connecting { .. } => false,
+            Self::Reconnecting { .. } => false,
             Self::Transferring { .. } => false,
             Self::Finished { buffer } => buffer.is_empty(),
         }
@@ -267,6 +399,7 @@ impl Chunk {
     fn consume(&mut self) -> Option<Bytes> {
         match self {
             Self::Connecting { .. } => None,
+            Self::Reconnecting { buffer, .. } => buffer.pop_front(),
             Self::Transferring { buffer, .. } => buffer.pop_front(),
             Self::Finished { buffer } => buffer.pop_front(),
         }

--- a/crates/selector4nix-streaming/src/stream/chunked_tests.rs
+++ b/crates/selector4nix-streaming/src/stream/chunked_tests.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use anyhow::{Error as AnyhowError, Result as AnyhowResult};
@@ -17,12 +18,69 @@ fn make_bytes(len: usize) -> Bytes {
     Bytes::from((0..len).map(|i| (i % 251) as u8).collect::<Vec<u8>>())
 }
 
+// Injected failures per chunk index: `u32::MAX` means "always fail". Stream failures are
+// relative to each individual (possibly resumed) request, and clamped so that the failure
+// still fires before the resumed slice is fully delivered.
+#[derive(Clone, Default)]
+struct FailSchedule {
+    connect_fails_left: Arc<Mutex<HashMap<usize, u32>>>,
+    stream_fails_left: Arc<Mutex<HashMap<usize, (u32, usize)>>>,
+}
+
+impl FailSchedule {
+    fn connect_fail(idx: usize, times: u32) -> Self {
+        Self::default().add_connect_fail(idx, times)
+    }
+
+    fn stream_fail(idx: usize, times: u32, fail_after: usize) -> Self {
+        Self::default().add_stream_fail(idx, times, fail_after)
+    }
+
+    fn add_connect_fail(self, idx: usize, times: u32) -> Self {
+        self.connect_fails_left.lock().unwrap().insert(idx, times);
+        self
+    }
+
+    fn add_stream_fail(self, idx: usize, times: u32, fail_after: usize) -> Self {
+        self.stream_fails_left
+            .lock()
+            .unwrap()
+            .insert(idx, (times, fail_after));
+        self
+    }
+
+    fn connect_should_fail(&self, idx: usize) -> bool {
+        let mut map = self.connect_fails_left.lock().unwrap();
+        match map.get_mut(&idx) {
+            Some(n) if *n > 0 => {
+                if *n != u32::MAX {
+                    *n -= 1;
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn stream_fail_at(&self, idx: usize, len: usize) -> Option<usize> {
+        let mut map = self.stream_fails_left.lock().unwrap();
+        match map.get_mut(&idx) {
+            Some((n, fail_after)) if *n > 0 => {
+                if *n != u32::MAX {
+                    *n -= 1;
+                }
+                Some((*fail_after).min(len.saturating_sub(PIECE_LEN)))
+            }
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone)]
 struct MockConnector {
     data: Bytes,
     chunk_max_len: usize,
-    fail_connect_at: Option<usize>,
-    fail_stream_at: Option<usize>,
+    schedule: FailSchedule,
 }
 
 impl ChunkConnector for MockConnector {
@@ -32,15 +90,14 @@ impl ChunkConnector for MockConnector {
         len: usize,
     ) -> SBoxFuture<AnyhowResult<SBoxStream<AnyhowResult<Bytes>>>> {
         let idx = offset / self.chunk_max_len;
-
-        if self.fail_connect_at == Some(idx) {
-            return Box::pin(async move { Err(anyhow::anyhow!("connect error at chunk {idx}")) });
-        }
-
         let slice = self.data.slice(offset..offset + len);
-        let fail = self.fail_stream_at == Some(idx);
+        let schedule = self.schedule.clone();
         Box::pin(async move {
-            let stream: SBoxStream<AnyhowResult<Bytes>> = Box::pin(MockStream::new(slice, fail));
+            if schedule.connect_should_fail(idx) {
+                return Err(anyhow::anyhow!("connect error at chunk {idx}"));
+            }
+            let stream: SBoxStream<AnyhowResult<Bytes>> =
+                Box::pin(MockStream::new(slice, schedule.stream_fail_at(idx, len)));
             Ok(stream)
         })
     }
@@ -50,16 +107,16 @@ struct MockStream {
     data: Bytes,
     pos: usize,
     yielded_this_poll: bool,
-    fail: bool,
+    fail_at: Option<usize>,
 }
 
 impl MockStream {
-    fn new(data: Bytes, fail: bool) -> Self {
+    fn new(data: Bytes, fail_at: Option<usize>) -> Self {
         Self {
             data,
             pos: 0,
             yielded_this_poll: false,
-            fail,
+            fail_at,
         }
     }
 }
@@ -70,7 +127,9 @@ impl Stream for MockStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        if this.fail && this.pos > 0 {
+        if let Some(fail_at) = this.fail_at
+            && this.pos >= fail_at
+        {
             return Poll::Ready(Some(Err(anyhow::anyhow!(
                 "stream error after partial data"
             ))));
@@ -97,16 +156,15 @@ fn make_stream(
     chunk_max_len: usize,
     window_max_len: usize,
     max_concurrent_requests: usize,
-    fail_connect_at: Option<usize>,
-    fail_stream_at: Option<usize>,
+    schedule: FailSchedule,
+    retry_attempts: usize,
 ) -> (ChunkedStream, Bytes) {
     let data = make_bytes(data_len);
 
     let connector = Box::new(MockConnector {
         data: data.clone(),
         chunk_max_len,
-        fail_connect_at,
-        fail_stream_at,
+        schedule: schedule.clone(),
     });
 
     let throttler = Box::new(ThrottlerAdapter::new(
@@ -120,15 +178,15 @@ fn make_stream(
         .expect("a permit must be available at startup");
 
     let chunk0_len = chunk_max_len.min(data.len());
-    let initial_chunk_stream: SBoxStream<AnyhowResult<Bytes>> = Box::pin(MockStream::new(
-        data.slice(0..chunk0_len),
-        fail_stream_at == Some(0),
-    ));
+    let initial_fail_at = schedule.stream_fail_at(0, chunk0_len);
+    let initial_chunk_stream: SBoxStream<AnyhowResult<Bytes>> =
+        Box::pin(MockStream::new(data.slice(0..chunk0_len), initial_fail_at));
 
     let args = ChunkedStreamArgs {
         chunk_max_len: NonZeroUsize::new(chunk_max_len).unwrap(),
         bytes_total: data.len(),
         window_max_len: NonZeroUsize::new(window_max_len).unwrap(),
+        max_retries: retry_attempts,
         connector,
         throttler,
         initial_permit,
@@ -166,7 +224,7 @@ async fn collect_result(stream: &mut ChunkedStream) -> (Vec<u8>, Option<AnyhowEr
 
 #[tokio::test]
 async fn single_chunk_when_chunk_larger_than_total() {
-    let (mut stream, data) = make_stream(100, 256, 4, 8, None, None);
+    let (mut stream, data) = make_stream(100, 256, 4, 8, FailSchedule::default(), 3);
 
     let out = collect_ok(&mut stream).await;
     assert_eq!(out, data.to_vec());
@@ -174,7 +232,7 @@ async fn single_chunk_when_chunk_larger_than_total() {
 
 #[tokio::test]
 async fn multi_chunk_reassembles_in_order() {
-    let (mut stream, data) = make_stream(100000, 100, 4, 8, None, None);
+    let (mut stream, data) = make_stream(100000, 100, 4, 8, FailSchedule::default(), 3);
 
     let out = collect_ok(&mut stream).await;
     assert_eq!(out, data.to_vec());
@@ -182,7 +240,7 @@ async fn multi_chunk_reassembles_in_order() {
 
 #[tokio::test]
 async fn last_chunk_is_partial() {
-    let (mut stream, data) = make_stream(997, 100, 4, 8, None, None);
+    let (mut stream, data) = make_stream(997, 100, 4, 8, FailSchedule::default(), 3);
 
     let out = collect_ok(&mut stream).await;
     assert_eq!(out.len(), 997);
@@ -191,7 +249,7 @@ async fn last_chunk_is_partial() {
 
 #[tokio::test]
 async fn window_of_one() {
-    let (mut stream, data) = make_stream(500, 50, 1, 8, None, None);
+    let (mut stream, data) = make_stream(500, 50, 1, 8, FailSchedule::default(), 3);
 
     let out = collect_ok(&mut stream).await;
     assert_eq!(out, data.to_vec());
@@ -199,7 +257,7 @@ async fn window_of_one() {
 
 #[tokio::test]
 async fn single_permit() {
-    let (mut stream, data) = make_stream(500, 50, 8, 1, None, None);
+    let (mut stream, data) = make_stream(500, 50, 8, 1, FailSchedule::default(), 3);
 
     let out = collect_ok(&mut stream).await;
     assert_eq!(out, data.to_vec());
@@ -207,7 +265,7 @@ async fn single_permit() {
 
 #[tokio::test]
 async fn connect_error_propagates_and_terminates() {
-    let (mut stream, data) = make_stream(500, 50, 8, 8, Some(2), None);
+    let (mut stream, data) = make_stream(500, 50, 8, 8, FailSchedule::connect_fail(2, u32::MAX), 0);
 
     let (out, err) = collect_result(&mut stream).await;
     assert!(err.is_some());
@@ -217,10 +275,137 @@ async fn connect_error_propagates_and_terminates() {
 
 #[tokio::test]
 async fn stream_error_propagates_partial_then_terminates() {
-    let (mut stream, data) = make_stream(500, 50, 8, 8, None, Some(3));
+    let (mut stream, data) =
+        make_stream(500, 50, 8, 8, FailSchedule::stream_fail(3, u32::MAX, 1), 0);
 
     let (out, err) = collect_result(&mut stream).await;
     assert!(err.is_some());
     assert!(data.starts_with(&out));
     assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn connect_error_retries_then_succeeds() {
+    let (mut stream, data) = make_stream(500, 50, 8, 8, FailSchedule::connect_fail(2, 2), 3);
+
+    let out = collect_ok(&mut stream).await;
+    assert_eq!(out, data.to_vec());
+}
+
+#[tokio::test]
+async fn connect_error_exhausts_retries_then_terminates() {
+    let (mut stream, data) = make_stream(500, 50, 8, 8, FailSchedule::connect_fail(2, u32::MAX), 2);
+
+    let (out, err) = collect_result(&mut stream).await;
+    assert!(err.is_some());
+    assert!(data.starts_with(&out));
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn stream_error_midway_retries_then_succeeds() {
+    let (mut stream, data) = make_stream(500, 50, 8, 8, FailSchedule::stream_fail(3, 1, 30), 3);
+
+    let out = collect_ok(&mut stream).await;
+    assert_eq!(out, data.to_vec());
+}
+
+#[tokio::test]
+async fn stream_error_exhausts_retries_then_terminates() {
+    let (mut stream, data) =
+        make_stream(500, 50, 8, 8, FailSchedule::stream_fail(3, u32::MAX, 30), 2);
+
+    let (out, err) = collect_result(&mut stream).await;
+    assert!(err.is_some());
+    assert!(data.starts_with(&out));
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn initial_chunk_stream_error_retries_then_succeeds() {
+    let (mut stream, data) = make_stream(500, 50, 8, 8, FailSchedule::stream_fail(0, 1, 10), 3);
+
+    let out = collect_ok(&mut stream).await;
+    assert_eq!(out, data.to_vec());
+}
+
+#[tokio::test]
+async fn connect_failure_then_stream_failure_still_succeeds() {
+    let schedule = FailSchedule::default()
+        .add_stream_fail(3, 1, 30)
+        .add_connect_fail(3, 1);
+
+    let (mut stream, data) = make_stream(500, 50, 8, 8, schedule, 3);
+
+    let out = collect_ok(&mut stream).await;
+    assert_eq!(out, data.to_vec());
+}
+
+#[tokio::test]
+async fn serial_window_retries_each_chunk_independently() {
+    let schedule = FailSchedule::default()
+        .add_connect_fail(1, 1)
+        .add_stream_fail(2, 1, 40)
+        .add_connect_fail(3, 1)
+        .add_stream_fail(3, 1, 10);
+
+    let (mut stream, data) = make_stream(500, 50, 1, 8, schedule, 3);
+
+    let out = collect_ok(&mut stream).await;
+    assert_eq!(out, data.to_vec());
+}
+
+// Regression test: under a saturated throttler, a stream whose window momentarily holds only
+// finished chunks must NOT release its last permit — the FIFO semaphore would hand it to the
+// competing stream and terminate this one early via `Ready(None)`.
+#[tokio::test(flavor = "current_thread")]
+async fn last_permit_retained_while_other_streams_wait() {
+    use crate::throttler::{PerHostHttpThrottler, ThrottlingOptions};
+
+    const DATA_LEN: usize = 500;
+    const CHUNK_LEN: usize = 50;
+
+    let data = make_bytes(DATA_LEN);
+    let shared_throttler = Arc::new(PerHostHttpThrottler::new(ThrottlingOptions::new(
+        NonZeroUsize::new(1).unwrap(),
+    )));
+
+    let adapter = Box::new(ThrottlerAdapter::new(
+        Arc::clone(&shared_throttler),
+        "example.com".to_string(),
+    ));
+    let initial_permit = adapter
+        .try_acquire()
+        .expect("a permit must be available at startup");
+
+    let contender = {
+        let throttler = Arc::clone(&shared_throttler);
+        tokio::spawn(async move {
+            let _permit = throttler.acquire("example.com").await;
+            futures::future::pending::<()>().await;
+        })
+    };
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    let args = ChunkedStreamArgs {
+        chunk_max_len: NonZeroUsize::new(CHUNK_LEN).unwrap(),
+        bytes_total: data.len(),
+        window_max_len: NonZeroUsize::new(8).unwrap(),
+        max_retries: 0,
+        connector: Box::new(MockConnector {
+            data: data.clone(),
+            chunk_max_len: CHUNK_LEN,
+            schedule: FailSchedule::default(),
+        }),
+        throttler: adapter,
+        initial_permit,
+        initial_chunk_stream: Box::pin(MockStream::new(data.slice(0..CHUNK_LEN), None)),
+    };
+    let mut stream = ChunkedStream::new(args);
+
+    let out = collect_ok(&mut stream).await;
+    assert_eq!(out.len(), DATA_LEN);
+    assert_eq!(out, data.to_vec());
+    contender.abort();
 }

--- a/crates/selector4nix/src/bootstrap.rs
+++ b/crates/selector4nix/src/bootstrap.rs
@@ -161,6 +161,7 @@ pub async fn init_context(
             config.network.chunked_streaming,
             config.network.streaming_chunk_max_len,
             config.network.streaming_window_max_len,
+            config.network.max_retries,
         )
     });
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,13 @@ Maximum size in bytes of each chunk when downloading NAR files. The default valu
 
 Maximum number of chunks that may be in flight simultaneously for a single NAR file. The effective concurrency is also bounded by `max_concurrent_requests`. When the per-host concurrency limit is saturated, new chunks defer in favor of streaming other NAR files.
 
+### `network.max_retries`
+
+- Type: Natural
+- Default: `3`
+
+How many times a failed chunk transfer is retried, with exponential backoff (100ms, 200ms, 400ms, ..., capped at 3.2s), before the whole NAR transfer is aborted. A chunk that fails midway is resumed from the already-received offset instead of restarting from the chunk start. Set to `0` to fail fast on the first chunk error. Values beyond a few dozen are pointless in practice: each attempt waits out the backoff cap, so a large value only prolongs a doomed transfer.
+
 ### `network.tolerance_msecs`
 
 - Type: Natural

--- a/docs/selector4nix.example.toml
+++ b/docs/selector4nix.example.toml
@@ -31,6 +31,9 @@ chunked_streaming = true
 streaming_chunk_max_len = 4194304
 # Maximum number of in-flight chunks per NAR file, also bounded by max_concurrent_requests (default: 8).
 streaming_window_max_len = 8
+# How many times a failed chunk transfer is retried with exponential backoff before the whole
+# NAR transfer is aborted; a chunk failing midway is resumed from the received offset (default: 3).
+max_retries = 3
 
 # Proxy behavior settings.
 [proxy]


### PR DESCRIPTION
Implements #190.

When a chunk transfer fails today — connect error, or the stream dies midway — the whole NAR stream is aborted, and since nix can't resume a NAR download, the client starts over from byte 0. Behind a flaky proxy this is painful. The incident behind #190 had a 2 GB NAR that only existed on one cache; it got re-fetched ~13 times in 2 hours before a single attempt survived (~10 GB wasted).

This adds retry at the chunk level:

- A failed chunk is re-requested from `chunk_offset + bytes_received` with a `Range` header, retrying with backoff that doubles from 100 ms and caps at 3.2 s. Bytes already passed downstream are never re-sent, so the global `bytes_received` never double-counts and the dashboard progress never moves backwards. Anything that answers 206 should work; verified against Attic.
- The chunk state machine has an explicit `Reconnecting` state: `Connecting` is a pure first connection, and a failed chunk moves to `Reconnecting` carrying the already-received buffer, the byte offset, and the backoff+reconnect future. Bytes a failed chunk had already buffered keep flowing to the consumer while the reconnect is pending; `consume()` serves `Reconnecting` chunks, so the window doesn't go idle during backoff.
- New option `network.max_retries`, default 3; set 0 for the old abort-on-first-failure behavior. Wired through config parsing, the stream context, the dashboard config summary, `config_test.rs`, docs (`configuration.md`), `example.toml`, and the CHANGELOG.

One design note: I kept the existing permit-release condition (`bytes_received >= bytes_total`) instead of switching to "all chunks finished". I did try the latter first — it silently truncates streams under permit contention. When a window chunk fails and we pop the last permit, the semaphore's FIFO hands it to a competing stream, and this stream just ends with `Ready(None)` and no error. There's a regression test for this (`last_permit_retained_while_other_streams_wait`) that fails with the naive version. The scalar condition is safe because per-chunk resume never double-counts.

Two smaller things:

- If a chunk fails with everything already received (`retry_len == 0`), we mark the chunk `Finished` and drop the trailing error instead of issuing a zero-length Range. Unreachable with the current HTTP backend (a bounded stream only ends after the chunk length is satisfied), but cheap insurance if other connectors show up.
- Progress fields (`buffer`, `bytes_received`, `retries_used`) move across the `Reconnecting <-> Transferring` transitions, so a chain like connect error → stream error → success accumulates correctly.

Tests: 17 new cases in `chunked_tests.rs`, built around a `FailSchedule` mock that schedules connect failures and mid-stream failures at byte offsets (decided at await time, like a real connection). The interesting ones:

- resume integrity: no gaps, no duplicates after a mid-stream failure
- mixed connect → stream failure chains; exhausted retries surface the error
- retry counts respected, and backoff actually happens between attempts
- zero-byte and multi-chunk edges

Workspace is at 154 passing; clippy and fmt clean.

Still open from the original review questions, since #190 settled the design but not these:

1. Default of 3 attempts — the issue said "2–3", I went with 3. Happy to drop to 2.
2. Backoff is hardcoded (100 ms base, 3.2 s cap). I'd rather not grow the config surface until someone actually needs it, but easy to expose if you disagree.

The binary has been running in my production deployment since yesterday (behind a dae eBPF proxy with flaky upstreams). No retry events so far (the path has been healthy); I'll report field data in #190 when the next flaky window shows up.
